### PR TITLE
fix(ui): prevent panic when label contains multi-byte chars

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,36 @@
+name: OpenCode
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_review_comment:
+    types:
+      - created
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  opencode:
+    # Triggers only when someone comments /oc or /opencode
+    if: contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          # Ensure this secret exists in your Repo Settings > Secrets
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/big-pickle
+          use_github_token: true

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -147,7 +147,10 @@ fn render_labels_cell(
         if current_len + text_to_add.len() > max_len {
             let allowed = max_len - current_len;
             if allowed > 1 {
-                text_to_add = &text_to_add[..allowed - 1];
+                // Snap to a valid char boundary to avoid panicking on multi-byte
+                // characters (emojis, accented letters, etc.).
+                let safe_end = text_to_add.floor_char_boundary(allowed - 1);
+                text_to_add = &text_to_add[..safe_end];
                 truncated = true;
             } else {
                 let mut style = Style::default().fg(THEME.read().unwrap().text_muted);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -80,6 +80,16 @@ fn get_label_color(label: &str) -> Color {
     colors[idx]
 }
 
+fn floor_char_boundary(s: &str, mut index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    while !s.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
 fn render_labels_cell(
     labels: &[String],
     query: &str,
@@ -149,7 +159,7 @@ fn render_labels_cell(
             if allowed > 1 {
                 // Snap to a valid char boundary to avoid panicking on multi-byte
                 // characters (emojis, accented letters, etc.).
-                let safe_end = text_to_add.floor_char_boundary(allowed - 1);
+                let safe_end = floor_char_boundary(text_to_add, allowed - 1);
                 text_to_add = &text_to_add[..safe_end];
                 truncated = true;
             } else {
@@ -6557,5 +6567,17 @@ mod tests {
         assert_eq!(formatted[3].2[1].1, "new line content");
         assert_eq!(formatted[4].2[0].1, "└─── End of Suggestion ───");
         assert_eq!(formatted[5].2[0].1, "outside suggestion");
+    }
+
+    #[test]
+    fn test_floor_char_boundary() {
+        let s = "👕hello";
+        assert_eq!(floor_char_boundary(s, 0), 0);
+        assert_eq!(floor_char_boundary(s, 1), 0);
+        assert_eq!(floor_char_boundary(s, 2), 0);
+        assert_eq!(floor_char_boundary(s, 3), 0);
+        assert_eq!(floor_char_boundary(s, 4), 4);
+        assert_eq!(floor_char_boundary(s, 5), 5);
+        assert_eq!(floor_char_boundary(s, 999), s.len());
     }
 }


### PR DESCRIPTION
Closes #90

Hi,

I wanted to try glab-tui but it crashes on projects where issues have emojis in labels. Here's the full backtrace:

```
thread 'main' (381669) panicked at src/ui.rs:150:43:
end byte index 3 is not a char boundary; it is inside '👕' (bytes 0..4 of string)
stack backtrace:
   0:     0x63abd6f00d5a - <<std[2b826acdc1f5e0a6]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[2a04ef4615689bd8]::fmt::Display>::fmt
   1:     0x63abd6f1931a - core[2a04ef4615689bd8]::fmt::write
   2:     0x63abd6f06e72 - <std[2b826acdc1f5e0a6]::sys::stdio::unix::Stderr as std[2b826acdc1f5e0a6]::io::Write>::write_fmt
   3:     0x63abd6edd51f - std[2b826acdc1f5e0a6]::panicking::default_hook::{closure#0}
   4:     0x63abd6ef6f21 - std[2b826acdc1f5e0a6]::panicking::default_hook
   5:     0x63abd6ef719b - std[2b826acdc1f5e0a6]::panicking::panic_with_hook
   6:     0x63abd6edd5d8 - std[2b826acdc1f5e0a6]::panicking::panic_handler::{closure#0}
   7:     0x63abd6ed1ed9 - std[2b826acdc1f5e0a6]::sys::backtrace::__rust_end_short_backtrace::<std[2b826acdc1f5e0a6]::panicking::panic_handler::{closure#0}, !>
   8:     0x63abd6ede51d - __rustc[38dafaa32e25e62e]::rust_begin_unwind
   9:     0x63abd6f19abc - core[2a04ef4615689bd8]::panicking::panic_fmt
  10:     0x63abd6f19635 - core[2a04ef4615689bd8]::str::slice_error_fail_rt
  11:     0x63abd6f1937a - core[2a04ef4615689bd8]::str::slice_error_fail
  12:     0x63abd6b64cac - glab_tui::ui::render_labels_cell::h71e6b9a4ba36c2ab
  13:     0x63abd6c8cad6 - <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold::hfa50a5f4c373398d
  14:     0x63abd6b5a6bf - <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter::h066540b95e780083
  15:     0x63abd6c135fa - ratatui_widgets::table::Table::new::h660bb9ea154bb243
  16:     0x63abd6b6fdd7 - glab_tui::ui::render::hde72f973d4094f6f
  17:     0x63abd6a82156 - glab_tui::main::{{closure}}::hb9460e5a12ef76cc
  18:     0x63abd6a77a99 - tokio::runtime::park::CachedParkThread::block_on::he5cabe88b52e7900
  19:     0x63abd6c48f59 - glab_tui::main::haaa03d433131fdb1
  20:     0x63abd6c96603 - std::sys::backtrace::__rust_begin_short_backtrace::h9259a4666a0ae8e3
  21:     0x63abd6c8e5bd - std::rt::lang_start::{{closure}}::ha0e3fd555a47b9b6
  22:     0x63abd6ef5944 - std[2b826acdc1f5e0a6]::rt::lang_start_internal
  23:     0x63abd6c548c5 - main
  24:     0x7b247922a1ca - <unknown>
  25:     0x7b247922a28b - __libc_start_main
  26:     0x63abd6a05155 - _start
  27:                0x0 - <unknown>
```

edit: I haven't tested but I assume it will fail on any multi-byte character if the slice length falls in the middle of it so UTF-8 accented characters are probably at risk too