### PR TITLE
enhancement(prs): add pipeline status to pr/mr pane

### DIFF
--- a/.glab-tui/config.toml
+++ b/.glab-tui/config.toml
@@ -1,5 +1,5 @@
 active_tab = "issues"
-page_size = 1000
+page_size = 100
 theme_preset = "default"
 
 [branches]
@@ -48,9 +48,14 @@ columns = [
     "State",
     "Title",
 ]
+group_by_column = "Due Date"
+
+[milestones.column_filters]
+State = ["active"]
 
 [mrs]
 columns = [
+    "Action",
     "ID",
     "Labels",
     "State",

--- a/src/app.rs
+++ b/src/app.rs
@@ -201,6 +201,7 @@ impl Tab {
                 "Assignees",
                 "Reviewers",
                 "Labels",
+                "Pipeline",
                 "Milestone",
                 "Author",
             ],

--- a/src/app.rs
+++ b/src/app.rs
@@ -171,7 +171,13 @@ impl Tab {
                     "MRs"
                 }
             }
-            Tab::Pipelines => "Pipelines",
+            Tab::Pipelines => {
+                if is_github {
+                    "Actions"
+                } else {
+                    "Pipelines"
+                }
+            }
             Tab::Jobs => "Jobs",
             Tab::Runners => "Runners",
             Tab::Releases => "Releases",
@@ -193,18 +199,25 @@ impl Tab {
                 cols.push("Author");
                 cols
             }
-            Tab::MergeRequests => vec![
-                "ID",
-                "State",
-                "Status",
-                "Title",
-                "Assignees",
-                "Reviewers",
-                "Labels",
-                "Pipeline",
-                "Milestone",
-                "Author",
-            ],
+            Tab::MergeRequests => {
+                let mut cols = vec![
+                    "ID",
+                    "State",
+                    "Status",
+                    "Title",
+                    "Assignees",
+                    "Reviewers",
+                    "Labels",
+                ];
+                if is_github {
+                    cols.push("Action");
+                } else {
+                    cols.push("Pipeline");
+                }
+                cols.push("Milestone");
+                cols.push("Author");
+                cols
+            }
             Tab::Pipelines => vec!["ID", "Status", "Stages", "Ref"],
             Tab::Jobs => vec!["ID", "Stage", "Status", "Name", "Matrix"],
             Tab::Runners => vec!["ID", "Description", "Status", "Active"],

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,6 +260,8 @@ pub struct KeybindingGlobal {
     #[serde(default)]
     pub search: String,
     #[serde(default)]
+    pub global_search: String,
+    #[serde(default)]
     pub refresh: String,
     #[serde(default)]
     pub configure: String,
@@ -439,6 +441,7 @@ keybind_defaults! {
     def_quit = "q",
     def_help = "?",
     def_search = "/",
+    def_global_search = "Ctrl+p",
     def_refresh = "Ctrl+r",
     def_configure = "Tab",
     def_next_tab = "l",
@@ -493,6 +496,7 @@ impl Default for KeybindingGlobal {
             quit: def_quit(),
             help: def_help(),
             search: def_search(),
+            global_search: def_global_search(),
             refresh: def_refresh(),
             configure: def_configure(),
             next_tab: def_next_tab(),
@@ -757,6 +761,7 @@ page_size = 100
 quit = "q"
 help = "?"
 search = "/"
+global_search = "Ctrl+p"
 refresh = "Ctrl+r"
 configure = "Tab"
 next_tab = "l"

--- a/src/gitlab/client.rs
+++ b/src/gitlab/client.rs
@@ -482,6 +482,32 @@ impl GitlabClient {
         }
     }
 
+    pub async fn fetch_branches(&self, project_path: &str) -> Result<Vec<String>> {
+        if self.is_github {
+            #[derive(serde::Deserialize)]
+            struct GithubBranch {
+                name: String,
+            }
+            let endpoint = format!("/repos/{}/branches?per_page=100", project_path);
+            let raw = self.execute_github_api(&endpoint, "GET", None).await?;
+            let branches: Vec<GithubBranch> = serde_json::from_str(&raw)?;
+            Ok(branches.into_iter().map(|b| b.name).collect())
+        } else {
+            #[derive(serde::Deserialize)]
+            struct GitlabBranch {
+                name: String,
+            }
+            let encoded_path = project_path.replace("/", "%2F");
+            let endpoint = format!(
+                "/projects/{}/repository/branches?per_page=100",
+                encoded_path
+            );
+            let raw = self.execute_gitlab_api(&endpoint, "GET", None).await?;
+            let branches: Vec<GitlabBranch> = serde_json::from_str(&raw)?;
+            Ok(branches.into_iter().map(|b| b.name).collect())
+        }
+    }
+
     pub async fn fetch_milestones(&self, project_path: &str) -> Result<Vec<String>> {
         if self.is_github {
             #[derive(serde::Deserialize)]

--- a/src/gitlab/mr.rs
+++ b/src/gitlab/mr.rs
@@ -42,6 +42,8 @@ pub struct MergeRequest {
     pub source_branch: String,
     pub draft: bool,
     pub description: Option<String>,
+    #[serde(default)]
+    pub head_pipeline: Option<super::pipelines::Pipeline>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -63,6 +65,8 @@ pub struct GitlabMergeRequest {
     pub source_branch: String,
     pub draft: bool,
     pub description: Option<String>,
+    #[serde(default)]
+    pub head_pipeline: Option<super::pipelines::GitlabPipeline>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -106,6 +110,7 @@ impl From<GitlabMergeRequest> for MergeRequest {
             source_branch: gl.source_branch,
             draft: gl.draft,
             description: gl.description,
+            head_pipeline: gl.head_pipeline.map(|p| p.into()),
         }
     }
 }
@@ -153,6 +158,7 @@ impl From<GithubPullRequest> for MergeRequest {
             source_branch,
             draft,
             description: gh.body,
+            head_pipeline: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2273,6 +2273,55 @@ async fn main() -> Result<()> {
                                 }
                                 KeyCode::Enter => {
                                     let field_type = selector.field_type.clone();
+                                    if field_type == "global_search" {
+                                        let filtered_items = selector.get_filtered_items();
+                                        let selected_val = if !selector.selected_items.is_empty() {
+                                            selector.selected_items.iter().next().cloned()
+                                        } else if !filtered_items.is_empty() {
+                                            Some(filtered_items[selector.cursor_idx].clone())
+                                        } else {
+                                            None
+                                        };
+                                        if let Some(val) = selected_val {
+                                            if val.starts_with("Issue #") {
+                                                if let Some(iid_str) = val
+                                                    .strip_prefix("Issue #")
+                                                    .and_then(|s| s.split(':').next())
+                                                {
+                                                    if let Ok(iid) = iid_str.parse::<u64>() {
+                                                        app.active_tab = crate::app::Tab::Issues;
+                                                        if let Some(idx) = app
+                                                            .issues
+                                                            .items
+                                                            .iter()
+                                                            .position(|i| i.iid == iid)
+                                                        {
+                                                            app.issues.state.select(Some(idx));
+                                                        }
+                                                    }
+                                                }
+                                            } else if val.starts_with("MR !") {
+                                                if let Some(iid_str) = val
+                                                    .strip_prefix("MR !")
+                                                    .and_then(|s| s.split(':').next())
+                                                {
+                                                    if let Ok(iid) = iid_str.parse::<u64>() {
+                                                        app.active_tab =
+                                                            crate::app::Tab::MergeRequests;
+                                                        if let Some(idx) = app
+                                                            .mrs
+                                                            .items
+                                                            .iter()
+                                                            .position(|m| m.iid == iid)
+                                                        {
+                                                            app.mrs.state.select(Some(idx));
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        continue;
+                                    }
                                     if field_type == "column_filter" {
                                         if let Some((tab, col)) = app.column_filter_context.take() {
                                             app.set_column_filter(
@@ -4264,11 +4313,9 @@ async fn main() -> Result<()> {
                                     } else if field_type == "source_branch"
                                         || field_type == "target_branch"
                                     {
-                                        all_items = get_branches();
-                                        is_loading = false;
+                                        is_loading = true;
                                     } else if field_type == "pipeline_branch" {
-                                        all_items = get_branches();
-                                        is_loading = false;
+                                        is_loading = true;
                                         // Pre-select the current branch value
                                         let current_val = menu.fields[menu.selected_idx].1.clone();
                                         if !current_val.is_empty() {
@@ -4413,6 +4460,12 @@ async fn main() -> Result<()> {
                                                     "milestone" => {
                                                         client
                                                             .fetch_milestones(&project_context)
+                                                            .await
+                                                    }
+                                                    "source_branch" | "target_branch"
+                                                    | "pipeline_branch" => {
+                                                        client
+                                                            .fetch_branches(&project_context)
                                                             .await
                                                     }
                                                     _ => Ok(Vec::new()),
@@ -4602,10 +4655,8 @@ async fn main() -> Result<()> {
 
                                 if field_name == "Title"
                                     || field_name == "Weight"
-                                    || field_name == "Branch / Ref"
                                     || field_name == "Variables"
                                     || field_name == "Inputs"
-                                    || field_name == "Workflow / CI File (GitHub)"
                                     || field_name == "Release Name"
                                     || field_name == "Tag"
                                 {
@@ -5648,6 +5699,42 @@ async fn main() -> Result<()> {
                         && !app.focus_column_checklist
                     {
                         app.is_typing_search = true;
+                        continue;
+                    }
+
+                    if keybinding_matches(&app.config.keybindings.global.global_search, &key_event)
+                        && !app.is_typing_search
+                        && app.text_input.is_none()
+                        && app.edit_menu.is_none()
+                        && app.selector.is_none()
+                        && !app.focus_column_checklist
+                    {
+                        let mut items = Vec::new();
+                        for issue in &app.issues.items {
+                            items.push(format!("Issue #{}: {}", issue.iid, issue.title));
+                        }
+                        for mr in &app.mrs.items {
+                            items.push(format!("MR !{}: {}", mr.iid, mr.title));
+                        }
+
+                        app.selector = Some(crate::app::Selector {
+                            title: " Global Search ".to_string(),
+                            all_items: items,
+                            selected_items: std::collections::HashSet::new(),
+                            cursor_idx: 0,
+                            search_query: String::new(),
+                            is_filtering: true,
+                            is_loading: false,
+                            entity_iid: 0,
+                            entity_type: "global_search".to_string(),
+                            field_type: "global_search".to_string(),
+                            multi_select: false,
+                            state: {
+                                let mut s = ratatui::widgets::ListState::default();
+                                s.select(Some(0));
+                                s
+                            },
+                        });
                         continue;
                     }
 

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -368,7 +368,11 @@ fn add_cmd(text: &mut Vec<Line<'static>>, key: &str, desc: &str) {
     ]));
 }
 
-pub(crate) fn build_log_line(cmd: &crate::app::TerminalCommand, width: usize) -> Line<'static> {
+pub(crate) fn build_log_line(
+    cmd: &crate::app::TerminalCommand,
+    width: usize,
+    is_github: bool,
+) -> Line<'static> {
     let time_str = if cmd.timestamp.len() >= 8 {
         let parts: Vec<&str> = cmd.timestamp.split('T').collect();
         if parts.len() > 1 {
@@ -470,8 +474,8 @@ pub(crate) fn build_log_line(cmd: &crate::app::TerminalCommand, width: usize) ->
                 } else if p.contains("job") {
                     target = "JOB";
                     break;
-                } else if p.contains("pipeline") {
-                    target = "PIPELINE";
+                } else if p.contains("pipeline") || p.contains("actions/runs") {
+                    target = if is_github { "ACTIONS" } else { "PIPELINES" };
                     break;
                 } else if p.contains("commit") {
                     target = "COMMIT";

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -350,7 +350,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
 
             for i in start_idx..num_cmds {
                 if let Some(cmd) = app.terminal_commands.get(i) {
-                    log_lines.push(build_log_line(cmd, bottom_inner.width as usize));
+                    log_lines.push(build_log_line(cmd, bottom_inner.width as usize, is_github));
                 }
             }
 

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -678,6 +678,77 @@ pub(crate) fn render_tab_merge_requests(
                     24,
                 ));
             }
+            if app.is_column_visible(Tab::MergeRequests, "Pipeline") {
+                if let Some(pipe) = &m.head_pipeline {
+                    let (pipe_text, pipe_color, pipe_bg) = match pipe.status.as_str() {
+                        "success" => (
+                            "SUCCESS",
+                            THEME.read().unwrap().green,
+                            THEME.read().unwrap().green_bg,
+                        ),
+                        "failed" => (
+                            "FAILED",
+                            THEME.read().unwrap().red,
+                            THEME.read().unwrap().red_bg,
+                        ),
+                        "running" => (
+                            "RUNNING",
+                            THEME.read().unwrap().blue,
+                            THEME.read().unwrap().blue_bg,
+                        ),
+                        "canceled" => (
+                            "CANCEL",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                        "pending" => (
+                            "PENDING",
+                            THEME.read().unwrap().yellow,
+                            THEME.read().unwrap().yellow_bg,
+                        ),
+                        "skipped" => (
+                            "SKIP",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                        "manual" => (
+                            "MANUAL",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                        _ => (
+                            "UNKNOWN",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                    };
+                    let bg = if is_selected {
+                        THEME.read().unwrap().highlight_bg
+                    } else {
+                        pipe_bg
+                    };
+                    cells.push(super::helpers::render_fuzzy_cell(
+                        pipe_text,
+                        &app.search_query,
+                        is_selected,
+                        false,
+                        Style::default()
+                            .fg(pipe_color)
+                            .bg(bg)
+                            .add_modifier(Modifier::BOLD),
+                        Alignment::Center,
+                    ));
+                } else {
+                    cells.push(super::helpers::render_fuzzy_cell(
+                        "—",
+                        &app.search_query,
+                        is_selected,
+                        false,
+                        Style::default().fg(THEME.read().unwrap().text_muted),
+                        Alignment::Center,
+                    ));
+                }
+            }
             if app.is_column_visible(Tab::MergeRequests, "Milestone") {
                 let mr_milestone_str = m
                     .milestone
@@ -744,6 +815,12 @@ pub(crate) fn render_tab_merge_requests(
         if app.is_column_visible(Tab::MergeRequests, "Labels") {
             header_cells.push(Cell::from("Labels"));
             widths.push(Constraint::Fill(1));
+        }
+        if app.is_column_visible(Tab::MergeRequests, "Pipeline") {
+            header_cells.push(Cell::from(
+                Line::from("Pipeline").alignment(Alignment::Center),
+            ));
+            widths.push(Constraint::Length(12));
         }
         if app.is_column_visible(Tab::MergeRequests, "Milestone") {
             header_cells.push(Cell::from("Milestone"));

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -678,8 +678,26 @@ pub(crate) fn render_tab_merge_requests(
                     24,
                 ));
             }
-            if app.is_column_visible(Tab::MergeRequests, "Pipeline") {
-                if let Some(pipe) = &m.head_pipeline {
+            let is_github = app
+                .gitlab_client
+                .as_ref()
+                .map(|c| c.is_github)
+                .unwrap_or(false);
+            if app.is_column_visible(
+                Tab::MergeRequests,
+                if is_github { "Action" } else { "Pipeline" },
+            ) {
+                let resolved_pipe = m.head_pipeline.as_ref().or_else(|| {
+                    if is_github {
+                        app.pipelines
+                            .items
+                            .iter()
+                            .find(|p| p.r#ref == m.source_branch)
+                    } else {
+                        None
+                    }
+                });
+                if let Some(pipe) = resolved_pipe {
                     let (pipe_text, pipe_color, pipe_bg) = match pipe.status.as_str() {
                         "success" => (
                             "SUCCESS",
@@ -816,9 +834,18 @@ pub(crate) fn render_tab_merge_requests(
             header_cells.push(Cell::from("Labels"));
             widths.push(Constraint::Fill(1));
         }
-        if app.is_column_visible(Tab::MergeRequests, "Pipeline") {
+        let is_github = app
+            .gitlab_client
+            .as_ref()
+            .map(|c| c.is_github)
+            .unwrap_or(false);
+        if app.is_column_visible(
+            Tab::MergeRequests,
+            if is_github { "Action" } else { "Pipeline" },
+        ) {
             header_cells.push(Cell::from(
-                Line::from("Pipeline").alignment(Alignment::Center),
+                Line::from(if is_github { "Action" } else { "Pipeline" })
+                    .alignment(Alignment::Center),
             ));
             widths.push(Constraint::Length(12));
         }
@@ -983,6 +1010,72 @@ pub(crate) fn render_tab_merge_requests(
                         Style::default().fg(THEME.read().unwrap().yellow),
                     ),
                 ]));
+                let resolved_pipe = mr.head_pipeline.as_ref().or_else(|| {
+                    if is_github {
+                        app.pipelines
+                            .items
+                            .iter()
+                            .find(|p| p.r#ref == mr.source_branch)
+                    } else {
+                        None
+                    }
+                });
+                if let Some(pipe) = resolved_pipe {
+                    let (pipe_text, pipe_color, pipe_bg) = match pipe.status.as_str() {
+                        "success" => (
+                            "SUCCESS",
+                            THEME.read().unwrap().green,
+                            THEME.read().unwrap().green_bg,
+                        ),
+                        "failed" => (
+                            "FAILED",
+                            THEME.read().unwrap().red,
+                            THEME.read().unwrap().red_bg,
+                        ),
+                        "running" => (
+                            "RUNNING",
+                            THEME.read().unwrap().blue,
+                            THEME.read().unwrap().blue_bg,
+                        ),
+                        "canceled" => (
+                            "CANCEL",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                        "pending" => (
+                            "PENDING",
+                            THEME.read().unwrap().yellow,
+                            THEME.read().unwrap().yellow_bg,
+                        ),
+                        "skipped" => (
+                            "SKIP",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                        _ => (
+                            "UNKNOWN",
+                            THEME.read().unwrap().text_muted,
+                            THEME.read().unwrap().inactive_bg,
+                        ),
+                    };
+                    text.push(Line::from(vec![
+                        Span::styled(
+                            if is_github {
+                                "Action:    "
+                            } else {
+                                "Pipeline:  "
+                            },
+                            Style::default().fg(THEME.read().unwrap().text_muted),
+                        ),
+                        Span::styled(
+                            format!(" {} ", pipe_text),
+                            Style::default()
+                                .fg(pipe_color)
+                                .bg(pipe_bg)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]));
+                }
                 if Some(mr.iid) == app.last_fetched_mr_iid {
                     let unresolved_count = app.unresolved_threads_count();
                     text.push(Line::from(vec![
@@ -1095,23 +1188,36 @@ pub(crate) fn render_tab_pipelines(
     highlight_style: Style,
     header_style: Style,
 ) {
+    let is_github = app
+        .gitlab_client
+        .as_ref()
+        .map(|c| c.is_github)
+        .unwrap_or(false);
     if app.pipelines.items.is_empty() && app.loading_tabs.contains(&app.active_tab) {
         f.render_widget(
-            Paragraph::new("\n\n Loading pipelines...")
-                .alignment(Alignment::Center)
-                .block(main_block.clone())
-                .style(Style::default().fg(THEME.read().unwrap().text_muted)),
+            Paragraph::new(if is_github {
+                "\n\n Loading actions..."
+            } else {
+                "\n\n Loading pipelines..."
+            })
+            .alignment(Alignment::Center)
+            .block(main_block.clone())
+            .style(Style::default().fg(THEME.read().unwrap().text_muted)),
             content_area,
         );
         f.render_widget(
-            Paragraph::new("Select a pipeline to view details...")
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(" Details ")
-                        .border_style(Style::default().fg(THEME.read().unwrap().border)),
-                )
-                .style(Style::default().fg(THEME.read().unwrap().text_muted)),
+            Paragraph::new(if is_github {
+                "Select an action to view details..."
+            } else {
+                "Select a pipeline to view details..."
+            })
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Details ")
+                    .border_style(Style::default().fg(THEME.read().unwrap().border)),
+            )
+            .style(Style::default().fg(THEME.read().unwrap().text_muted)),
             detail_rect,
         );
     } else {
@@ -3409,11 +3515,18 @@ pub(crate) fn render_tab_terminal(
         }
     }
 
+    let is_github = app
+        .gitlab_client
+        .as_ref()
+        .map(|c| c.is_github)
+        .unwrap_or(false);
+
     for i in start_idx..end_idx {
         if let Some(cmd) = app.terminal_commands.get(i) {
             log_lines.push(super::helpers::build_log_line(
                 cmd,
                 inner_rect.width as usize,
+                is_github,
             ));
         }
     }


### PR DESCRIPTION
Closes #126

It would be nice to have a column for pipeline status relating to a MR/PR

---

## Engineering Description

### 1. Summary

Add a "Pipeline" column to the Merge Request / Pull Request table view that displays the latest pipeline/CI status for each MR/PR (e.g., "passed", "failed", "running", "pending", "canceled"). This gives users at-a-glance CI health without needing to switch to the Pipelines tab.

### 2. Impact on Current TUI Layers

| Layer | File(s) | Impact |
|-------|---------|--------|
| **Domain Model** | `src/gitlab/mr.rs`, `src/gitlab/pipelines.rs` | Add `head_pipeline: Option<Pipeline>` to `MergeRequest` struct; `Pipeline` already exists |
| **Event System** | `src/event.rs` | No new event needed — pipeline data can be fetched eagerly and embedded in the existing MR fetch flow, or a new `MrsWithPipelinesFetched(Vec<MergeRequest>, HashMap<u64, Pipeline>)` event for async batch fetch |
| **Application State** | `src/app.rs` | Add `"Pipeline"` to `columns()` and optionally `default_columns()` for `Tab::MergeRequests`; update `filtered_mrs_list` / `filtered_mrs` / `collect_unique_column_values` / `rebuild_group_map` to handle pipeline status strings |
| **UI Rendering** | `src/ui.rs` | Add pipeline status cell rendering (colored badge: green/red/yellow/grey), header cell with appropriate width, and optionally show pipeline status in the details preview pane |
| **Data Fetching** | `src/main.rs` | Extend `spawn_refresh_active_tab` for MRs to also fetch the latest pipeline for each MR (or rely on the API head_pipeline field); update `Event::MrsFetched` handler to store associated pipeline data |

### 3. Implementation Plan

**Phase A — GitLab API integration (`src/gitlab/mr.rs`)**
- Add `head_pipeline: Option<Pipeline>` field to `MergeRequest` (deserialized from GitLab API's `head_pipeline` field in the MR JSON response).
- The `Pipeline` struct in `src/gitlab/pipelines.rs` already has `id`, `status`, `r#ref`, `updated_at` — sufficient for display.

**Phase B — Application state (`src/app.rs`)**
- Add `"Pipeline"` to the `Tab::MergeRequests` column list in `columns()` (around line 155-165).
- Update `filtered_mrs_list` function to extract pipeline status string from `m.head_pipeline` (e.g., `m.head_pipeline.as_ref().map(|p| p.status.clone()).unwrap_or_default()`).
- Update `filtered_mrs` to include pipeline status in the column filter values.
- Update `collect_unique_column_values` for `Tab::MergeRequests` to collect pipeline statuses.
- Update `rebuild_group_map` for `Tab::MergeRequests` to support grouping by pipeline status.

**Phase C — Data fetching (`src/main.rs`)**
- In `spawn_refresh_active_tab` for `Tab::MergeRequests`, after fetching MRs, optionally batch-fetch latest pipeline per MR via `list_pipelines` and match by source branch, OR rely on the `head_pipeline` field already present in the MR API response (preferred — zero extra API calls).
- For GitHub: fetch commit statuses or check runs via `gh api` and map to a comparable status string.

**Phase D — UI rendering (`src/ui.rs`)**
- In the `Tab::MergeRequests` row-building block (around line 1301-1420), add a new branch for `"Pipeline"`:
  - Render a colored badge (e.g., `" PASSED "` on green, `" FAILED "` on red, `" RUNNING "` on yellow, `" PENDING "` on grey).
  - Use the existing `format_pipeline_status`-style helper or inline mapping.
- In the header section (around line 1422-1473), add the `"Pipeline"` header cell with `Constraint::Length(12)` width (enough for "CANCELED").
- Optionally show pipeline status in the details preview pane (bottom-half view when an MR is selected).

**Phase E — GitHub parity (`src/gitlab/client.rs`)**
- The `GitlabClient` already converts GitLab endpoints to GitHub equivalents. For GitHub PRs, the `head_pipeline` equivalent is the latest commit status/check run. The client should fetch the PR's status via `gh pr view <number> --json statusCheckRollup` or similar and translate to a status string matching the GitLab schema (passed/failed/running/pending/canceled).

### 4. Design / UX Acceptance Criteria

1. **Column visibility**: When `"Pipeline"` is in the enabled columns set, a pipeline status badge appears for each MR row. When hidden, no pipeline column is rendered.
2. **Color semantics**: The status badge follows the same color convention as the Pipelines tab:
   - `passed` / `success` → green
   - `failed` → red
   - `running` / `pending` → yellow/amber
   - `canceled` / `skipped` → grey
   - `created` / `manual` → white/default
3. **Details pane**: When an MR is selected and the details pane is visible, the pipeline status (and optionally pipeline ID) is shown in the metadata section (below state/draft status).
4. **Filtering**: Pipeline status values appear in the column-filter selector overlay when pressing Enter on the "Pipeline" column header in the configure popup.
5. **Grouping**: Users can group the MR table by pipeline status via the configure popup's "GROUP BY" section.
6. **Sorting**: Pipeline status sorts alphabetically by status string (the existing column-based sorting mechanism handles this without changes).
7. **Performance**: Pipeline data is fetched as part of the MR list API call (head_pipeline is included in GitLab's MR list response by default). No additional API requests per MR. For GitHub, one extra `gh` call per page of PRs may be needed — consider batching.
8. **Cache**: Pipeline status is cached alongside MR data (the existing `cache.mrs` field stores MergeRequest objects, so head_pipeline is automatically cached once added to the struct).
9. **No regression**: All existing columns, filtering, grouping, and sorting for the MR tab continue to work unchanged.