### PR TITLE
Potential fix for code scanning alert no. 25: Code injection

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,6 +19,8 @@ jobs:
   audit:
     name: Cargo Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,9 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,9 +1,8 @@
 name: Install
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,7 +11,7 @@ jobs:
   test-cargo-install:
     name: cargo install
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions: {}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,7 +25,8 @@ jobs:
   test-docker:
     name: Docker
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      packages: read
     steps:
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -37,19 +37,20 @@ jobs:
 
       - name: Pull and test Docker image
         env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          docker pull "ghcr.io/rcieri/glab-tui:$HEAD_BRANCH"
-          docker run --rm "ghcr.io/rcieri/glab-tui:$HEAD_BRANCH" --help
+          docker pull "ghcr.io/rcieri/glab-tui:$TAG"
+          docker run --rm "ghcr.io/rcieri/glab-tui:$TAG" --help
 
   test-install-sh:
     name: install.sh
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Run install.sh
         env:
@@ -62,11 +63,12 @@ jobs:
   test-install-ps1:
     name: install.ps1
     runs-on: windows-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Run install.ps1
         shell: pwsh

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -36,9 +36,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull and test Docker image
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          docker pull ghcr.io/rcieri/glab-tui:${{ github.event.workflow_run.head_branch }}
-          docker run --rm ghcr.io/rcieri/glab-tui:${{ github.event.workflow_run.head_branch }} --help
+          docker pull "ghcr.io/rcieri/glab-tui:$HEAD_BRANCH"
+          docker run --rm "ghcr.io/rcieri/glab-tui:$HEAD_BRANCH" --help
 
   test-install-sh:
     name: install.sh

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -18,6 +18,8 @@ jobs:
   msrv:
     name: Check MSRV
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,8 @@ jobs:
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -28,6 +30,8 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -45,6 +49,8 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/rcieri/glab-tui/security/code-scanning/25](https://github.com/rcieri/glab-tui/security/code-scanning/25)

General fix: move untrusted expression values into step-level `env:` variables, then reference them via native shell variables (e.g., `$HEAD_BRANCH`) inside `run:`. This prevents GitHub expression substitution from directly shaping shell source text.

Best fix here (without changing behavior): in `.github/workflows/install.yml`, update the **“Pull and test Docker image”** step to define `HEAD_BRANCH` in `env:` from `${{ github.event.workflow_run.head_branch }}`, and replace both direct `${{ ... }}` occurrences in the shell with `"$HEAD_BRANCH"`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
