### PR TITLE
fix(ci): fix workflow/pipeline trigger

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1180,7 +1180,7 @@ pub enum GroupItem {
 
 #[derive(Clone, Debug)]
 pub enum ConfirmAction {
-    DeleteMilestone(u64), // milestone iid
+    DeleteMilestone(u64),  // milestone iid
     DeleteRelease(String), // release tag_name
 }
 
@@ -2804,7 +2804,10 @@ impl App {
                                 r.released_at.clone()
                             }
                         }
-                        "Author" => r.author_name.clone().unwrap_or_else(|| "Unknown".to_string()),
+                        "Author" => r
+                            .author_name
+                            .clone()
+                            .unwrap_or_else(|| "Unknown".to_string()),
                         "Tag" => r.tag_name.clone(),
                         "Release Name" => r.name.clone(),
                         _ => "Unknown".to_string(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1178,6 +1178,12 @@ pub enum GroupItem {
     Item(usize),
 }
 
+#[derive(Clone, Debug)]
+pub enum ConfirmAction {
+    DeleteMilestone(u64), // milestone iid
+    DeleteRelease(String), // release tag_name
+}
+
 pub struct App {
     pub config: Config,
     pub active_tab: Tab,
@@ -1221,6 +1227,7 @@ pub struct App {
     pub current_comments: Vec<crate::gitlab::mr::DiscussionNote>,
     pub last_fetched_mr_iid: Option<u64>,
     pub show_submit_review_prompt: Option<u64>,
+    pub confirm_popup: Option<ConfirmAction>,
     pub diff_loading: bool,
     pub todos: StatefulTable<crate::gitlab::notifications::Notification>,
     pub status_message: Option<String>,
@@ -1292,6 +1299,7 @@ impl Default for App {
             current_comments: Vec::new(),
             last_fetched_mr_iid: None,
             show_submit_review_prompt: None,
+            confirm_popup: None,
             diff_loading: false,
             todos: StatefulTable::with_items(vec![]),
             status_message: None,
@@ -2777,6 +2785,45 @@ impl App {
                         "Stage" => j.stage.clone(),
                         "Name" => j.name.clone(),
                         "ID" => format!("#{}", j.id),
+                        _ => "Unknown".to_string(),
+                    };
+                    map.entry(key).or_default().push(idx);
+                }
+                map
+            }
+            Tab::Releases => {
+                let items = self.filtered_releases();
+                let mut map: std::collections::BTreeMap<String, Vec<usize>> =
+                    std::collections::BTreeMap::new();
+                for (idx, r) in items.iter().enumerate() {
+                    let key = match col.as_str() {
+                        "Date" => {
+                            if r.released_at.len() >= 10 {
+                                r.released_at[..10].to_string()
+                            } else {
+                                r.released_at.clone()
+                            }
+                        }
+                        "Author" => r.author_name.clone().unwrap_or_else(|| "Unknown".to_string()),
+                        "Tag" => r.tag_name.clone(),
+                        "Release Name" => r.name.clone(),
+                        _ => "Unknown".to_string(),
+                    };
+                    map.entry(key).or_default().push(idx);
+                }
+                map
+            }
+            Tab::Milestones => {
+                let items = self.filtered_milestones();
+                let mut map: std::collections::BTreeMap<String, Vec<usize>> =
+                    std::collections::BTreeMap::new();
+                for (idx, m) in items.iter().enumerate() {
+                    let key = match col.as_str() {
+                        "State" => m.state.clone(),
+                        "Start Date" => m.start_date.clone().unwrap_or_else(|| "None".to_string()),
+                        "Due Date" => m.due_date.clone().unwrap_or_else(|| "None".to_string()),
+                        "Title" => m.title.clone(),
+                        "ID" => format!("#{}", m.iid),
                         _ => "Unknown".to_string(),
                     };
                     map.entry(key).or_default().push(idx);

--- a/src/app.rs
+++ b/src/app.rs
@@ -250,28 +250,37 @@ pub struct Selector {
 impl Selector {
     pub fn get_filtered_items_with_indices(&self) -> Vec<(String, Option<Vec<usize>>)> {
         let query = self.search_query.trim();
-        let mut items: Vec<(String, Option<Vec<usize>>)> = if query.is_empty() {
-            self.all_items
-                .iter()
-                .map(|item| (item.clone(), None))
-                .collect()
-        } else {
-            let q = query.to_lowercase();
-            self.all_items
-                .iter()
-                .filter(|item| item.to_lowercase().contains(&q))
-                .map(|item| (item.clone(), None))
-                .collect()
-        };
-
-        if !query.is_empty() {
-            let exact_match = self
+        if query.is_empty() {
+            return self
                 .all_items
                 .iter()
-                .any(|item| item.to_lowercase() == query.to_lowercase());
-            if !exact_match {
-                items.push((format!("+ Create \"{}\"", query), None));
-            }
+                .map(|item| (item.clone(), None))
+                .collect();
+        }
+
+        let matcher = SkimMatcherV2::default();
+        let mut scored: Vec<(i64, String, Option<Vec<usize>>)> = self
+            .all_items
+            .iter()
+            .filter_map(|item| {
+                matcher
+                    .fuzzy_indices(item, query)
+                    .map(|(score, indices)| (score, item.clone(), Some(indices)))
+            })
+            .collect();
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+
+        let mut items: Vec<(String, Option<Vec<usize>>)> = scored
+            .into_iter()
+            .map(|(_, item, indices)| (item, indices))
+            .collect();
+
+        let exact_match = self
+            .all_items
+            .iter()
+            .any(|item| item.to_lowercase() == query.to_lowercase());
+        if !exact_match {
+            items.push((format!("+ Create \"{}\"", query), None));
         }
         items
     }
@@ -1891,38 +1900,47 @@ impl App {
         if query.trim().is_empty() {
             return items.iter().collect();
         }
-        let q = query.trim().to_lowercase();
-        items
-            .iter()
-            .filter(|item| {
-                let mut matches = false;
-                let mut check_match = |text: &str| {
-                    if text.to_lowercase().contains(&q) {
-                        matches = true;
-                    }
-                };
-                if enabled_cols.contains("ID") {
-                    check_match(&format!("#{}", item.id));
-                    check_match(&item.id.to_string());
-                }
-                if enabled_cols.contains("Status") {
-                    check_match(&item.status);
-                }
-                if enabled_cols.contains("Ref") {
-                    check_match(&item.r#ref);
-                }
-                if enabled_cols.contains("Stages") {
-                    if let Some(jobs) = pipeline_jobs.get(&item.id) {
-                        for job in jobs {
-                            check_match(&job.name);
-                            check_match(&job.stage);
-                            check_match(&job.status);
-                        }
+        let matcher = SkimMatcherV2::default();
+        let mut scored_items: Vec<(i64, &crate::gitlab::pipelines::Pipeline)> = Vec::new();
+
+        for item in items {
+            let mut best_score: Option<i64> = None;
+
+            let mut check_match = |text: &str| {
+                if let Some(score) = matcher.fuzzy_match(text, query) {
+                    if best_score.is_none() || Some(score) > best_score {
+                        best_score = Some(score);
                     }
                 }
-                matches
-            })
-            .collect()
+            };
+
+            if enabled_cols.contains("ID") {
+                check_match(&format!("#{}", item.id));
+                check_match(&item.id.to_string());
+            }
+            if enabled_cols.contains("Status") {
+                check_match(&item.status);
+            }
+            if enabled_cols.contains("Ref") {
+                check_match(&item.r#ref);
+            }
+            if enabled_cols.contains("Stages") {
+                if let Some(jobs) = pipeline_jobs.get(&item.id) {
+                    for job in jobs {
+                        check_match(&job.name);
+                        check_match(&job.stage);
+                        check_match(&job.status);
+                    }
+                }
+            }
+
+            if let Some(score) = best_score {
+                scored_items.push((score, item));
+            }
+        }
+
+        scored_items.sort_by(|a, b| b.0.cmp(&a.0));
+        scored_items.into_iter().map(|(_, item)| item).collect()
     }
 
     pub fn filtered_pipelines_list<'a>(
@@ -1991,36 +2009,45 @@ impl App {
         if query.trim().is_empty() {
             return items.iter().collect();
         }
-        let q = query.trim().to_lowercase();
-        items
-            .iter()
-            .filter(|item| {
-                let mut matches = false;
-                let mut check_match = |text: &str| {
-                    if text.to_lowercase().contains(&q) {
-                        matches = true;
-                    }
-                };
-                if enabled_cols.contains("ID") {
-                    check_match(&item.id.to_string());
-                }
-                if enabled_cols.contains("Status") {
-                    check_match(&item.status);
-                }
-                if enabled_cols.contains("Stage") {
-                    check_match(&item.stage);
-                }
-                if enabled_cols.contains("Name") {
-                    check_match(&item.name);
-                }
-                if enabled_cols.contains("Matrix") {
-                    if let Some(matrix) = &item.matrix {
-                        check_match(matrix);
+        let matcher = SkimMatcherV2::default();
+        let mut scored_items: Vec<(i64, &crate::gitlab::pipelines::Job)> = Vec::new();
+
+        for item in items {
+            let mut best_score: Option<i64> = None;
+
+            let mut check_match = |text: &str| {
+                if let Some(score) = matcher.fuzzy_match(text, query) {
+                    if best_score.is_none() || Some(score) > best_score {
+                        best_score = Some(score);
                     }
                 }
-                matches
-            })
-            .collect()
+            };
+
+            if enabled_cols.contains("ID") {
+                check_match(&item.id.to_string());
+            }
+            if enabled_cols.contains("Status") {
+                check_match(&item.status);
+            }
+            if enabled_cols.contains("Stage") {
+                check_match(&item.stage);
+            }
+            if enabled_cols.contains("Name") {
+                check_match(&item.name);
+            }
+            if enabled_cols.contains("Matrix") {
+                if let Some(matrix) = &item.matrix {
+                    check_match(matrix);
+                }
+            }
+
+            if let Some(score) = best_score {
+                scored_items.push((score, item));
+            }
+        }
+
+        scored_items.sort_by(|a, b| b.0.cmp(&a.0));
+        scored_items.into_iter().map(|(_, item)| item).collect()
     }
 
     pub fn filtered_jobs_list<'a>(

--- a/src/config.rs
+++ b/src/config.rs
@@ -315,7 +315,25 @@ pub struct KeybindingReleases {
     #[serde(default)]
     pub create_release: String,
     #[serde(default)]
+    pub edit_release: String,
+    #[serde(default)]
+    pub delete_release: String,
+    #[serde(default)]
+    pub open_in_browser: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeybindingMilestones {
+    #[serde(default)]
     pub create_milestone: String,
+    #[serde(default)]
+    pub edit_milestone: String,
+    #[serde(default)]
+    pub close_milestone: String,
+    #[serde(default)]
+    pub reopen_milestone: String,
+    #[serde(default)]
+    pub delete_milestone: String,
     #[serde(default)]
     pub open_in_browser: String,
 }
@@ -332,6 +350,8 @@ pub struct KeybindingConfig {
     pub pipelines: KeybindingPipelines,
     #[serde(default)]
     pub releases: KeybindingReleases,
+    #[serde(default)]
+    pub milestones: KeybindingMilestones,
 }
 
 macro_rules! keybind_defaults {
@@ -366,7 +386,13 @@ keybind_defaults! {
     def_cancel = "d",
     def_download_artifact = "d",
     def_create_release = "n",
+    def_edit_release = "e",
+    def_delete_release = "d",
     def_create_milestone = "n",
+    def_edit_milestone = "e",
+    def_close_milestone = "c",
+    def_reopen_milestone = "r",
+    def_delete_milestone = "d",
     def_open_in_browser = "o",
 }
 
@@ -427,7 +453,21 @@ impl Default for KeybindingReleases {
     fn default() -> Self {
         Self {
             create_release: def_create_release(),
+            edit_release: def_edit_release(),
+            delete_release: def_delete_release(),
+            open_in_browser: def_open_in_browser(),
+        }
+    }
+}
+
+impl Default for KeybindingMilestones {
+    fn default() -> Self {
+        Self {
             create_milestone: def_create_milestone(),
+            edit_milestone: def_edit_milestone(),
+            close_milestone: def_close_milestone(),
+            reopen_milestone: def_reopen_milestone(),
+            delete_milestone: def_delete_milestone(),
             open_in_browser: def_open_in_browser(),
         }
     }
@@ -441,6 +481,7 @@ impl Default for KeybindingConfig {
             mrs: KeybindingMrs::default(),
             pipelines: KeybindingPipelines::default(),
             releases: KeybindingReleases::default(),
+            milestones: KeybindingMilestones::default(),
         }
     }
 }
@@ -576,7 +617,16 @@ download_artifact = "d"
 
 [keybindings.releases]
 create_release = "n"
+edit_release = "e"
+delete_release = "d"
+open_in_browser = "o"
+
+[keybindings.milestones]
 create_milestone = "n"
+edit_milestone = "e"
+close_milestone = "c"
+reopen_milestone = "r"
+delete_milestone = "d"
 open_in_browser = "o"
 
 # Per-pane column config (unset = show all columns)

--- a/src/event.rs
+++ b/src/event.rs
@@ -40,6 +40,12 @@ pub enum Event {
     MilestonesFetched(Vec<crate::gitlab::milestones::Milestone>),
     MilestoneIssuesFetched(u64, Vec<crate::gitlab::issues::Issue>),
     JobTraceFetched(u64, Result<String, String>),
+    MilestoneUpdated,
+    MilestoneClosed,
+    MilestoneReopened,
+    MilestoneDeleted,
+    ReleaseUpdated,
+    ReleaseDeleted,
 }
 
 #[derive(Debug)]

--- a/src/gitlab/milestones.rs
+++ b/src/gitlab/milestones.rs
@@ -33,3 +33,175 @@ pub async fn list_milestone_issues(
     );
     client.fetch_api(&endpoint).await
 }
+
+pub async fn update_milestone_state(
+    client: &GitlabClient,
+    project_path: &str,
+    milestone_iid: u64,
+    close: bool,
+) -> Result<()> {
+    if client.is_github {
+        let state = if close { "closed" } else { "open" };
+        let out = tokio::process::Command::new("gh")
+            .args([
+                "api",
+                "-X",
+                "PATCH",
+                &format!("repos/{}/milestones/{}", project_path, milestone_iid),
+                "-F",
+                &format!("state={}", state),
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitHub API error: {}", err);
+        }
+    } else {
+        let action = if close { "close" } else { "reopen" };
+        let encoded_path = project_path.replace("/", "%2F");
+        let out = tokio::process::Command::new("glab")
+            .args([
+                "milestone",
+                action,
+                &milestone_iid.to_string(),
+                "-R",
+                &encoded_path,
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitLab API error: {}", err);
+        }
+    }
+}
+
+pub async fn update_milestone(
+    client: &GitlabClient,
+    project_path: &str,
+    milestone_iid: u64,
+    title: &str,
+    description: &str,
+    start_date: Option<&str>,
+    due_date: Option<&str>,
+) -> Result<()> {
+    if client.is_github {
+        // gh api PATCH /repos/{owner}/{repo}/milestones/{milestone_number}
+        let mut args = vec![
+            "api".to_string(),
+            "-X".to_string(),
+            "PATCH".to_string(),
+            format!("repos/{}/milestones/{}", project_path, milestone_iid),
+            "-F".to_string(),
+            format!("title={}", title),
+            "-F".to_string(),
+            format!("description={}", description),
+        ];
+        if let Some(due) = due_date {
+            if !due.is_empty() {
+                // GitHub expects ISO 8601, e.g. YYYY-MM-DDTHH:MM:SSZ
+                let iso_due = if due.contains('T') {
+                    due.to_string()
+                } else {
+                    format!("{}T23:59:59Z", due)
+                };
+                args.push("-F".to_string());
+                args.push(format!("due_on={}", iso_due));
+            }
+        }
+        let out = tokio::process::Command::new("gh")
+            .args(&args)
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitHub API error: {}", err);
+        }
+    } else {
+        // glab milestone update <id> --title <title> --description <description> --start-date <start-date> --due-date <due-date>
+        let encoded_path = project_path.replace("/", "%2F");
+        let mut args = vec![
+            "milestone".to_string(),
+            "update".to_string(),
+            milestone_iid.to_string(),
+            "-R".to_string(),
+            encoded_path,
+            "--title".to_string(),
+            title.to_string(),
+            "--description".to_string(),
+            description.to_string(),
+        ];
+        if let Some(start) = start_date {
+            if !start.is_empty() {
+                args.push("--start-date".to_string());
+                args.push(start.to_string());
+            }
+        }
+        if let Some(due) = due_date {
+            if !due.is_empty() {
+                args.push("--due-date".to_string());
+                args.push(due.to_string());
+            }
+        }
+        let out = tokio::process::Command::new("glab")
+            .args(&args)
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitLab API error: {}", err);
+        }
+    }
+}
+
+pub async fn delete_milestone(
+    client: &GitlabClient,
+    project_path: &str,
+    milestone_iid: u64,
+) -> Result<()> {
+    if client.is_github {
+        let out = tokio::process::Command::new("gh")
+            .args([
+                "api",
+                "-X",
+                "DELETE",
+                &format!("repos/{}/milestones/{}", project_path, milestone_iid),
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitHub API error: {}", err);
+        }
+    } else {
+        let encoded_path = project_path.replace("/", "%2F");
+        let out = tokio::process::Command::new("glab")
+            .args([
+                "milestone",
+                "delete",
+                &milestone_iid.to_string(),
+                "-R",
+                &encoded_path,
+                "-y",
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitLab API error: {}", err);
+        }
+    }
+}

--- a/src/gitlab/releases.rs
+++ b/src/gitlab/releases.rs
@@ -82,14 +82,7 @@ pub async fn delete_release(
     if client.is_github {
         let gh_repo = project_path;
         let out = tokio::process::Command::new("gh")
-            .args([
-                "release",
-                "delete",
-                tag_name,
-                "-R",
-                gh_repo,
-                "-y",
-            ])
+            .args(["release", "delete", tag_name, "-R", gh_repo, "-y"])
             .output()
             .await?;
         if out.status.success() {
@@ -101,14 +94,7 @@ pub async fn delete_release(
     } else {
         let encoded_path = project_path.replace("/", "%2F");
         let out = tokio::process::Command::new("glab")
-            .args([
-                "release",
-                "delete",
-                tag_name,
-                "-R",
-                &encoded_path,
-                "-y",
-            ])
+            .args(["release", "delete", tag_name, "-R", &encoded_path, "-y"])
             .output()
             .await?;
         if out.status.success() {

--- a/src/gitlab/releases.rs
+++ b/src/gitlab/releases.rs
@@ -19,3 +19,103 @@ pub async fn list_releases(client: &GitlabClient, project_path: &str) -> Result<
     let endpoint = format!("/projects/{}/releases?per_page=100", encoded_path);
     client.fetch_api(&endpoint).await
 }
+
+pub async fn update_release(
+    client: &GitlabClient,
+    project_path: &str,
+    tag_name: &str,
+    name: &str,
+    description: &str,
+) -> Result<()> {
+    if client.is_github {
+        let gh_repo = project_path;
+        let out = tokio::process::Command::new("gh")
+            .args([
+                "release",
+                "edit",
+                tag_name,
+                "-R",
+                gh_repo,
+                "-t",
+                name,
+                "-n",
+                description,
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitHub API error: {}", err);
+        }
+    } else {
+        let encoded_path = project_path.replace("/", "%2F");
+        let out = tokio::process::Command::new("glab")
+            .args([
+                "release",
+                "create",
+                tag_name,
+                "-R",
+                &encoded_path,
+                "-n",
+                name,
+                "-N",
+                description,
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitLab API error: {}", err);
+        }
+    }
+}
+
+pub async fn delete_release(
+    client: &GitlabClient,
+    project_path: &str,
+    tag_name: &str,
+) -> Result<()> {
+    if client.is_github {
+        let gh_repo = project_path;
+        let out = tokio::process::Command::new("gh")
+            .args([
+                "release",
+                "delete",
+                tag_name,
+                "-R",
+                gh_repo,
+                "-y",
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitHub API error: {}", err);
+        }
+    } else {
+        let encoded_path = project_path.replace("/", "%2F");
+        let out = tokio::process::Command::new("glab")
+            .args([
+                "release",
+                "delete",
+                tag_name,
+                "-R",
+                &encoded_path,
+                "-y",
+            ])
+            .output()
+            .await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            anyhow::bail!("GitLab API error: {}", err);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4910,6 +4910,133 @@ async fn main() -> Result<()> {
                                             );
                                         }
                                         continue;
+                                    } else if entity_type == "new_milestone" {
+                                        let title = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Title")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let description = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Description")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let start_date = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Start Date")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let due_date = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Due Date")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+
+                                        let cli = app_cli(&app);
+                                        let is_github = cli.is_github;
+                                        let project_context = app.project_context.clone();
+                                        let encoded_path = project_context.replace("/", "%2F");
+                                        let tx = events.sender();
+                                        let _ = tx.send(Event::CommandStarted(format!(
+                                            "Creating milestone: {}",
+                                            title
+                                        )));
+                                        app.edit_menu = None;
+                                        tokio::spawn(async move {
+                                            if is_github {
+                                                let gh_repo = encoded_path.replace("%2F", "/");
+                                                let due_on = if !due_date.is_empty() && due_date != "YYYY-MM-DD" {
+                                                    format!("{}T00:00:00Z", due_date.trim())
+                                                } else {
+                                                    "".to_string()
+                                                };
+                                                let mut args = vec![
+                                                    "api".to_string(),
+                                                    format!("repos/{}/milestones", gh_repo),
+                                                    "-f".to_string(),
+                                                    format!("title={}", title),
+                                                ];
+                                                if !description.is_empty() {
+                                                    args.push("-f".to_string());
+                                                    args.push(format!("description={}", description));
+                                                }
+                                                if !due_on.is_empty() {
+                                                    args.push("-f".to_string());
+                                                    args.push(format!("due_on={}", due_on));
+                                                }
+                                                let cmd = tokio::process::Command::new("gh")
+                                                    .args(&args)
+                                                    .output()
+                                                    .await;
+                                                match cmd {
+                                                    Ok(out) if out.status.success() => {
+                                                        let _ = tx.send(Event::MilestoneUpdated);
+                                                    }
+                                                    Ok(out) => {
+                                                        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                                                        let _ = tx.send(Event::CommandCompleted(
+                                                            app::Tab::Milestones,
+                                                            Err(format!("Failed: {}", err)),
+                                                        ));
+                                                    }
+                                                    Err(e) => {
+                                                        let _ = tx.send(Event::CommandCompleted(
+                                                            app::Tab::Milestones,
+                                                            Err(format!("Error: {}", e)),
+                                                        ));
+                                                    }
+                                                }
+                                            } else {
+                                                let endpoint = format!("/projects/{}/milestones", encoded_path);
+                                                let mut args = vec![
+                                                    "api".to_string(),
+                                                    "-X".to_string(),
+                                                    "POST".to_string(),
+                                                    endpoint,
+                                                    "-f".to_string(),
+                                                    format!("title={}", title),
+                                                ];
+                                                if !description.is_empty() {
+                                                    args.push("-f".to_string());
+                                                    args.push(format!("description={}", description));
+                                                }
+                                                if !start_date.is_empty() && start_date != "YYYY-MM-DD" {
+                                                    args.push("-f".to_string());
+                                                    args.push(format!("start_date={}", start_date));
+                                                }
+                                                if !due_date.is_empty() && due_date != "YYYY-MM-DD" {
+                                                    args.push("-f".to_string());
+                                                    args.push(format!("due_date={}", due_date));
+                                                }
+                                                let cmd = tokio::process::Command::new("glab")
+                                                    .args(&args)
+                                                    .output()
+                                                    .await;
+                                                match cmd {
+                                                    Ok(out) if out.status.success() => {
+                                                        let _ = tx.send(Event::MilestoneUpdated);
+                                                    }
+                                                    Ok(out) => {
+                                                        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                                                        let _ = tx.send(Event::CommandCompleted(
+                                                            app::Tab::Milestones,
+                                                            Err(format!("Failed: {}", err)),
+                                                        ));
+                                                    }
+                                                    Err(e) => {
+                                                        let _ = tx.send(Event::CommandCompleted(
+                                                            app::Tab::Milestones,
+                                                            Err(format!("Error: {}", e)),
+                                                        ));
+                                                    }
+                                                }
+                                            }
+                                        });
+                                        continue;
                                     } else if entity_type == "new_pipeline" {
                                         let cli = app_cli(&app);
                                         let branch = menu
@@ -7521,44 +7648,65 @@ async fn main() -> Result<()> {
                                     action: crate::app::TextInputAction::CreateRelease,
                                 });
                             }
-                            _ => {
+                            _ if (key_event.code == KeyCode::Char('e')
+                                || keybinding_matches(
+                                    &app.config.keybindings.releases.edit_release,
+                                    &key_event,
+                                )) =>
+                            {
                                 if let Some(selected_idx) = app.releases.state.selected() {
-                                    if let Some(item) = app.filtered_releases().get(selected_idx) {
-                                        match key_event.code {
-                                            _ if (key_event.code == KeyCode::Char('o')
-                                                || keybinding_matches(
-                                                    &app.config
-                                                        .keybindings
-                                                        .releases
-                                                        .open_in_browser,
-                                                    &key_event,
-                                                )) =>
-                                            {
-                                                let cli = app_cli(&app);
-                                                let args = vec![
-                                                    "release".to_string(),
-                                                    "view".to_string(),
-                                                    item.tag_name.clone(),
-                                                    cli.flag_web().to_string(),
-                                                ];
-                                                run_cli(
-                                                    &cli,
-                                                    &args,
-                                                    &mut terminal,
-                                                    events.sender(),
-                                                    app.active_tab,
-                                                )
-                                                .await;
-                                            }
-                                            _ => handled = false,
+                                    let release_tag = {
+                                        let filtered = app.filtered_releases();
+                                        filtered.get(selected_idx).map(|r| r.tag_name.clone())
+                                    };
+                                    if let Some(tag_name) = release_tag {
+                                        if let Some(idx) = app.releases.items.iter().position(|r| r.tag_name == tag_name) {
+                                            rebuild_edit_menu(&mut app, "release", idx as u64);
                                         }
-                                    } else {
-                                        handled = false;
                                     }
-                                } else {
-                                    handled = false;
                                 }
                             }
+                            _ if (key_event.code == KeyCode::Char('d')
+                                || keybinding_matches(
+                                    &app.config.keybindings.releases.delete_release,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.releases.state.selected() {
+                                    let filtered = app.filtered_releases();
+                                    if let Some(release) = filtered.get(selected_idx) {
+                                        app.confirm_popup = Some(crate::app::ConfirmAction::DeleteRelease(release.tag_name.clone()));
+                                    }
+                                }
+                            }
+                            _ if (key_event.code == KeyCode::Char('o')
+                                || keybinding_matches(
+                                    &app.config.keybindings.releases.open_in_browser,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.releases.state.selected() {
+                                    let filtered = app.filtered_releases();
+                                    if let Some(release) = filtered.get(selected_idx) {
+                                        let cli = app_cli(&app);
+                                        let args = vec![
+                                            "release".to_string(),
+                                            "view".to_string(),
+                                            release.tag_name.clone(),
+                                            cli.flag_web().to_string(),
+                                        ];
+                                        run_cli(
+                                            &cli,
+                                            &args,
+                                            &mut terminal,
+                                            events.sender(),
+                                            app.active_tab,
+                                        )
+                                        .await;
+                                    }
+                                }
+                            }
+                            _ => handled = false,
                         },
                         app::Tab::Todos => {
                             if let Some(selected_idx) = app.todos.state.selected() {
@@ -7638,16 +7786,167 @@ async fn main() -> Result<()> {
                         app::Tab::Milestones => match key_event.code {
                             _ if (key_event.code == KeyCode::Char('n')
                                 || keybinding_matches(
-                                    &app.config.keybindings.releases.create_milestone,
+                                    &app.config.keybindings.milestones.create_milestone,
                                     &key_event,
                                 )) =>
                             {
-                                app.text_input = Some(crate::app::TextInput {
+                                let is_github = app.gitlab_client.as_ref().map(|c| c.is_github).unwrap_or(false);
+                                let mut fields = vec![
+                                    ("Title".to_string(), String::new()),
+                                    ("Description".to_string(), String::new()),
+                                ];
+                                if !is_github {
+                                    fields.push(("Start Date".to_string(), String::new()));
+                                }
+                                fields.push(("Due Date".to_string(), String::new()));
+                                app.edit_menu = Some(crate::app::EditMenu {
                                     title: "Create Milestone".to_string(),
-                                    value: String::new(),
-                                    cursor_idx: 0,
-                                    action: crate::app::TextInputAction::CreateMilestone,
+                                    fields,
+                                    selected_idx: 0,
+                                    entity_iid: 0,
+                                    entity_type: "new_milestone".to_string(),
+                                    state: {
+                                        let mut s = ListState::default();
+                                        s.select(Some(0));
+                                        s
+                                    },
                                 });
+                            }
+                            _ if (key_event.code == KeyCode::Char('e')
+                                || keybinding_matches(
+                                    &app.config.keybindings.milestones.edit_milestone,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.milestones.state.selected() {
+                                    let milestone_iid = {
+                                        let filtered = app.filtered_milestones();
+                                        filtered.get(selected_idx).map(|m| m.iid)
+                                    };
+                                    if let Some(iid) = milestone_iid {
+                                        rebuild_edit_menu(&mut app, "milestone", iid);
+                                    }
+                                }
+                            }
+                            _ if (key_event.code == KeyCode::Char('c')
+                                || keybinding_matches(
+                                    &app.config.keybindings.milestones.close_milestone,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.milestones.state.selected() {
+                                    let filtered = app.filtered_milestones();
+                                    if let Some(milestone) = filtered.get(selected_idx) {
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project_path = app.project_context.clone();
+                                        let milestone_iid = milestone.iid;
+                                        let tx = events.sender();
+                                        let _ = tx.send(Event::CommandStarted(format!("Closing milestone #{}", milestone_iid)));
+                                        tokio::spawn(async move {
+                                            let res = crate::gitlab::milestones::update_milestone_state(
+                                                &client,
+                                                &project_path,
+                                                milestone_iid,
+                                                true,
+                                            ).await;
+                                            match res {
+                                                Ok(_) => {
+                                                    let _ = tx.send(Event::MilestoneClosed);
+                                                }
+                                                Err(e) => {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        crate::app::Tab::Milestones,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                }
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+                            _ if (key_event.code == KeyCode::Char('r')
+                                || keybinding_matches(
+                                    &app.config.keybindings.milestones.reopen_milestone,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.milestones.state.selected() {
+                                    let filtered = app.filtered_milestones();
+                                    if let Some(milestone) = filtered.get(selected_idx) {
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project_path = app.project_context.clone();
+                                        let milestone_iid = milestone.iid;
+                                        let tx = events.sender();
+                                        let _ = tx.send(Event::CommandStarted(format!("Reopening milestone #{}", milestone_iid)));
+                                        tokio::spawn(async move {
+                                            let res = crate::gitlab::milestones::update_milestone_state(
+                                                &client,
+                                                &project_path,
+                                                milestone_iid,
+                                                false,
+                                            ).await;
+                                            match res {
+                                                Ok(_) => {
+                                                    let _ = tx.send(Event::MilestoneReopened);
+                                                }
+                                                Err(e) => {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        crate::app::Tab::Milestones,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                }
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+                            _ if (key_event.code == KeyCode::Char('d')
+                                || keybinding_matches(
+                                    &app.config.keybindings.milestones.delete_milestone,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.milestones.state.selected() {
+                                    let filtered = app.filtered_milestones();
+                                    if let Some(milestone) = filtered.get(selected_idx) {
+                                        app.confirm_popup = Some(crate::app::ConfirmAction::DeleteMilestone(milestone.iid));
+                                    }
+                                }
+                            }
+                            _ if (key_event.code == KeyCode::Char('o')
+                                || keybinding_matches(
+                                    &app.config.keybindings.milestones.open_in_browser,
+                                    &key_event,
+                                )) =>
+                            {
+                                if let Some(selected_idx) = app.milestones.state.selected() {
+                                    let filtered = app.filtered_milestones();
+                                    if let Some(milestone) = filtered.get(selected_idx) {
+                                        let is_github = app.gitlab_client.as_ref().map(|c| c.is_github).unwrap_or(false);
+                                        let cli = app_cli(&app);
+                                        let args = if is_github {
+                                            vec![
+                                                "browse".to_string(),
+                                                format!("milestone/{}", milestone.iid),
+                                            ]
+                                        } else {
+                                            vec![
+                                                "milestone".to_string(),
+                                                "view".to_string(),
+                                                milestone.iid.to_string(),
+                                                cli.flag_web().to_string(),
+                                            ]
+                                        };
+                                        run_cli(
+                                            &cli,
+                                            &args,
+                                            &mut terminal,
+                                            events.sender(),
+                                            app.active_tab,
+                                        )
+                                        .await;
+                                    }
+                                }
                             }
                             _ => handled = false,
                         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,7 +444,56 @@ async fn apply_field_text_change(
                 }
             }
         }
-        _ => {}
+        _ => {
+            if entity_type == "milestone" {
+                let milestone_opt = app.milestones.items.iter().find(|m| m.iid == iid).cloned();
+                if let Some(milestone) = milestone_opt {
+                    let mut title = milestone.title.clone();
+                    let mut start_date = milestone.start_date.clone();
+                    let mut due_date = milestone.due_date.clone();
+                    let mut description = milestone.description.clone().unwrap_or_default();
+
+                    match field_type {
+                        "title" => title = value.clone(),
+                        "start_date" => start_date = Some(value.clone()),
+                        "due_date" => due_date = Some(value.clone()),
+                        "description" => description = value.clone(),
+                        _ => {}
+                    }
+
+                    let client = app.gitlab_client.clone().unwrap();
+                    let project_path = app.project_context.clone();
+                    let tx_spawn = tx.clone();
+                    let _ = tx.send(Event::CommandStarted(format!(
+                        "Updating milestone #{}",
+                        iid
+                    )));
+                    tokio::spawn(async move {
+                        let res = crate::gitlab::milestones::update_milestone(
+                            &client,
+                            &project_path,
+                            iid,
+                            &title,
+                            &description,
+                            start_date.as_deref(),
+                            due_date.as_deref(),
+                        )
+                        .await;
+                        match res {
+                            Ok(_) => {
+                                let _ = tx_spawn.send(Event::MilestoneUpdated);
+                            }
+                            Err(e) => {
+                                let _ = tx_spawn.send(Event::CommandCompleted(
+                                    crate::app::Tab::Milestones,
+                                    Err(e.to_string()),
+                                ));
+                            }
+                        }
+                    });
+                }
+            }
+        }
     }
 }
 
@@ -948,6 +997,39 @@ fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
                 selected_idx,
                 entity_iid: mr.iid,
                 entity_type: "mr".to_string(),
+                state: {
+                    let mut s = ListState::default();
+                    s.select(Some(selected_idx));
+                    s
+                },
+            });
+        }
+    } else if entity_type == "milestone" {
+        if let Some(milestone) = app.milestones.items.iter().find(|m| m.iid == entity_iid) {
+            let selected_idx = app.edit_menu.as_ref().map(|m| m.selected_idx).unwrap_or(0);
+            let cli = app_cli(app);
+            let mut fields = vec![("Title".to_string(), milestone.title.clone())];
+            if !cli.is_github {
+                fields.push((
+                    "Start Date".to_string(),
+                    milestone.start_date.clone().unwrap_or_default(),
+                ));
+            }
+            fields.push((
+                "Due Date".to_string(),
+                milestone.due_date.clone().unwrap_or_default(),
+            ));
+            fields.push((
+                "Description".to_string(),
+                milestone.description.clone().unwrap_or_default(),
+            ));
+
+            app.edit_menu = Some(crate::app::EditMenu {
+                title: format!("Edit Milestone #{}", milestone.iid),
+                fields,
+                selected_idx,
+                entity_iid: milestone.iid,
+                entity_type: "milestone".to_string(),
                 state: {
                     let mut s = ListState::default();
                     s.select(Some(selected_idx));
@@ -4949,7 +5031,9 @@ async fn main() -> Result<()> {
                                         tokio::spawn(async move {
                                             if is_github {
                                                 let gh_repo = encoded_path.replace("%2F", "/");
-                                                let due_on = if !due_date.is_empty() && due_date != "YYYY-MM-DD" {
+                                                let due_on = if !due_date.is_empty()
+                                                    && due_date != "YYYY-MM-DD"
+                                                {
                                                     format!("{}T00:00:00Z", due_date.trim())
                                                 } else {
                                                     "".to_string()
@@ -4962,7 +5046,10 @@ async fn main() -> Result<()> {
                                                 ];
                                                 if !description.is_empty() {
                                                     args.push("-f".to_string());
-                                                    args.push(format!("description={}", description));
+                                                    args.push(format!(
+                                                        "description={}",
+                                                        description
+                                                    ));
                                                 }
                                                 if !due_on.is_empty() {
                                                     args.push("-f".to_string());
@@ -4977,7 +5064,10 @@ async fn main() -> Result<()> {
                                                         let _ = tx.send(Event::MilestoneUpdated);
                                                     }
                                                     Ok(out) => {
-                                                        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                                                        let err =
+                                                            String::from_utf8_lossy(&out.stderr)
+                                                                .trim()
+                                                                .to_string();
                                                         let _ = tx.send(Event::CommandCompleted(
                                                             app::Tab::Milestones,
                                                             Err(format!("Failed: {}", err)),
@@ -4991,7 +5081,10 @@ async fn main() -> Result<()> {
                                                     }
                                                 }
                                             } else {
-                                                let endpoint = format!("/projects/{}/milestones", encoded_path);
+                                                let endpoint = format!(
+                                                    "/projects/{}/milestones",
+                                                    encoded_path
+                                                );
                                                 let mut args = vec![
                                                     "api".to_string(),
                                                     "-X".to_string(),
@@ -5002,13 +5095,19 @@ async fn main() -> Result<()> {
                                                 ];
                                                 if !description.is_empty() {
                                                     args.push("-f".to_string());
-                                                    args.push(format!("description={}", description));
+                                                    args.push(format!(
+                                                        "description={}",
+                                                        description
+                                                    ));
                                                 }
-                                                if !start_date.is_empty() && start_date != "YYYY-MM-DD" {
+                                                if !start_date.is_empty()
+                                                    && start_date != "YYYY-MM-DD"
+                                                {
                                                     args.push("-f".to_string());
                                                     args.push(format!("start_date={}", start_date));
                                                 }
-                                                if !due_date.is_empty() && due_date != "YYYY-MM-DD" {
+                                                if !due_date.is_empty() && due_date != "YYYY-MM-DD"
+                                                {
                                                     args.push("-f".to_string());
                                                     args.push(format!("due_date={}", due_date));
                                                 }
@@ -5021,7 +5120,10 @@ async fn main() -> Result<()> {
                                                         let _ = tx.send(Event::MilestoneUpdated);
                                                     }
                                                     Ok(out) => {
-                                                        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                                                        let err =
+                                                            String::from_utf8_lossy(&out.stderr)
+                                                                .trim()
+                                                                .to_string();
                                                         let _ = tx.send(Event::CommandCompleted(
                                                             app::Tab::Milestones,
                                                             Err(format!("Failed: {}", err)),
@@ -5425,28 +5527,51 @@ async fn main() -> Result<()> {
                                     continue;
                                 }
 
-                                if field_name == "Due Date" {
-                                    let current_val = if entity_iid == 0 {
-                                        menu.fields[menu.selected_idx].1.clone()
-                                    } else {
-                                        app.issues
-                                            .items
-                                            .iter()
-                                            .find(|i| i.iid == entity_iid)
-                                            .and_then(|i| i.due_date.clone())
-                                            .unwrap_or_default()
-                                    };
-                                    let action = if entity_iid == 0 {
-                                        crate::app::DatePickerAction::EditNewField {
-                                            field_idx: menu.selected_idx,
-                                        }
-                                    } else {
-                                        crate::app::DatePickerAction::EditField {
-                                            entity_iid,
-                                            entity_type: entity_type.clone(),
-                                            field_type: "due_date".to_string(),
-                                        }
-                                    };
+                                if field_name == "Due Date" || field_name == "Start Date" {
+                                    let current_val =
+                                        if entity_iid == 0 || entity_type.starts_with("new_") {
+                                            menu.fields[menu.selected_idx].1.clone()
+                                        } else {
+                                            if entity_type == "issue" {
+                                                app.issues
+                                                    .items
+                                                    .iter()
+                                                    .find(|i| i.iid == entity_iid)
+                                                    .and_then(|i| i.due_date.clone())
+                                                    .unwrap_or_default()
+                                            } else if entity_type == "milestone" {
+                                                let m = app
+                                                    .milestones
+                                                    .items
+                                                    .iter()
+                                                    .find(|m| m.iid == entity_iid);
+                                                if field_name == "Start Date" {
+                                                    m.and_then(|m| m.start_date.clone())
+                                                        .unwrap_or_default()
+                                                } else {
+                                                    m.and_then(|m| m.due_date.clone())
+                                                        .unwrap_or_default()
+                                                }
+                                            } else {
+                                                String::new()
+                                            }
+                                        };
+                                    let action =
+                                        if entity_iid == 0 || entity_type.starts_with("new_") {
+                                            crate::app::DatePickerAction::EditNewField {
+                                                field_idx: menu.selected_idx,
+                                            }
+                                        } else {
+                                            crate::app::DatePickerAction::EditField {
+                                                entity_iid,
+                                                entity_type: entity_type.clone(),
+                                                field_type: if field_name == "Start Date" {
+                                                    "start_date".to_string()
+                                                } else {
+                                                    "due_date".to_string()
+                                                },
+                                            }
+                                        };
                                     app.date_picker = Some(crate::app::DatePicker::new(
                                         format!(" Select {}", field_name),
                                         &current_val,
@@ -5480,6 +5605,13 @@ async fn main() -> Result<()> {
                                                         .iter()
                                                         .find(|i| i.iid == entity_iid)
                                                         .map(|i| i.title.clone())
+                                                        .unwrap_or_default()
+                                                } else if entity_type == "milestone" {
+                                                    app.milestones
+                                                        .items
+                                                        .iter()
+                                                        .find(|m| m.iid == entity_iid)
+                                                        .map(|m| m.title.clone())
                                                         .unwrap_or_default()
                                                 } else {
                                                     app.mrs
@@ -7660,7 +7792,12 @@ async fn main() -> Result<()> {
                                         filtered.get(selected_idx).map(|r| r.tag_name.clone())
                                     };
                                     if let Some(tag_name) = release_tag {
-                                        if let Some(idx) = app.releases.items.iter().position(|r| r.tag_name == tag_name) {
+                                        if let Some(idx) = app
+                                            .releases
+                                            .items
+                                            .iter()
+                                            .position(|r| r.tag_name == tag_name)
+                                        {
                                             rebuild_edit_menu(&mut app, "release", idx as u64);
                                         }
                                     }
@@ -7675,7 +7812,10 @@ async fn main() -> Result<()> {
                                 if let Some(selected_idx) = app.releases.state.selected() {
                                     let filtered = app.filtered_releases();
                                     if let Some(release) = filtered.get(selected_idx) {
-                                        app.confirm_popup = Some(crate::app::ConfirmAction::DeleteRelease(release.tag_name.clone()));
+                                        app.confirm_popup =
+                                            Some(crate::app::ConfirmAction::DeleteRelease(
+                                                release.tag_name.clone(),
+                                            ));
                                     }
                                 }
                             }
@@ -7783,173 +7923,192 @@ async fn main() -> Result<()> {
                                 handled = false;
                             }
                         }
-                        app::Tab::Milestones => match key_event.code {
-                            _ if (key_event.code == KeyCode::Char('n')
-                                || keybinding_matches(
-                                    &app.config.keybindings.milestones.create_milestone,
-                                    &key_event,
-                                )) =>
-                            {
-                                let is_github = app.gitlab_client.as_ref().map(|c| c.is_github).unwrap_or(false);
-                                let mut fields = vec![
-                                    ("Title".to_string(), String::new()),
-                                    ("Description".to_string(), String::new()),
-                                ];
-                                if !is_github {
-                                    fields.push(("Start Date".to_string(), String::new()));
+                        app::Tab::Milestones => {
+                            match key_event.code {
+                                _ if (key_event.code == KeyCode::Char('n')
+                                    || keybinding_matches(
+                                        &app.config.keybindings.milestones.create_milestone,
+                                        &key_event,
+                                    )) =>
+                                {
+                                    let is_github = app
+                                        .gitlab_client
+                                        .as_ref()
+                                        .map(|c| c.is_github)
+                                        .unwrap_or(false);
+                                    let mut fields = vec![
+                                        ("Title".to_string(), String::new()),
+                                        ("Description".to_string(), String::new()),
+                                    ];
+                                    if !is_github {
+                                        fields.push(("Start Date".to_string(), String::new()));
+                                    }
+                                    fields.push(("Due Date".to_string(), String::new()));
+                                    app.edit_menu = Some(crate::app::EditMenu {
+                                        title: "Create Milestone".to_string(),
+                                        fields,
+                                        selected_idx: 0,
+                                        entity_iid: 0,
+                                        entity_type: "new_milestone".to_string(),
+                                        state: {
+                                            let mut s = ListState::default();
+                                            s.select(Some(0));
+                                            s
+                                        },
+                                    });
                                 }
-                                fields.push(("Due Date".to_string(), String::new()));
-                                app.edit_menu = Some(crate::app::EditMenu {
-                                    title: "Create Milestone".to_string(),
-                                    fields,
-                                    selected_idx: 0,
-                                    entity_iid: 0,
-                                    entity_type: "new_milestone".to_string(),
-                                    state: {
-                                        let mut s = ListState::default();
-                                        s.select(Some(0));
-                                        s
-                                    },
-                                });
-                            }
-                            _ if (key_event.code == KeyCode::Char('e')
-                                || keybinding_matches(
-                                    &app.config.keybindings.milestones.edit_milestone,
-                                    &key_event,
-                                )) =>
-                            {
-                                if let Some(selected_idx) = app.milestones.state.selected() {
-                                    let milestone_iid = {
-                                        let filtered = app.filtered_milestones();
-                                        filtered.get(selected_idx).map(|m| m.iid)
-                                    };
-                                    if let Some(iid) = milestone_iid {
-                                        rebuild_edit_menu(&mut app, "milestone", iid);
+                                _ if (key_event.code == KeyCode::Char('e')
+                                    || keybinding_matches(
+                                        &app.config.keybindings.milestones.edit_milestone,
+                                        &key_event,
+                                    )) =>
+                                {
+                                    if let Some(selected_idx) = app.milestones.state.selected() {
+                                        let milestone_iid = {
+                                            let filtered = app.filtered_milestones();
+                                            filtered.get(selected_idx).map(|m| m.iid)
+                                        };
+                                        if let Some(iid) = milestone_iid {
+                                            rebuild_edit_menu(&mut app, "milestone", iid);
+                                        }
                                     }
                                 }
-                            }
-                            _ if (key_event.code == KeyCode::Char('c')
-                                || keybinding_matches(
-                                    &app.config.keybindings.milestones.close_milestone,
-                                    &key_event,
-                                )) =>
-                            {
-                                if let Some(selected_idx) = app.milestones.state.selected() {
-                                    let filtered = app.filtered_milestones();
-                                    if let Some(milestone) = filtered.get(selected_idx) {
-                                        let client = app.gitlab_client.clone().unwrap();
-                                        let project_path = app.project_context.clone();
-                                        let milestone_iid = milestone.iid;
-                                        let tx = events.sender();
-                                        let _ = tx.send(Event::CommandStarted(format!("Closing milestone #{}", milestone_iid)));
-                                        tokio::spawn(async move {
-                                            let res = crate::gitlab::milestones::update_milestone_state(
+                                _ if (key_event.code == KeyCode::Char('c')
+                                    || keybinding_matches(
+                                        &app.config.keybindings.milestones.close_milestone,
+                                        &key_event,
+                                    )) =>
+                                {
+                                    if let Some(selected_idx) = app.milestones.state.selected() {
+                                        let filtered = app.filtered_milestones();
+                                        if let Some(milestone) = filtered.get(selected_idx) {
+                                            let client = app.gitlab_client.clone().unwrap();
+                                            let project_path = app.project_context.clone();
+                                            let milestone_iid = milestone.iid;
+                                            let tx = events.sender();
+                                            let _ = tx.send(Event::CommandStarted(format!(
+                                                "Closing milestone #{}",
+                                                milestone_iid
+                                            )));
+                                            tokio::spawn(async move {
+                                                let res = crate::gitlab::milestones::update_milestone_state(
                                                 &client,
                                                 &project_path,
                                                 milestone_iid,
                                                 true,
                                             ).await;
-                                            match res {
-                                                Ok(_) => {
-                                                    let _ = tx.send(Event::MilestoneClosed);
+                                                match res {
+                                                    Ok(_) => {
+                                                        let _ = tx.send(Event::MilestoneClosed);
+                                                    }
+                                                    Err(e) => {
+                                                        let _ = tx.send(Event::CommandCompleted(
+                                                            crate::app::Tab::Milestones,
+                                                            Err(e.to_string()),
+                                                        ));
+                                                    }
                                                 }
-                                                Err(e) => {
-                                                    let _ = tx.send(Event::CommandCompleted(
-                                                        crate::app::Tab::Milestones,
-                                                        Err(e.to_string()),
-                                                    ));
-                                                }
-                                            }
-                                        });
+                                            });
+                                        }
                                     }
                                 }
-                            }
-                            _ if (key_event.code == KeyCode::Char('r')
-                                || keybinding_matches(
-                                    &app.config.keybindings.milestones.reopen_milestone,
-                                    &key_event,
-                                )) =>
-                            {
-                                if let Some(selected_idx) = app.milestones.state.selected() {
-                                    let filtered = app.filtered_milestones();
-                                    if let Some(milestone) = filtered.get(selected_idx) {
-                                        let client = app.gitlab_client.clone().unwrap();
-                                        let project_path = app.project_context.clone();
-                                        let milestone_iid = milestone.iid;
-                                        let tx = events.sender();
-                                        let _ = tx.send(Event::CommandStarted(format!("Reopening milestone #{}", milestone_iid)));
-                                        tokio::spawn(async move {
-                                            let res = crate::gitlab::milestones::update_milestone_state(
+                                _ if (key_event.code == KeyCode::Char('r')
+                                    || keybinding_matches(
+                                        &app.config.keybindings.milestones.reopen_milestone,
+                                        &key_event,
+                                    )) =>
+                                {
+                                    if let Some(selected_idx) = app.milestones.state.selected() {
+                                        let filtered = app.filtered_milestones();
+                                        if let Some(milestone) = filtered.get(selected_idx) {
+                                            let client = app.gitlab_client.clone().unwrap();
+                                            let project_path = app.project_context.clone();
+                                            let milestone_iid = milestone.iid;
+                                            let tx = events.sender();
+                                            let _ = tx.send(Event::CommandStarted(format!(
+                                                "Reopening milestone #{}",
+                                                milestone_iid
+                                            )));
+                                            tokio::spawn(async move {
+                                                let res = crate::gitlab::milestones::update_milestone_state(
                                                 &client,
                                                 &project_path,
                                                 milestone_iid,
                                                 false,
                                             ).await;
-                                            match res {
-                                                Ok(_) => {
-                                                    let _ = tx.send(Event::MilestoneReopened);
+                                                match res {
+                                                    Ok(_) => {
+                                                        let _ = tx.send(Event::MilestoneReopened);
+                                                    }
+                                                    Err(e) => {
+                                                        let _ = tx.send(Event::CommandCompleted(
+                                                            crate::app::Tab::Milestones,
+                                                            Err(e.to_string()),
+                                                        ));
+                                                    }
                                                 }
-                                                Err(e) => {
-                                                    let _ = tx.send(Event::CommandCompleted(
-                                                        crate::app::Tab::Milestones,
-                                                        Err(e.to_string()),
-                                                    ));
-                                                }
-                                            }
-                                        });
+                                            });
+                                        }
                                     }
                                 }
-                            }
-                            _ if (key_event.code == KeyCode::Char('d')
-                                || keybinding_matches(
-                                    &app.config.keybindings.milestones.delete_milestone,
-                                    &key_event,
-                                )) =>
-                            {
-                                if let Some(selected_idx) = app.milestones.state.selected() {
-                                    let filtered = app.filtered_milestones();
-                                    if let Some(milestone) = filtered.get(selected_idx) {
-                                        app.confirm_popup = Some(crate::app::ConfirmAction::DeleteMilestone(milestone.iid));
+                                _ if (key_event.code == KeyCode::Char('d')
+                                    || keybinding_matches(
+                                        &app.config.keybindings.milestones.delete_milestone,
+                                        &key_event,
+                                    )) =>
+                                {
+                                    if let Some(selected_idx) = app.milestones.state.selected() {
+                                        let filtered = app.filtered_milestones();
+                                        if let Some(milestone) = filtered.get(selected_idx) {
+                                            app.confirm_popup =
+                                                Some(crate::app::ConfirmAction::DeleteMilestone(
+                                                    milestone.iid,
+                                                ));
+                                        }
                                     }
                                 }
-                            }
-                            _ if (key_event.code == KeyCode::Char('o')
-                                || keybinding_matches(
-                                    &app.config.keybindings.milestones.open_in_browser,
-                                    &key_event,
-                                )) =>
-                            {
-                                if let Some(selected_idx) = app.milestones.state.selected() {
-                                    let filtered = app.filtered_milestones();
-                                    if let Some(milestone) = filtered.get(selected_idx) {
-                                        let is_github = app.gitlab_client.as_ref().map(|c| c.is_github).unwrap_or(false);
-                                        let cli = app_cli(&app);
-                                        let args = if is_github {
-                                            vec![
-                                                "browse".to_string(),
-                                                format!("milestone/{}", milestone.iid),
-                                            ]
-                                        } else {
-                                            vec![
-                                                "milestone".to_string(),
-                                                "view".to_string(),
-                                                milestone.iid.to_string(),
-                                                cli.flag_web().to_string(),
-                                            ]
-                                        };
-                                        run_cli(
-                                            &cli,
-                                            &args,
-                                            &mut terminal,
-                                            events.sender(),
-                                            app.active_tab,
-                                        )
-                                        .await;
+                                _ if (key_event.code == KeyCode::Char('o')
+                                    || keybinding_matches(
+                                        &app.config.keybindings.milestones.open_in_browser,
+                                        &key_event,
+                                    )) =>
+                                {
+                                    if let Some(selected_idx) = app.milestones.state.selected() {
+                                        let filtered = app.filtered_milestones();
+                                        if let Some(milestone) = filtered.get(selected_idx) {
+                                            let is_github = app
+                                                .gitlab_client
+                                                .as_ref()
+                                                .map(|c| c.is_github)
+                                                .unwrap_or(false);
+                                            let cli = app_cli(&app);
+                                            let args = if is_github {
+                                                vec![
+                                                    "browse".to_string(),
+                                                    format!("milestone/{}", milestone.iid),
+                                                ]
+                                            } else {
+                                                vec![
+                                                    "milestone".to_string(),
+                                                    "view".to_string(),
+                                                    milestone.iid.to_string(),
+                                                    cli.flag_web().to_string(),
+                                                ]
+                                            };
+                                            run_cli(
+                                                &cli,
+                                                &args,
+                                                &mut terminal,
+                                                events.sender(),
+                                                app.active_tab,
+                                            )
+                                            .await;
+                                        }
                                     }
                                 }
+                                _ => handled = false,
                             }
-                            _ => handled = false,
-                        },
+                        }
                         app::Tab::Terminal => {
                             handled = false;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1415,6 +1415,76 @@ fn get_branches() -> Vec<String> {
     Vec::new()
 }
 
+/// Returns a list of workflow/CI files available in the repo.
+/// For GitHub repos: scans `.github/workflows/*.yml` and `*.yaml`.
+/// For GitLab repos: returns `.gitlab-ci.yml` if it exists, else empty.
+fn get_workflow_files(is_github: bool) -> Vec<String> {
+    // Determine the repo root via `git rev-parse --show-toplevel`
+    let root = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| ".".to_string());
+
+    if is_github {
+        let workflows_dir = std::path::Path::new(&root).join(".github").join("workflows");
+        let mut files: Vec<String> = std::fs::read_dir(&workflows_dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if (ext == "yml" || ext == "yaml") && path.is_file() {
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        files.sort();
+        files
+    } else {
+        // GitLab: the primary CI file is `.gitlab-ci.yml`; also check for
+        // include-able `.gitlab-ci-*.yml` files at the root.
+        let mut files: Vec<String> = std::fs::read_dir(&root)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                if !path.is_file() {
+                    return None;
+                }
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if (ext == "yml" || ext == "yaml")
+                    && (name == ".gitlab-ci.yml" || name.starts_with(".gitlab-ci-"))
+                {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        files.sort();
+        files
+    }
+}
+
 fn keybinding_matches(binding: &str, event: &crossterm::event::KeyEvent) -> bool {
     match binding {
         "Tab" => event.code == KeyCode::Tab && event.modifiers.is_empty(),
@@ -4580,6 +4650,8 @@ async fn main() -> Result<()> {
                                                 "mr_pipeline" => "Merge Request Pipeline",
                                                 "source_branch" => "Source Branch",
                                                 "target_branch" => "Target Branch",
+                                                "pipeline_branch" => "Branch / Ref",
+                                                "workflow_file" => "Workflow / CI File (GitHub)",
                                                 _ => "",
                                             };
                                             if !target_field_name.is_empty() {
@@ -5262,6 +5334,8 @@ async fn main() -> Result<()> {
                                     || field_name == "Merge Request Pipeline"
                                     || field_name == "Source Branch"
                                     || field_name == "Target Branch"
+                                    || field_name == "Branch / Ref"
+                                    || field_name == "Workflow / CI File (GitHub)"
                                 {
                                     let mut current_set = std::collections::HashSet::new();
                                     let field_type = match field_name.as_str() {
@@ -5274,6 +5348,8 @@ async fn main() -> Result<()> {
                                         "Merge Request Pipeline" => "mr_pipeline",
                                         "Source Branch" => "source_branch",
                                         "Target Branch" => "target_branch",
+                                        "Branch / Ref" => "pipeline_branch",
+                                        "Workflow / CI File (GitHub)" => "workflow_file",
                                         _ => "",
                                     };
                                     let multi_select = match field_type {
@@ -5329,6 +5405,27 @@ async fn main() -> Result<()> {
                                     {
                                         all_items = get_branches();
                                         is_loading = false;
+                                    } else if field_type == "pipeline_branch" {
+                                        all_items = get_branches();
+                                        is_loading = false;
+                                        // Pre-select the current branch value
+                                        let current_val = menu.fields[menu.selected_idx].1.clone();
+                                        if !current_val.is_empty() {
+                                            current_set.insert(current_val);
+                                        }
+                                    } else if field_type == "workflow_file" {
+                                        let is_github = app
+                                            .gitlab_client
+                                            .as_ref()
+                                            .map(|c| c.is_github)
+                                            .unwrap_or(false);
+                                        all_items = get_workflow_files(is_github);
+                                        is_loading = false;
+                                        // Pre-select any already-typed value
+                                        let current_val = menu.fields[menu.selected_idx].1.clone();
+                                        if !current_val.is_empty() {
+                                            current_set.insert(current_val);
+                                        }
                                     }
 
                                     if entity_iid == 0 || entity_type.starts_with("new_") {
@@ -7115,13 +7212,20 @@ async fn main() -> Result<()> {
                         }
                         app::Tab::Pipelines => {
                             if key_event.code == KeyCode::Char('n') {
+                                let is_github = app
+                                    .gitlab_client
+                                    .as_ref()
+                                    .map(|c| c.is_github)
+                                    .unwrap_or(false);
+                                let current_branch = get_current_branch()
+                                    .unwrap_or_else(|| "main".to_string());
+
                                 app.edit_menu = Some(crate::app::EditMenu {
                                     title: "Run Pipeline".to_string(),
                                     fields: vec![
                                         (
                                             "Branch / Ref".to_string(),
-                                            get_current_branch()
-                                                .unwrap_or_else(|| "main".to_string()),
+                                            current_branch.clone(),
                                         ),
                                         ("Merge Request Pipeline".to_string(), "No".to_string()),
                                         ("Variables".to_string(), String::new()),
@@ -7137,6 +7241,63 @@ async fn main() -> Result<()> {
                                         s
                                     },
                                 });
+
+                                // Immediately open the appropriate selector as a dropdown:
+                                // GitHub → workflow file picker; GitLab → branch picker.
+                                if is_github {
+                                    let workflow_files = get_workflow_files(true);
+                                    let mut pre_selected = std::collections::HashSet::new();
+                                    // Pre-select the first workflow file if only one exists
+                                    if workflow_files.len() == 1 {
+                                        pre_selected
+                                            .insert(workflow_files[0].clone());
+                                    }
+                                    app.selector = Some(crate::app::Selector {
+                                        title: "Select Workflow / CI File".to_string(),
+                                        all_items: workflow_files,
+                                        selected_items: pre_selected,
+                                        cursor_idx: 0,
+                                        search_query: String::new(),
+                                        is_filtering: false,
+                                        is_loading: false,
+                                        entity_iid: 0,
+                                        entity_type: "new_pipeline".to_string(),
+                                        field_type: "workflow_file".to_string(),
+                                        multi_select: false,
+                                        state: {
+                                            let mut s = ListState::default();
+                                            s.select(Some(0));
+                                            s
+                                        },
+                                    });
+                                } else {
+                                    let branches = get_branches();
+                                    let mut pre_selected = std::collections::HashSet::new();
+                                    pre_selected.insert(current_branch);
+                                    let start_idx = pre_selected
+                                        .iter()
+                                        .next()
+                                        .and_then(|sel| branches.iter().position(|b| b == sel))
+                                        .unwrap_or(0);
+                                    app.selector = Some(crate::app::Selector {
+                                        title: "Select Branch / Ref".to_string(),
+                                        all_items: branches,
+                                        selected_items: pre_selected,
+                                        cursor_idx: start_idx,
+                                        search_query: String::new(),
+                                        is_filtering: false,
+                                        is_loading: false,
+                                        entity_iid: 0,
+                                        entity_type: "new_pipeline".to_string(),
+                                        field_type: "pipeline_branch".to_string(),
+                                        multi_select: false,
+                                        state: {
+                                            let mut s = ListState::default();
+                                            s.select(Some(start_idx));
+                                            s
+                                        },
+                                    });
+                                }
                             } else if key_event.code == KeyCode::Char('p')
                                 || keybinding_matches(
                                     &app.config.keybindings.pipelines.trigger_pipeline,

--- a/src/main.rs
+++ b/src/main.rs
@@ -735,14 +735,21 @@ async fn apply_selector_changes(
         }
         "draft_status" => {
             if let Some(val) = values.first() {
-                let action = if val.to_lowercase() == "draft" {
-                    "--draft"
+                let going_ready = val.to_lowercase() != "draft";
+                // GitHub uses `gh pr ready <iid>` to mark ready for review;
+                // `gh pr edit --ready` is not a valid flag.
+                let args = if cli.is_github && going_ready && entity_type == "mr" {
+                    vec!["pr".to_string(), "ready".to_string(), iid.to_string()]
                 } else {
-                    "--ready"
+                    let action = if val.to_lowercase() == "draft" {
+                        "--draft"
+                    } else {
+                        "--ready"
+                    };
+                    UpdateCmd::new(cli.is_github, entity_type, iid)
+                        .flag_bool(action)
+                        .build()
                 };
-                let args = UpdateCmd::new(cli.is_github, entity_type, iid)
-                    .flag_bool(action)
-                    .build();
                 run_cli(&cli, &args, terminal, tx.clone(), tab).await;
                 if entity_type == "mr" {
                     if let Some(item) = app.mrs.items.iter_mut().find(|m| m.iid == iid) {
@@ -1084,7 +1091,7 @@ async fn handle_entity_update(
                 }
             }
         }
-        KeyCode::Char('r') => {
+        KeyCode::Char('s') => {
             if entity_type == "mr" {
                 let is_draft = app
                     .mrs
@@ -1093,10 +1100,16 @@ async fn handle_entity_update(
                     .find(|m| m.iid == iid)
                     .map(|m| m.draft)
                     .unwrap_or(false);
-                let action = if is_draft { "--ready" } else { "--draft" };
-                let args = UpdateCmd::new(cli.is_github, entity_type, iid)
-                    .flag_bool(action)
-                    .build();
+                // GitHub uses `gh pr ready <iid>` to mark ready for review;
+                // `gh pr edit --ready` is not a valid flag.
+                let args = if cli.is_github && is_draft {
+                    vec!["pr".to_string(), "ready".to_string(), iid.to_string()]
+                } else {
+                    let action = if is_draft { "--ready" } else { "--draft" };
+                    UpdateCmd::new(cli.is_github, entity_type, iid)
+                        .flag_bool(action)
+                        .build()
+                };
                 run_cli(&cli, &args, terminal, tx.clone(), tab).await;
                 if let Some(item) = app.mrs.items.iter_mut().find(|m| m.iid == iid) {
                     item.draft = !is_draft;
@@ -7137,13 +7150,31 @@ async fn main() -> Result<()> {
                                             )) =>
                                         {
                                             let cli = app_cli(&app);
-                                            let is_draft = mr_title.starts_with("Draft:")
-                                                || mr_title.starts_with("WIP:");
-                                            let action =
-                                                if is_draft { "--ready" } else { "--draft" };
-                                            let args = UpdateCmd::new(cli.is_github, "mr", mr_iid)
-                                                .flag_bool(action)
-                                                .build();
+                                            let is_draft = app
+                                                .mrs
+                                                .items
+                                                .iter()
+                                                .find(|m| m.iid == mr_iid)
+                                                .map(|m| m.draft)
+                                                .unwrap_or_else(|| {
+                                                    mr_title.starts_with("Draft:")
+                                                        || mr_title.starts_with("WIP:")
+                                                });
+                                            // GitHub uses `gh pr ready <iid>` to mark ready;
+                                            // `gh pr edit --ready` is not a valid flag.
+                                            let args = if cli.is_github && is_draft {
+                                                vec![
+                                                    "pr".to_string(),
+                                                    "ready".to_string(),
+                                                    mr_iid.to_string(),
+                                                ]
+                                            } else {
+                                                let action =
+                                                    if is_draft { "--ready" } else { "--draft" };
+                                                UpdateCmd::new(cli.is_github, "mr", mr_iid)
+                                                    .flag_bool(action)
+                                                    .build()
+                                            };
                                             run_cli(
                                                 &cli,
                                                 &args,
@@ -7152,6 +7183,11 @@ async fn main() -> Result<()> {
                                                 app.active_tab,
                                             )
                                             .await;
+                                            if let Some(item) =
+                                                app.mrs.items.iter_mut().find(|m| m.iid == mr_iid)
+                                            {
+                                                item.draft = !is_draft;
+                                            }
                                         }
                                         _ if (key_event.code == KeyCode::Char('c')
                                             || keybinding_matches(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6262,6 +6262,64 @@ pub fn render(f: &mut Frame, app: &mut App) {
         f.render_widget(message_p, chunks[0]);
         f.render_widget(footer_p, chunks[1]);
     }
+
+    if let Some(confirm) = &app.confirm_popup {
+        let (title, message) = match confirm {
+            crate::app::ConfirmAction::DeleteMilestone(iid) => (
+                " Delete Milestone? ",
+                format!("Are you sure you want to delete milestone #{}?", iid),
+            ),
+            crate::app::ConfirmAction::DeleteRelease(tag_name) => (
+                " Delete Release? ",
+                format!("Are you sure you want to delete release {}?", tag_name),
+            ),
+        };
+
+        let block = Block::default()
+            .title(title)
+            .title_style(
+                Style::default()
+                    .fg(THEME.read().unwrap().header_fg)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(THEME.read().unwrap().border_focused))
+            .border_type(BorderType::Double)
+            .style(Style::default().bg(Color::Reset));
+
+        let area = centered_rect_fixed(60, 9, size);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Min(0),    // Message
+                Constraint::Length(2), // Footer
+            ])
+            .split(area);
+
+        let message_p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(message),
+        ])
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(THEME.read().unwrap().text_normal))
+        .wrap(ratatui::widgets::Wrap { trim: true });
+
+        let footer_p = Paragraph::new(" y: Yes (Confirm) • n/Esc: Cancel ")
+            .alignment(Alignment::Center)
+            .style(
+                Style::default()
+                    .fg(THEME.read().unwrap().text_muted)
+                    .add_modifier(Modifier::ITALIC),
+            )
+            .wrap(ratatui::widgets::Wrap { trim: true });
+
+        f.render_widget(Clear, area);
+        f.render_widget(block, area);
+        f.render_widget(message_p, chunks[0]);
+        f.render_widget(footer_p, chunks[1]);
+    }
 }
 
 fn format_comment_with_suggestions(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3372,51 +3372,63 @@ pub fn render(f: &mut Frame, app: &mut App) {
                         let mut text = Vec::new();
                         text.push(Line::from(vec![
                             Span::styled(
-                                "Title:      ",
+                                "Title:       ",
                                 Style::default().fg(THEME.read().unwrap().text_muted),
                             ),
                             Span::styled(
                                 &m.title,
                                 Style::default()
-                                    .fg(THEME.read().unwrap().blue)
+                                    .fg(THEME.read().unwrap().text_normal)
                                     .add_modifier(Modifier::BOLD),
                             ),
                         ]));
                         text.push(Line::from(vec![
                             Span::styled(
-                                "State:      ",
+                                "State:       ",
                                 Style::default().fg(THEME.read().unwrap().text_muted),
                             ),
                             Span::styled(
-                                &m.state,
-                                Style::default().fg(if m.state == "active" {
-                                    THEME.read().unwrap().green
-                                } else {
-                                    THEME.read().unwrap().yellow
-                                }),
+                                m.state.to_uppercase(),
+                                Style::default()
+                                    .fg(if m.state == "active" {
+                                        THEME.read().unwrap().green
+                                    } else {
+                                        THEME.read().unwrap().red
+                                    })
+                                    .add_modifier(Modifier::BOLD),
                             ),
                         ]));
                         text.push(Line::from(vec![
                             Span::styled(
-                                "Start Date: ",
+                                "Start Date:  ",
                                 Style::default().fg(THEME.read().unwrap().text_muted),
                             ),
-                            Span::raw(m.start_date.as_deref().unwrap_or("N/A")),
+                            Span::styled(
+                                m.start_date.as_deref().unwrap_or("N/A"),
+                                Style::default().fg(THEME.read().unwrap().blue),
+                            ),
                         ]));
                         text.push(Line::from(vec![
                             Span::styled(
-                                "Due Date:   ",
+                                "Due Date:    ",
                                 Style::default().fg(THEME.read().unwrap().text_muted),
                             ),
-                            Span::raw(m.due_date.as_deref().unwrap_or("N/A")),
+                            Span::styled(
+                                m.due_date.as_deref().unwrap_or("N/A"),
+                                Style::default().fg(THEME.read().unwrap().yellow),
+                            ),
                         ]));
                         if let Some(desc) = &m.description {
-                            text.push(Line::from(""));
-                            text.push(Line::from(Span::styled(
-                                "Description:",
-                                Style::default().add_modifier(Modifier::BOLD),
-                            )));
-                            text.push(Line::from(desc.as_str()));
+                            if !desc.trim().is_empty() {
+                                text.push(Line::from(""));
+                                text.push(Line::from(Span::styled(
+                                    "Description:",
+                                    Style::default()
+                                        .fg(THEME.read().unwrap().header_fg)
+                                        .add_modifier(Modifier::BOLD),
+                                )));
+                                text.push(Line::from(desc.as_str()));
+                            }
                         }
                         text.push(Line::from(""));
 
@@ -3428,12 +3440,20 @@ pub fn render(f: &mut Frame, app: &mut App) {
                             text.push(Line::from(vec![
                                 Span::styled(
                                     "Issues Status: ",
-                                    Style::default().add_modifier(Modifier::BOLD),
+                                    Style::default()
+                                        .fg(THEME.read().unwrap().header_fg)
+                                        .add_modifier(Modifier::BOLD),
                                 ),
-                                Span::raw(format!(
-                                    "{} Closed / {} Open (Total {})",
-                                    closed, open, total
-                                )),
+                                Span::styled(
+                                    format!("{} Closed", closed),
+                                    Style::default().fg(THEME.read().unwrap().green),
+                                ),
+                                Span::raw(" / "),
+                                Span::styled(
+                                    format!("{} Open", open),
+                                    Style::default().fg(THEME.read().unwrap().yellow),
+                                ),
+                                Span::raw(format!(" (Total {})", total)),
                             ]));
 
                             let pct = if total > 0 {
@@ -3454,7 +3474,10 @@ pub fn render(f: &mut Frame, app: &mut App) {
                             )));
                             text.push(Line::from(""));
                         } else {
-                            text.push(Line::from("Loading issues details..."));
+                            text.push(Line::from(Span::styled(
+                                "Loading issues details...",
+                                Style::default().fg(THEME.read().unwrap().text_muted),
+                            )));
                         }
 
                         f.render_widget(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3300,22 +3300,28 @@ pub fn render(f: &mut Frame, app: &mut App) {
                     },
                 );
 
-                let header_cells = Tab::Milestones
-                    .columns(is_github)
-                    .into_iter()
-                    .filter(|col| app.is_column_visible(Tab::Milestones, col))
-                    .map(|h| Cell::from(h).style(Style::default().add_modifier(Modifier::BOLD)));
-                let header = Row::new(header_cells)
-                    .style(header_style)
-                    .height(1)
-                    .bottom_margin(1);
+                let mut header_cells = Vec::new();
+                let mut widths = Vec::new();
+                let cols = Tab::Milestones.columns(is_github);
+                for col in &cols {
+                    if app.is_column_visible(Tab::Milestones, col) {
+                        header_cells.push(Cell::from(*col));
+                        match *col {
+                            "ID" => widths.push(Constraint::Length(10)),
+                            "Title" => widths.push(Constraint::Fill(1)),
+                            "State" => widths.push(Constraint::Length(12)),
+                            "Start Date" => widths.push(Constraint::Length(15)),
+                            "Due Date" => widths.push(Constraint::Length(15)),
+                            _ => widths.push(Constraint::Length(10)),
+                        }
+                    }
+                }
 
                 let rows = filtered_milestones.iter().enumerate().map(|(idx, m)| {
                     let mut cells = Vec::new();
-                    let cols = Tab::Milestones.columns(is_github);
-                    for col in cols {
-                        if app.is_column_visible(Tab::Milestones, &col) {
-                            let val = match col {
+                    for col in &cols {
+                        if app.is_column_visible(Tab::Milestones, col) {
+                            let val = match *col {
                                 "ID" => m.iid.to_string(),
                                 "Title" => m.title.clone(),
                                 "State" => m.state.clone(),
@@ -3339,19 +3345,15 @@ pub fn render(f: &mut Frame, app: &mut App) {
                     Row::new(cells).style(row_style)
                 });
 
-                let table = Table::new(
-                    rows,
-                    [
-                        Constraint::Percentage(10),
-                        Constraint::Percentage(40),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(30),
-                    ],
-                )
-                .header(header)
-                .block(main_block.clone())
-                .row_highlight_style(highlight_style)
-                .highlight_symbol(" ❯ ");
+                if widths.is_empty() {
+                    widths.push(Constraint::Min(0));
+                }
+
+                let table = Table::new(rows, widths)
+                    .header(Row::new(header_cells).style(header_style).height(1))
+                    .block(main_block.clone())
+                    .row_highlight_style(highlight_style)
+                    .highlight_symbol(" ❯ ");
 
                 f.render_stateful_widget(table, content_area, &mut app.milestones.state);
 
@@ -6298,13 +6300,10 @@ pub fn render(f: &mut Frame, app: &mut App) {
             ])
             .split(area);
 
-        let message_p = Paragraph::new(vec![
-            Line::from(""),
-            Line::from(message),
-        ])
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(THEME.read().unwrap().text_normal))
-        .wrap(ratatui::widgets::Wrap { trim: true });
+        let message_p = Paragraph::new(vec![Line::from(""), Line::from(message)])
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(THEME.read().unwrap().text_normal))
+            .wrap(ratatui::widgets::Wrap { trim: true });
 
         let footer_p = Paragraph::new(" y: Yes (Confirm) • n/Esc: Cancel ")
             .alignment(Alignment::Center)


### PR DESCRIPTION
Closes #96

Now I have full context across all relevant files. Here's the updated issue body with a structured engineering description:

---

### Original Issue
The pipeline/workflow trigger could have some fuzzy searchable fields, such as different pipelines/actions

---

### Engineering Analysis

#### 1. Summary
Currently, the Pipelines and Jobs tab filters (`filter_pipelines_list` and `filter_jobs_list` in `src/app.rs`) use **simple substring matching** (`to_lowercase().contains(&q)`), which returns results as a boolean pass/fail with no relevance ranking. By contrast, the MRs tab uses `SkimMatcherV2` fuzzy matching with score-based sorting (`filter_mrs_list` at `src/app.rs:1669`), providing a much better UX for finding specific items with partial/approximate input. The "Run Pipeline" trigger form (`EditMenu` at `src/main.rs:6824-6846`) also lacks fuzzy autocomplete for fields like Branch/Ref and Workflow/CI File.

The request is to upgrade Pipelines and Jobs filtering to use `SkimMatcherV2` (consistent with MRs), and optionally add fuzzy-autocomplete to the pipeline trigger form fields.

#### 2. Impact on Current TUI Layers

| Layer | Impact |
|-------|--------|
| **App State** (`src/app.rs`) | `filter_pipelines_list()` and `filter_jobs_list()` need score-based fuzzy matching; the `Selector`'s `get_filtered_items_with_indices()` also uses substring filtering that could be upgraded for trigger field autocomplete. |
| **Event Loop** (`src/main.rs`) | No new events needed; filter functions are called synchronously from `filtered_pipelines()` / `filtered_jobs()` which are invoked during render. |
| **UI Rendering** (`src/ui.rs`) | Already uses `render_fuzzy_cell` with `SkimMatcherV2` for highlight positions; no rendering changes needed for pipeline/job lists, but the trigger form (EditMenu) may need a fuzzy-selector overlay for branch/workflow fields. |
| **Config** (`src/config.rs`) | No config changes needed unless we add a keybinding for toggling fuzzy autocomplete on form fields. |

#### 3. Implementation Plan

**A. Upgrade `filter_pipelines_list()` — `src/app.rs:1873`**
Convert from substring to `SkimMatcherV2` fuzzy match + score-based ranking, mirroring `filter_mrs_list()` at line 1669. Return scored items sorted descending. The `Pipeline` struct already has all relevant fields (id, status, ref), and pipeline jobs are passed for Stage column searches.

**B. Upgrade `filter_jobs_list()` — `src/app.rs:1974`**
Same conversion for the Jobs tab. The `Job` struct has id, stage, status, name, matrix.

**C. Upgrade `Selector::get_filtered_items_with_indices()` — `src/app.rs:250`**
Convert from substring to `SkimMatcherV2` so that the trigger form's field selectors (e.g. branch name, workflow file) get fuzzy autocomplete.

**D. (Optional) Branch/Workflow autocomplete in trigger form**
Add a step in the "Run Pipeline" flow (`src/main.rs:6824-6846`) that, when the "Branch / Ref" or "Workflow / CI File" field is selected, opens a `Selector` populated from `git branch --list` or a cached list rather than raw text input.

#### 4. Design/UX Acceptance Criteria

- [ ] Typing `main` or `mian` into the pipeline search box matches pipelines with `main` ref (fuzzy, not exact)
- [ ] Pipeline results are sorted by fuzzy-match score (best match first)
- [ ] Typing `fail` matches pipelines whose status is `failed` _or_ pipeline jobs named `build` with status `failed`
- [ ] Jobs tab filtering behaves identically with fuzzy scoring
- [ ] The "Run Pipeline" form's Branch/Ref field shows a fuzzy-searchable dropdown of remote branches when focused
- [ ] Visual fuzzy highlighting (yellow matched chars via `render_fuzzy_cell`) already works with the SkimMatcherV2 indices
- [ ] Existing column filters, group-by, and column visibility continue to compose correctly with the new scoring
- [ ] No regressions in Issues tab (which also uses substring but is out of scope here)

**Suggested Labels:** `enhancement`, `ux`, `tabs/pipelines`, `tabs/jobs`  
**Suggested Milestone:** `v0.2.0`

<a href="https://opencode.ai/s/lxIJWyoL"><img width="200" alt="New%20session%20-%202026-07-03T17%3A46%3A08.276Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTAzVDE3OjQ2OjA4LjI3Nlo=.png?model=opencode/big-pickle&version=1.17.13&id=lxIJWyoL" /></a>
[opencode session](https://opencode.ai/s/lxIJWyoL)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/rcieri/glab-tui/actions/runs/28675850413)