### PR TITLE
feat(backend): add BackendKind enum and App helpers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::backend::BackendKind;
 use crate::config::Config;
 use crate::utils::ui::StatefulTable;
 use fuzzy_matcher::FuzzyMatcher;
@@ -161,19 +162,19 @@ impl Tab {
         }
     }
 
-    pub fn title(&self, is_github: bool) -> String {
+    pub fn title(&self, kind: BackendKind) -> String {
         let icons = crate::config::ICONS.read().unwrap();
         match self {
             Tab::Issues => format!("{} Issues", icons.tab_issue),
             Tab::MergeRequests => {
-                if is_github {
+                if kind.is_github() {
                     format!("{} PRs", icons.tab_pr)
                 } else {
                     format!("{} MRs", icons.tab_pr)
                 }
             }
             Tab::Pipelines => {
-                if is_github {
+                if kind.is_github() {
                     format!("{} Actions", icons.tab_pipeline)
                 } else {
                     format!("{} Pipelines", icons.tab_pipeline)
@@ -183,7 +184,7 @@ impl Tab {
             Tab::Runners => format!("{} Runners", icons.tab_runner),
             Tab::Releases => format!("{} Releases", icons.tab_release),
             Tab::Todos => {
-                if is_github {
+                if kind.is_github() {
                     format!("{} Notifications", icons.tab_todo)
                 } else {
                     format!("{} Todos", icons.tab_todo)
@@ -196,11 +197,11 @@ impl Tab {
         }
     }
 
-    pub fn columns(&self, is_github: bool) -> Vec<&'static str> {
+    pub fn columns(&self, kind: BackendKind) -> Vec<&'static str> {
         match self {
             Tab::Issues => {
                 let mut cols = vec!["ID", "State", "Title", "Assignees", "Labels", "Milestone"];
-                if !is_github {
+                if !kind.is_github() {
                     cols.push("Due Date");
                 }
                 cols.push("Author");
@@ -216,7 +217,7 @@ impl Tab {
                     "Reviewers",
                     "Labels",
                 ];
-                if is_github {
+                if kind.is_github() {
                     cols.push("Action");
                 } else {
                     cols.push("Pipeline");
@@ -227,7 +228,7 @@ impl Tab {
             }
             Tab::Pipelines => {
                 let mut cols = vec!["ID", "Status", "Ref"];
-                if is_github {
+                if kind.is_github() {
                     cols.push("Name");
                     cols.push("Event");
                     cols.push("SHA");
@@ -239,7 +240,7 @@ impl Tab {
             }
             Tab::Jobs => {
                 let mut cols = vec!["ID", "Status", "Name", "Matrix"];
-                if is_github {
+                if kind.is_github() {
                     cols.push("Runner");
                 } else {
                     cols.push("Stage");
@@ -263,25 +264,25 @@ impl Tab {
         }
     }
 
-    pub fn default_columns(&self, is_github: bool) -> Vec<&'static str> {
+    pub fn default_columns(&self, kind: BackendKind) -> Vec<&'static str> {
         match self {
             Tab::Issues => {
                 let mut cols = vec!["ID", "State", "Title", "Labels"];
-                if !is_github {
+                if !kind.is_github() {
                     cols.push("Due Date");
                 }
                 cols
             }
             Tab::MergeRequests => vec!["ID", "State", "Status", "Title", "Labels"],
             Tab::Pipelines => {
-                if is_github {
+                if kind.is_github() {
                     vec!["Name", "Status", "Event", "Ref"]
                 } else {
                     vec!["ID", "Status", "Stages", "Ref"]
                 }
             }
             Tab::Jobs => {
-                if is_github {
+                if kind.is_github() {
                     vec!["Name", "Status", "Ref"]
                 } else {
                     vec!["ID", "Stage", "Status", "Name", "Matrix"]
@@ -297,7 +298,7 @@ impl Tab {
         }
     }
 
-    pub fn available_on_platform(&self, _is_github: bool) -> bool {
+    pub fn available_on_platform(&self, _kind: BackendKind) -> bool {
         true
     }
 }
@@ -1835,7 +1836,7 @@ impl Default for App {
                 let mut ec = std::collections::HashMap::new();
                 for tab in Tab::ALL {
                     let set: std::collections::HashSet<String> = tab
-                        .default_columns(false)
+                        .default_columns(BackendKind::GitLab)
                         .iter()
                         .map(|s| s.to_string())
                         .collect();
@@ -1869,6 +1870,17 @@ impl Default for App {
 }
 
 impl App {
+    pub fn kind(&self) -> BackendKind {
+        self.gitlab_client
+            .as_ref()
+            .map(|c| c.backend.kind())
+            .unwrap_or(BackendKind::GitLab)
+    }
+
+    pub fn is_github(&self) -> bool {
+        self.kind().is_github()
+    }
+
     pub fn start_loading_tab(&mut self, tab: Tab) {
         if !self.loading_tabs.contains(&tab) {
             self.loading_tabs.insert(tab);
@@ -1882,12 +1894,7 @@ impl App {
     }
 
     pub fn is_column_visible(&self, tab: Tab, col: &str) -> bool {
-        let is_github = self
-            .gitlab_client
-            .as_ref()
-            .map(|c| c.is_github)
-            .unwrap_or(false);
-        if is_github {
+        if self.is_github() {
             if tab == Tab::Issues && col == "Due Date" {
                 return false;
             }
@@ -1903,18 +1910,14 @@ impl App {
     }
 
     pub fn available_tabs(&self) -> Vec<Tab> {
-        let is_github = self
-            .gitlab_client
-            .as_ref()
-            .map(|c| c.is_github)
-            .unwrap_or(false);
+        let kind = self.kind();
         let mut tabs: Vec<Tab> = Tab::ALL
             .iter()
-            .filter(|t| t.available_on_platform(is_github))
+            .filter(|t| t.available_on_platform(kind))
             .copied()
             .collect();
         if let Some(disabled) = &self.config.disabled_tabs {
-            tabs.retain(|t| !disabled.iter().any(|d| d == &t.title(is_github)));
+            tabs.retain(|t| !disabled.iter().any(|d| d == &t.title(kind)));
         }
         tabs
     }
@@ -4146,7 +4149,7 @@ mod tests {
 
         let items = vec![mr_draft_meta, mr_draft_title, mr_ready];
         let enabled_cols: std::collections::HashSet<String> = Tab::MergeRequests
-            .columns(false)
+            .columns(BackendKind::GitLab)
             .iter()
             .map(|s| s.to_string())
             .collect();

--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -74,6 +74,10 @@ impl GhBackend {
 
 #[async_trait]
 impl Backend for GhBackend {
+    fn kind(&self) -> super::BackendKind {
+        super::BackendKind::GitHub
+    }
+
     fn program(&self) -> &'static str {
         "gh"
     }

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -78,6 +78,10 @@ impl GlabBackend {
 
 #[async_trait]
 impl Backend for GlabBackend {
+    fn kind(&self) -> super::BackendKind {
+        super::BackendKind::GitLab
+    }
+
     fn program(&self) -> &'static str {
         "glab"
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,8 +15,43 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::mpsc::UnboundedSender;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendKind {
+    GitLab,
+    GitHub,
+}
+
+impl BackendKind {
+    pub fn is_github(self) -> bool {
+        matches!(self, BackendKind::GitHub)
+    }
+
+    pub fn is_gitlab(self) -> bool {
+        matches!(self, BackendKind::GitLab)
+    }
+
+    pub fn term(self, key: &str) -> &'static str {
+        match (self, key) {
+            (BackendKind::GitLab, "mr") => "Merge Request",
+            (BackendKind::GitHub, "mr") => "Pull Request",
+            (BackendKind::GitLab, "mr_short") => "MR",
+            (BackendKind::GitHub, "mr_short") => "PR",
+            (BackendKind::GitLab, "pipeline") => "Pipeline",
+            (BackendKind::GitHub, "pipeline") => "Action",
+            (BackendKind::GitLab, "pipeline_plural") => "Pipelines",
+            (BackendKind::GitHub, "pipeline_plural") => "Actions",
+            (BackendKind::GitLab, "todo") => "Todo",
+            (BackendKind::GitHub, "todo") => "Notification",
+            (BackendKind::GitLab, "todo_plural") => "Todos",
+            (BackendKind::GitHub, "todo_plural") => "Notifications",
+            _ => "",
+        }
+    }
+}
+
 #[async_trait]
 pub trait Backend: Send + Sync {
+    fn kind(&self) -> BackendKind;
     fn program(&self) -> &'static str;
 
     fn set_tx(&mut self, tx: UnboundedSender<Event>);

--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -1,4 +1,4 @@
-use crate::backend::Backend;
+use crate::backend::{Backend, BackendKind};
 use anyhow::{Context, Result};
 
 pub struct GitlabClient {
@@ -9,6 +9,10 @@ pub struct GitlabClient {
 }
 
 impl GitlabClient {
+    pub fn kind(&self) -> BackendKind {
+        self.backend.kind()
+    }
+
     pub async fn new() -> Result<Self> {
         let is_github = match tokio::process::Command::new("git")
             .args(["remote", "get-url", "origin"])

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -553,7 +553,7 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
 
             let selected_idx = app.edit_menu.as_ref().map(|m| m.selected_idx).unwrap_or(0);
 
-            let is_github = app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+            let is_github = app.is_github();
             let program = if is_github { "gh" } else { "glab" };
             let mut fields = vec![
                 ("Title".to_string(), issue.title.clone()),
@@ -621,9 +621,7 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
 
             let selected_idx = app.edit_menu.as_ref().map(|m| m.selected_idx).unwrap_or(0);
 
-            let is_github = app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
-            let program = if is_github { "gh" } else { "glab" };
-            let is_github = is_github;
+            let is_github = app.is_github();
             let mut fields = vec![
                 ("Title".to_string(), mr.title.clone()),
                 ("Labels".to_string(), labels),

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -18,11 +18,7 @@ pub async fn handle_active_tab_key(
     match app.active_tab {
         crate::app::Tab::Issues => match key_event.code {
             _ if keybinding_matches(&app.config.keybindings.issues.create_issue, key_event) => {
-                let is_github = app
-                    .gitlab_client
-                    .as_ref()
-                    .map(|c| c.is_github)
-                    .unwrap_or(false);
+                let is_github = app.is_github();
                 let mut fields = vec![
                     ("Title".to_string(), String::new()),
                     ("Labels".to_string(), String::new()),
@@ -131,7 +127,7 @@ pub async fn handle_active_tab_key(
             KeyCode::Char('o') => {
                 if let Some(selected_idx) = app.issues.state.selected() {
                     if let Some(issue) = app.filtered_issues().get(selected_idx) {
-                        let is_github = app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                        let is_github = app.is_github();
                         let Some(client) = app.gitlab_client.clone() else {
                             return;
                         };
@@ -177,11 +173,7 @@ pub async fn handle_active_tab_key(
         },
         crate::app::Tab::MergeRequests => {
             if keybinding_matches(&app.config.keybindings.mrs.create_mr, key_event) {
-                let is_github = app
-                    .gitlab_client
-                    .as_ref()
-                    .map(|c| c.is_github)
-                    .unwrap_or(false);
+                let is_github = app.is_github();
                 let pr_suffix = if is_github {
                     "Pull Request"
                 } else {
@@ -435,8 +427,7 @@ pub async fn handle_active_tab_key(
                             });
                         }
                         KeyCode::Char('o') => {
-                            let is_github =
-                                app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                            let is_github = app.is_github();
                             let entity = if is_github { "pr" } else { "mr" };
                             let Some(client) = app.gitlab_client.clone() else {
                                 return;
@@ -693,8 +684,7 @@ pub async fn handle_active_tab_key(
                             }
                         }
                         KeyCode::Char('o') => {
-                            let is_github =
-                                app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                            let is_github = app.is_github();
                             let Some(client) = app.gitlab_client.clone() else {
                                 return;
                             };
@@ -1170,7 +1160,7 @@ pub async fn handle_active_tab_key(
                 if let Some(selected_idx) = app.releases.state.selected() {
                     let filtered = app.filtered_releases();
                     if let Some(release) = filtered.get(selected_idx) {
-                        let is_github = app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                        let is_github = app.is_github();
                         let Some(client) = app.gitlab_client.clone() else {
                             return;
                         };
@@ -1242,8 +1232,7 @@ pub async fn handle_active_tab_key(
                             key_event,
                         ) =>
                         {
-                            let is_github =
-                                app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                            let is_github = app.is_github();
                             let entity = if item.target_type.contains("MergeRequest") {
                                 if is_github { "pr" } else { "mr" }
                             } else {
@@ -1280,11 +1269,7 @@ pub async fn handle_active_tab_key(
                 key_event,
             ) =>
             {
-                let is_github = app
-                    .gitlab_client
-                    .as_ref()
-                    .map(|c| c.is_github)
-                    .unwrap_or(false);
+                let is_github = app.is_github();
                 let mut fields = vec![
                     ("Title".to_string(), String::new()),
                     ("Description".to_string(), String::new()),
@@ -1424,7 +1409,7 @@ pub async fn handle_active_tab_key(
                 if let Some(selected_idx) = app.milestones.state.selected() {
                     let filtered = app.filtered_milestones();
                     if let Some(milestone) = filtered.get(selected_idx) {
-                        let is_github = app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                        let is_github = app.is_github();
                         let Some(client) = app.gitlab_client.clone() else {
                             return;
                         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1195,11 +1195,7 @@ async fn main() -> Result<()> {
                                         if !value.trim().is_empty() {
                                             let tag_name = value.trim().to_string();
                                             let tx = events.sender();
-                                            let is_github = app
-                                                .gitlab_client
-                                                .as_ref()
-                                                .map(|c| c.is_github)
-                                                .unwrap_or(false);
+                                            let is_github = app.is_github();
                                             let program = if is_github { "gh" } else { "glab" };
                                             let _ = tx.send(Event::CommandStarted(format!(
                                                 "Creating Release: {} release create {}",
@@ -1558,10 +1554,7 @@ async fn main() -> Result<()> {
                                         mr_iid,
                                         status,
                                     } => {
-                                        let is_github = app
-                                            .gitlab_client
-                                            .as_ref()
-                                            .map_or(false, |c| c.is_github);
+                                        let is_github = app.is_github();
                                         let tx = events.sender();
                                         let comments = app.draft_comments.clone();
                                         app.draft_comments.clear();
@@ -2503,11 +2496,7 @@ async fn main() -> Result<()> {
 
                                         app.selector = None;
 
-                                        let is_github = app
-                                            .gitlab_client
-                                            .as_ref()
-                                            .map(|c| c.is_github)
-                                            .unwrap_or(false);
+                                        let is_github = app.is_github();
                                         let pr_suffix = if is_github {
                                             "Pull Request"
                                         } else {
@@ -2788,10 +2777,7 @@ async fn main() -> Result<()> {
                                                         .find(|c| c.id == comment_id)
                                                         .cloned()
                                                     {
-                                                        let is_github = app
-                                                            .gitlab_client
-                                                            .as_ref()
-                                                            .map_or(false, |c| c.is_github);
+                                                        let is_github = app.is_github();
 
                                                         let mut actions =
                                                             vec!["Reply to Thread".to_string()];
@@ -3800,12 +3786,7 @@ async fn main() -> Result<()> {
                                             current_set.insert(current_val);
                                         }
                                     } else if field_type == "workflow_file" {
-                                        let is_github = app
-                                            .gitlab_client
-                                            .as_ref()
-                                            .map(|c| c.is_github)
-                                            .unwrap_or(false);
-                                        all_items = get_workflow_files(is_github);
+                                        all_items = get_workflow_files(app.is_github());
                                         is_loading = false;
                                         // Pre-select any already-typed value
                                         let current_val = menu.fields[menu.selected_idx].1.clone();
@@ -4725,10 +4706,7 @@ async fn main() -> Result<()> {
                                         } else if matching_current.len() == 1 {
                                             let comment = matching_current[0];
                                             let comment_id = comment.id;
-                                            let is_github = app
-                                                .gitlab_client
-                                                .as_ref()
-                                                .map_or(false, |c| c.is_github);
+                                            let is_github = app.is_github();
 
                                             let mut actions = vec!["Reply to Thread".to_string()];
 
@@ -4885,8 +4863,7 @@ async fn main() -> Result<()> {
                                 app.diff_view = Some(diff_view);
                             }
                             KeyCode::Char('r') => {
-                                let is_github =
-                                    app.gitlab_client.as_ref().map_or(false, |c| c.is_github);
+                                let is_github = app.is_github();
                                 app.selector = Some(crate::app::Selector {
                                     title: format!(
                                         " Submit {} Review ",
@@ -5090,12 +5067,8 @@ async fn main() -> Result<()> {
                             continue;
                         }
 
-                        let is_github = app
-                            .gitlab_client
-                            .as_ref()
-                            .map(|c| c.is_github)
-                            .unwrap_or(false);
-                        let cols = app.active_tab.columns(is_github);
+                        let kind = app.kind();
+                        let cols = app.active_tab.columns(kind);
                         let group_cols: Vec<&str> = cols.iter().copied().collect();
                         let cols_end = cols.len();
                         let group_end = cols_end + group_cols.len();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -159,7 +159,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
 
     // Top: Title & Context
     let icons = crate::config::ICONS.read().unwrap();
-    let header_icon = if app.gitlab_client.as_ref().map_or(false, |c| c.is_github) {
+    let header_icon = if app.is_github() {
         &icons.header_github
     } else {
         &icons.header_gitlab
@@ -283,16 +283,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
     };
 
     // Sidebar: Tabs
-    let is_github = app
-        .gitlab_client
-        .as_ref()
-        .map(|c| c.is_github)
-        .unwrap_or(false);
+    let kind = app.kind();
     let sidebar_items: Vec<ListItem> = app
         .available_tabs()
         .iter()
         .map(|t| {
-            let title = format!(" {} ", t.title(is_github).to_uppercase());
+            let title = format!(" {} ", t.title(kind).to_uppercase());
             if *t == app.active_tab {
                 ListItem::new(title).style(
                     Style::default()
@@ -320,7 +316,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
     f.render_widget(sidebar, sidebar_rect);
 
     // Main Area Title
-    let tab_title = format!(" {} ", app.active_tab.title(is_github));
+    let tab_title = format!(" {} ", app.active_tab.title(kind));
     let main_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(if app.focus_column_checklist {
@@ -493,7 +489,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             .border_style(Style::default().fg(THEME.read().unwrap().border_focused))
             .style(Style::default().bg(Color::Reset));
 
-        let pr_label = if app.gitlab_client.as_ref().map_or(true, |c| c.is_github) {
+        let pr_label = if app.is_github() {
             "Pull Request"
         } else {
             "Merge Request"
@@ -540,7 +536,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             String::new()
         };
 
-        let pr_label = if app.gitlab_client.as_ref().map_or(true, |c| c.is_github) {
+        let pr_label = if app.is_github() {
             "Pull Request"
         } else {
             "Merge Request"

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1203,12 +1203,9 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
 
     if app.focus_column_checklist {
         let tab = app.active_tab;
-        let is_github = app
-            .gitlab_client
-            .as_ref()
-            .map(|c| c.is_github)
-            .unwrap_or(false);
-        let cols = tab.columns(is_github);
+        let kind = app.kind();
+        let is_github = kind.is_github();
+        let cols = tab.columns(kind);
         let active_idx = app.column_checklist_idx;
 
         let group_cols: Vec<&str> = cols.iter().copied().collect();
@@ -1230,7 +1227,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             .title(format!(
                 " {} Configure View: {} ",
                 icons.label_configure,
-                tab.title(is_github)
+                tab.title(kind)
             ))
             .title_style(
                 Style::default()

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -683,11 +683,7 @@ pub(crate) fn render_tab_merge_requests(
                     24,
                 ));
             }
-            let is_github = app
-                .gitlab_client
-                .as_ref()
-                .map(|c| c.is_github)
-                .unwrap_or(false);
+            let is_github = app.is_github();
             if app.is_column_visible(
                 Tab::MergeRequests,
                 if is_github { "Action" } else { "Pipeline" },
@@ -851,11 +847,7 @@ pub(crate) fn render_tab_merge_requests(
             header_cells.push(Cell::from("Labels"));
             widths.push(Constraint::Length(26));
         }
-        let is_github = app
-            .gitlab_client
-            .as_ref()
-            .map(|c| c.is_github)
-            .unwrap_or(false);
+        let is_github = app.is_github();
         if app.is_column_visible(
             Tab::MergeRequests,
             if is_github { "Action" } else { "Pipeline" },
@@ -1229,11 +1221,7 @@ pub(crate) fn render_tab_pipelines(
     header_style: Style,
 ) {
     let icons = crate::config::ICONS.read().unwrap();
-    let is_github = app
-        .gitlab_client
-        .as_ref()
-        .map(|c| c.is_github)
-        .unwrap_or(false);
+    let is_github = app.is_github();
     if app.pipelines.items.is_empty() && app.loading_tabs.contains(&app.active_tab) {
         f.render_widget(
             Paragraph::new(if is_github {
@@ -1862,12 +1850,9 @@ pub(crate) fn render_tab_jobs(
             widths.push(Constraint::Min(0));
         }
 
-        let is_github = app
-            .gitlab_client
-            .as_ref()
-            .map(|c| c.is_github)
-            .unwrap_or(false);
-        let jobs_title = Tab::Jobs.title(is_github);
+        let kind = app.kind();
+        let is_github = kind.is_github();
+        let jobs_title = Tab::Jobs.title(kind);
         let table = Table::new(rows, widths)
             .header(Row::new(header_cells).style(header_style).height(1))
             .block(
@@ -2956,11 +2941,7 @@ pub(crate) fn render_tab_milestones(
             detail_rect,
         );
     } else {
-        let is_github = app
-            .gitlab_client
-            .as_ref()
-            .map(|c| c.is_github)
-            .unwrap_or(false);
+        let kind = app.kind();
         let mut filtered_milestones = App::filtered_milestones_list(
             &app.milestones.items,
             &app.search_query,
@@ -2986,7 +2967,7 @@ pub(crate) fn render_tab_milestones(
 
         let mut header_cells = Vec::new();
         let mut widths = Vec::new();
-        let cols = Tab::Milestones.columns(is_github);
+        let cols = Tab::Milestones.columns(kind);
         for col in &cols {
             if app.is_column_visible(Tab::Milestones, col) {
                 header_cells.push(Cell::from(*col));
@@ -3370,7 +3351,7 @@ pub(crate) fn render_tab_branches(
             Row::new(cells).style(row_style).height(1)
         });
 
-        let cols = Tab::Branches.columns(false);
+        let cols = Tab::Branches.columns(app.kind());
         let widths: Vec<Constraint> = cols
             .iter()
             .filter(|c| app.is_column_visible(Tab::Branches, c))
@@ -3507,7 +3488,7 @@ pub(crate) fn render_tab_environments(
             Row::new(cells).style(row_style).height(1)
         });
 
-        let cols = Tab::Environments.columns(false);
+        let cols = Tab::Environments.columns(app.kind());
         let widths: Vec<Constraint> = cols
             .iter()
             .filter(|c| app.is_column_visible(Tab::Environments, c))


### PR DESCRIPTION
Adds `BackendKind` enum (GitLab, GitHub) with `term()` method for backend-specific UI terminology. Adds `kind()` to the `Backend` trait, implemented by `GlabBackend` and `GhBackend`. Adds `App::kind()` and `App::is_github()` convenience methods.

Changes:
- `BackendKind` enum with `is_github()`, `is_gitlab()`, `term()` methods
- `Backend::kind()` trait method implemented in both backends
- `App::kind()` and `App::is_github()` helpers
- `Tab` methods updated to accept `BackendKind` instead of `bool`
- ~30 scattered `app.gitlab_client.as_ref().map(|c| c.is_github).unwrap_or(false)` patterns replaced with `app.is_github()`
- Fixed inverted `map_or(true, ...)` bugs at `src/ui/mod.rs:492,539` (defaulted to "Pull Request" when client was None)

Closes #192