### PR TITLE
fix(ui): 🐛 Truncate labels correctly in UI render function

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,26 @@
+name: OpenCode
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write # Required for Copilot auth
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          # Use the built-in GitHub Token to authenticate your Copilot subscription
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Hardcode the model from the Copilot provider
+          model: github-copilot/gpt-4o

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,21 +6,22 @@ on:
 
 jobs:
   opencode:
-    if: contains(github.event.comment.body, '/opencode')
+    if: contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc')
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
       issues: write
-      id-token: write # Required for Copilot auth
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
         env:
-          # Use the built-in GitHub Token to authenticate your Copilot subscription
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass the Zen key here
+          OPENAI_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          # Set the Base URL to point to the Zen gateway
+          OPENAI_API_BASE: https://opencode.ai/zen/v1
         with:
-          # Hardcode the model from the Copilot provider
-          model: github-copilot/gpt-4o
+          # Select a model available through Zen (e.g., claude-sonnet-3-5)
+          model: openai/claude-sonnet-3-5

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -142,12 +142,12 @@ fn render_labels_cell(
             label_style = label_style.bg(bg);
         }
 
-        let mut text_to_add = label.as_str();
+        let mut text_to_add = label.to_string();
         let mut truncated = false;
         if current_len + text_to_add.len() > max_len {
             let allowed = max_len - current_len;
             if allowed > 1 {
-                text_to_add = &text_to_add[..allowed - 1];
+                text_to_add = text_to_add.chars().take(allowed - 1).collect();
                 truncated = true;
             } else {
                 let mut style = Style::default().fg(THEME.read().unwrap().text_muted);


### PR DESCRIPTION
This fixes #90.

Looking for solutions to this bug I found this issue: https://github.com/typst/typst/issues/4308 which matched the problem. I've adapted the solution to limit as much as possible the impact on the code.

Please note that I basically know nothing about rust so there's probably a more idiomatic way to do this. It seems to work correctly on a Gitlab repository with lots of issues and lots of emojis in labels.