### PR TITLE
feature(edit): create/edit full attribute milestones/releases

### DIFF
--- a/src/gitlab/client.rs
+++ b/src/gitlab/client.rs
@@ -833,7 +833,8 @@ fn translate_release(v: &serde_json::Value) -> serde_json::Value {
         .unwrap_or_else(|| tag_name.clone());
     let released_at = v
         .get("published_at")
-        .cloned()
+        .and_then(|v| v.as_str())
+        .map(|s| serde_json::Value::String(s.chars().take(10).collect()))
         .unwrap_or(serde_json::Value::Null);
     let description = v.get("body").cloned().unwrap_or(serde_json::Value::Null);
     let author_name = v
@@ -1028,9 +1029,7 @@ fn translate_json_to_gitlab(endpoint: &str, val: serde_json::Value) -> Result<se
                     let due_on = m
                         .get("due_on")
                         .and_then(|v| v.as_str())
-                        .map(|s| {
-                            serde_json::Value::String(s.chars().take(10).collect())
-                        })
+                        .map(|s| serde_json::Value::String(s.chars().take(10).collect()))
                         .unwrap_or(serde_json::Value::Null);
                     let created_at = m
                         .get("created_at")

--- a/src/gitlab/client.rs
+++ b/src/gitlab/client.rs
@@ -1025,7 +1025,13 @@ fn translate_json_to_gitlab(endpoint: &str, val: serde_json::Value) -> Result<se
                         .unwrap_or(serde_json::Value::Null);
                     let state = m.get("state").and_then(|s| s.as_str()).unwrap_or("open");
                     let gl_state = if state == "open" { "active" } else { "closed" };
-                    let due_on = m.get("due_on").cloned().unwrap_or(serde_json::Value::Null);
+                    let due_on = m
+                        .get("due_on")
+                        .and_then(|v| v.as_str())
+                        .map(|s| {
+                            serde_json::Value::String(s.chars().take(10).collect())
+                        })
+                        .unwrap_or(serde_json::Value::Null);
                     let created_at = m
                         .get("created_at")
                         .cloned()

--- a/src/gitlab/releases.rs
+++ b/src/gitlab/releases.rs
@@ -54,7 +54,7 @@ pub async fn update_release(
         let out = tokio::process::Command::new("glab")
             .args([
                 "release",
-                "create",
+                "update",
                 tag_name,
                 "-R",
                 &encoded_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,6 +359,106 @@ async fn apply_field_text_change(
     tx: tokio::sync::mpsc::UnboundedSender<Event>,
     tab: crate::app::Tab,
 ) {
+    // Milestones and releases use dedicated update functions, not UpdateCmd
+    if entity_type == "milestone" {
+        if let Some(item) = app.milestones.items.iter_mut().find(|m| m.iid == iid) {
+            match field_type {
+                "title" => item.title = value.clone(),
+                "start_date" => item.start_date = Some(value.clone()),
+                "due_date" => item.due_date = Some(value.clone()),
+                "description" => item.description = Some(value.clone()),
+                _ => {}
+            }
+        }
+        let milestone_opt = app.milestones.items.iter().find(|m| m.iid == iid).cloned();
+        if let Some(milestone) = milestone_opt {
+            let mut title = milestone.title.clone();
+            let mut start_date = milestone.start_date.clone();
+            let mut due_date = milestone.due_date.clone();
+            let mut description = milestone.description.clone().unwrap_or_default();
+
+            match field_type {
+                "title" => title = value.clone(),
+                "start_date" => start_date = Some(value.clone()),
+                "due_date" => due_date = Some(value.clone()),
+                "description" => description = value.clone(),
+                _ => {}
+            }
+
+            let client = app.gitlab_client.clone().unwrap();
+            let project_path = app.project_context.clone();
+            let tx_spawn = tx.clone();
+            let _ = tx.send(Event::CommandStarted(format!("Updating milestone #{}", iid)));
+            tokio::spawn(async move {
+                let res = crate::gitlab::milestones::update_milestone(
+                    &client,
+                    &project_path,
+                    iid,
+                    &title,
+                    &description,
+                    start_date.as_deref(),
+                    due_date.as_deref(),
+                )
+                .await;
+                match res {
+                    Ok(_) => {
+                        let _ = tx_spawn.send(Event::MilestoneUpdated);
+                    }
+                    Err(e) => {
+                        let _ = tx_spawn.send(Event::CommandCompleted(
+                            crate::app::Tab::Milestones,
+                            Err(e.to_string()),
+                        ));
+                    }
+                }
+            });
+        }
+        return;
+    }
+
+    if entity_type == "release" {
+        let release_opt = app.releases.items.get(iid as usize).cloned();
+        if let Some(release) = release_opt {
+            let mut name = release.name.clone();
+            let mut tag = release.tag_name.clone();
+            let mut description = release.description.clone().unwrap_or_default();
+
+            match field_type {
+                "title" | "release_name" => name = value.clone(),
+                "tag" => tag = value.clone(),
+                "description" => description = value.clone(),
+                _ => {}
+            }
+
+            let client = app.gitlab_client.clone().unwrap();
+            let project_path = app.project_context.clone();
+            let tx_spawn = tx.clone();
+            let _ = tx.send(Event::CommandStarted(format!("Updating release {}", tag)));
+            tokio::spawn(async move {
+                let res = crate::gitlab::releases::update_release(
+                    &client,
+                    &project_path,
+                    &tag,
+                    &name,
+                    &description,
+                )
+                .await;
+                match res {
+                    Ok(_) => {
+                        let _ = tx_spawn.send(Event::ReleaseUpdated);
+                    }
+                    Err(e) => {
+                        let _ = tx_spawn.send(Event::CommandCompleted(
+                            crate::app::Tab::Releases,
+                            Err(e.to_string()),
+                        ));
+                    }
+                }
+            });
+        }
+        return;
+    }
+
     let cli = app_cli(app);
     match field_type {
         "title" => {
@@ -444,56 +544,7 @@ async fn apply_field_text_change(
                 }
             }
         }
-        _ => {
-            if entity_type == "milestone" {
-                let milestone_opt = app.milestones.items.iter().find(|m| m.iid == iid).cloned();
-                if let Some(milestone) = milestone_opt {
-                    let mut title = milestone.title.clone();
-                    let mut start_date = milestone.start_date.clone();
-                    let mut due_date = milestone.due_date.clone();
-                    let mut description = milestone.description.clone().unwrap_or_default();
-
-                    match field_type {
-                        "title" => title = value.clone(),
-                        "start_date" => start_date = Some(value.clone()),
-                        "due_date" => due_date = Some(value.clone()),
-                        "description" => description = value.clone(),
-                        _ => {}
-                    }
-
-                    let client = app.gitlab_client.clone().unwrap();
-                    let project_path = app.project_context.clone();
-                    let tx_spawn = tx.clone();
-                    let _ = tx.send(Event::CommandStarted(format!(
-                        "Updating milestone #{}",
-                        iid
-                    )));
-                    tokio::spawn(async move {
-                        let res = crate::gitlab::milestones::update_milestone(
-                            &client,
-                            &project_path,
-                            iid,
-                            &title,
-                            &description,
-                            start_date.as_deref(),
-                            due_date.as_deref(),
-                        )
-                        .await;
-                        match res {
-                            Ok(_) => {
-                                let _ = tx_spawn.send(Event::MilestoneUpdated);
-                            }
-                            Err(e) => {
-                                let _ = tx_spawn.send(Event::CommandCompleted(
-                                    crate::app::Tab::Milestones,
-                                    Err(e.to_string()),
-                                ));
-                            }
-                        }
-                    });
-                }
-            }
-        }
+        _ => {}
     }
 }
 
@@ -2128,6 +2179,68 @@ async fn main() -> Result<()> {
                         app.selected_milestone_issues = Some(issues);
                     }
                 }
+                Event::MilestoneUpdated | Event::MilestoneClosed | Event::MilestoneReopened => {
+                    app.complete_loading_tab(app::Tab::Milestones, "Success");
+                    app.status_message = None;
+                    if let Some(client) = app.gitlab_client.clone() {
+                        if !app.loading_tabs.contains(&app::Tab::Milestones) {
+                            app.start_loading_tab(app::Tab::Milestones);
+                        }
+                        spawn_refresh_active_tab(
+                            &client,
+                            &app.project_context,
+                            app::Tab::Milestones,
+                            events.sender(),
+                        );
+                    }
+                }
+                Event::MilestoneDeleted => {
+                    app.complete_loading_tab(app::Tab::Milestones, "Success");
+                    app.status_message = None;
+                    app.milestones.items.clear();
+                    if let Some(client) = app.gitlab_client.clone() {
+                        if !app.loading_tabs.contains(&app::Tab::Milestones) {
+                            app.start_loading_tab(app::Tab::Milestones);
+                        }
+                        spawn_refresh_active_tab(
+                            &client,
+                            &app.project_context,
+                            app::Tab::Milestones,
+                            events.sender(),
+                        );
+                    }
+                }
+                Event::ReleaseUpdated => {
+                    app.complete_loading_tab(app::Tab::Releases, "Success");
+                    app.status_message = None;
+                    if let Some(client) = app.gitlab_client.clone() {
+                        if !app.loading_tabs.contains(&app::Tab::Releases) {
+                            app.start_loading_tab(app::Tab::Releases);
+                        }
+                        spawn_refresh_active_tab(
+                            &client,
+                            &app.project_context,
+                            app::Tab::Releases,
+                            events.sender(),
+                        );
+                    }
+                }
+                Event::ReleaseDeleted => {
+                    app.complete_loading_tab(app::Tab::Releases, "Success");
+                    app.status_message = None;
+                    app.releases.items.clear();
+                    if let Some(client) = app.gitlab_client.clone() {
+                        if !app.loading_tabs.contains(&app::Tab::Releases) {
+                            app.start_loading_tab(app::Tab::Releases);
+                        }
+                        spawn_refresh_active_tab(
+                            &client,
+                            &app.project_context,
+                            app::Tab::Releases,
+                            events.sender(),
+                        );
+                    }
+                }
                 Event::SelectorItemsFetched(items) => {
                     if let Some(mut selector) = app.selector.take() {
                         selector.all_items = items;
@@ -2365,6 +2478,77 @@ async fn main() -> Result<()> {
                                 app.show_submit_review_prompt = None;
                             }
                             _ => {}
+                        }
+                        continue;
+                    }
+
+                    if let Some(confirm_action) = app.confirm_popup.take() {
+                        match key_event.code {
+                            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                                match confirm_action {
+                                    crate::app::ConfirmAction::DeleteMilestone(iid) => {
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project_path = app.project_context.clone();
+                                        let tx = events.sender();
+                                        let _ = tx.send(Event::CommandStarted(format!(
+                                            "Deleting milestone #{}",
+                                            iid
+                                        )));
+                                        tokio::spawn(async move {
+                                            let res = crate::gitlab::milestones::delete_milestone(
+                                                &client,
+                                                &project_path,
+                                                iid,
+                                            )
+                                            .await;
+                                            match res {
+                                                Ok(_) => {
+                                                    let _ = tx.send(Event::MilestoneDeleted);
+                                                }
+                                                Err(e) => {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        crate::app::Tab::Milestones,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                }
+                                            }
+                                        });
+                                    }
+                                    crate::app::ConfirmAction::DeleteRelease(tag_name) => {
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project_path = app.project_context.clone();
+                                        let tx = events.sender();
+                                        let _ = tx.send(Event::CommandStarted(format!(
+                                            "Deleting release {}",
+                                            tag_name
+                                        )));
+                                        tokio::spawn(async move {
+                                            let res = crate::gitlab::releases::delete_release(
+                                                &client,
+                                                &project_path,
+                                                &tag_name,
+                                            )
+                                            .await;
+                                            match res {
+                                                Ok(_) => {
+                                                    let _ = tx.send(Event::ReleaseDeleted);
+                                                }
+                                                Err(e) => {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        crate::app::Tab::Releases,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                }
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+                            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {}
+                            _ => {
+                                app.confirm_popup = Some(confirm_action);
+                                continue;
+                            }
                         }
                         continue;
                     }
@@ -4584,6 +4768,13 @@ async fn main() -> Result<()> {
                                                     .get(entity_iid as usize)
                                                     .and_then(|r| r.description.clone())
                                                     .unwrap_or_default()
+                                            } else if entity_type == "milestone" {
+                                                app.milestones
+                                                    .items
+                                                    .iter()
+                                                    .find(|m| m.iid == entity_iid)
+                                                    .and_then(|m| m.description.clone())
+                                                    .unwrap_or_default()
                                             } else {
                                                 app.mrs
                                                     .items
@@ -4661,6 +4852,52 @@ async fn main() -> Result<()> {
                                                             app.active_tab,
                                                         )
                                                         .await;
+                                                    } else if entity_type == "milestone" {
+                                                        if let Some(item) = app
+                                                            .milestones
+                                                            .items
+                                                            .iter_mut()
+                                                            .find(|m| m.iid == entity_iid)
+                                                        {
+                                                            item.description =
+                                                                Some(new_desc.clone());
+                                                        }
+                                                        let client =
+                                                            app.gitlab_client.clone().unwrap();
+                                                        let project_path =
+                                                            app.project_context.clone();
+                                                        let tx_spawn = events.sender();
+                                                        let _ = tx_spawn.send(
+                                                            Event::CommandStarted(format!(
+                                                                "Updating milestone #{}",
+                                                                entity_iid
+                                                            )),
+                                                        );
+                                                        tokio::spawn(async move {
+                                                            let res = crate::gitlab::milestones::update_milestone(
+                                                                &client,
+                                                                &project_path,
+                                                                entity_iid,
+                                                                "",
+                                                                &new_desc,
+                                                                None,
+                                                                None,
+                                                            )
+                                                            .await;
+                                                            match res {
+                                                                Ok(_) => {
+                                                                    let _ = tx_spawn.send(
+                                                                        Event::MilestoneUpdated,
+                                                                    );
+                                                                }
+                                                                Err(e) => {
+                                                                    let _ = tx_spawn.send(Event::CommandCompleted(
+                                                                        crate::app::Tab::Milestones,
+                                                                        Err(e.to_string()),
+                                                                    ));
+                                                                }
+                                                            }
+                                                        });
                                                     } else if entity_type == "release" {
                                                         let release_opt = app
                                                             .releases

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,10 @@ async fn apply_field_text_change(
             let client = app.gitlab_client.clone().unwrap();
             let project_path = app.project_context.clone();
             let tx_spawn = tx.clone();
-            let _ = tx.send(Event::CommandStarted(format!("Updating milestone #{}", iid)));
+            let _ = tx.send(Event::CommandStarted(format!(
+                "Updating milestone #{}",
+                iid
+            )));
             tokio::spawn(async move {
                 let res = crate::gitlab::milestones::update_milestone(
                     &client,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2885,7 +2885,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                 }
                 if app.is_column_visible(Tab::Releases, "Date") {
                     header_cells.push(Cell::from("Date"));
-                    widths.push(Constraint::Length(12));
+                    widths.push(Constraint::Length(15));
                 }
                 if app.is_column_visible(Tab::Releases, "Author") {
                     header_cells.push(Cell::from("Author"));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -411,7 +411,7 @@ fn build_log_line(cmd: &crate::app::TerminalCommand, width: usize) -> Line<'stat
         if cmd_clean.starts_with("glab") || cmd_clean.starts_with("gh") {
             "RUNNING COMMAND".to_string()
         } else {
-            "SYSTEM LOG".to_string()
+            "RUNNING COMMAND".to_string()
         }
     } else {
         desc.to_uppercase()


### PR DESCRIPTION
Closes #86

## Summary

Currently, Milestones and Releases in `glab-tui` support **viewing and basic creation** but lack full CRUD editing capabilities. This ticket tracks adding comprehensive create/edit/delete functionality for both entities, bringing them on par with the existing Issue editing experience.

---

## Current State

### Milestones
- **List/View**: Full table with columns (ID, Title, State, Start Date, Due Date), detail preview pane, auto-loads milestone issues with progress bar
- **Create**: Basic single-field `TextInput` → inline CLI call (`gh api`/`glab api`)
- **Edit**: ❌ Not supported
- **Close/Reopen/Delete**: ❌ Not supported
- **Open in Browser**: ❌ Not supported
- **Group-by**: ❌ `rebuild_group_map()` falls through to `_ => return` for Milestones

### Releases
- **List/View**: Full table with columns (Tag, Release Name, Date, Description, Author, Assets), detail preview pane
- **Create**: Changelog generation + inline CLI call (`gh release create`/`glab release create`)
- **Edit**: ❌ Not supported
- **Delete**: ❌ Not supported
- **Open in Browser**: ✅ Supported
- **Group-by**: ❌ `rebuild_group_map()` falls through to `_ => return` for Releases

---

## Required Changes

### 1. Milestones — Full CRUD

- **Edit**: Implement `EditMenu`-based editing (like Issues) with fields: Title, Description, Start Date, Due Date, State (closed/active).
  - Add `update_milestone()` to `src/gitlab/milestones.rs`
  - Wire to a keybinding (default `e`) in `Tab::Milestones`
- **Close/Reopen**: Add keybinding (default `c`/`r`) and CLI calls:
  - `gh api -X PATCH repos/{owner}/{repo}/milestones/{number} -f state=closed`
  - `glab api -X PUT /projects/{encoded}/milestones/{iid} -f state_event=close`
- **Delete**: Add keybinding + confirmation + CLI call:
  - `gh api -X DELETE repos/{owner}/{repo}/milestones/{number}`
  - `glab api -X DELETE /projects/{encoded}/milestones/{iid}`
- **Open in Browser**: Add keybinding + CLI call:
  - `gh milestone view {iid} --web` / `glab milestone view {iid} --web`
- **Keybindings**: Extract `KeybindingMilestones` from `KeybindingReleases` (currently `create_milestone` lives inside `KeybindingReleases`).

### 2. Releases — Full CRUD

- **Edit**: Add keybinding (default `e`) with fields: Release Name, Tag Name, Description.
  - Add `update_release()` to `src/gitlab/releases.rs`
  - `gh release edit {tag} --notes "..."` / `glab release edit {tag} --notes "..."`
- **Delete**: Add keybinding + confirmation + CLI call:
  - `gh release delete {tag}` / `glab release delete {tag}`
- **Group-by**: Add support in `rebuild_group_map()` for `Tab::Releases` (group by date, author).

### 3. Shared / Cross-Cutting

- **Events**: Add `MilestoneUpdated`, `MilestoneClosed`, `MilestoneReopened`, `MilestoneDeleted`, `ReleaseUpdated`, `ReleaseDeleted` to `Event` enum.
- **Cache**: Invalidate/resync cache after mutating operations.
- **Error handling**: Display errors via `app.error_message` (standard pattern).
- **EditMenu integration**: Support `DatePicker` for Start Date / Due Date fields in milestone editing.

---

## Implementation References

- **Issue editing pattern**: See `Tab::Issues` keybinding handlers in `src/main.rs` (lines 6230–6419) for `EditMenu` workflow, close/reopen pattern.
- **Create milestone pattern**: See `TextInputAction::CreateMilestone` in `src/main.rs` (lines 2665–2769).
- **Create release pattern**: See `TextInputAction::CreateRelease` in `src/main.rs` (lines 2498–2662).
- **DatePicker**: Already exists in `src/app.rs` for due date editing.

---

## Files to Modify

| File | Changes |
|------|---------|
| `src/gitlab/milestones.rs` | Add `update_milestone`, `close_milestone`, `reopen_milestone`, `delete_milestone` |
| `src/gitlab/releases.rs` | Add `update_release`, `delete_release` |
| `src/event.rs` | Add new event variants |
| `src/app.rs` | Update `TextInputAction` / `EditMenu` for entity types, add group-by support |
| `src/main.rs` | Add keybinding handlers, event handlers, data fetching |
| `src/ui.rs` | Add help text, update detail panes if needed |
| `src/config.rs` | Add `KeybindingMilestones`, update defaults |

---

## Acceptance Criteria

- [ ] Milestones can be created via `EditMenu` with full attributes (title, description, start/due dates)
- [ ] Milestones can be edited (title, description, dates)
- [ ] Milestones can be closed/reopened
- [ ] Milestones can be deleted with confirmation
- [ ] Milestones can be opened in browser
- [ ] Releases can be edited (name, description)
- [ ] Releases can be deleted with confirmation
- [ ] Releases support group-by
- [ ] Milestones support group-by
- [ ] All operations show success/failure feedback in the UI
- [ ] Keybindings are configurable via `config.toml`
- [ ] Cache is properly invalidated after mutations