### PR TITLE
fix(pipelines): use workflow name for GitHub job stage

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -1167,6 +1167,26 @@ impl Backend for GhBackend {
         pipeline_id: u64,
         _page_size: usize,
     ) -> Result<Vec<Job>> {
+        // Fetch workflow name for this run
+        let workflow_name = self
+            .run_gh(
+                &[
+                    "run",
+                    "view",
+                    &pipeline_id.to_string(),
+                    "--json",
+                    "workflowName",
+                    "--jq",
+                    ".workflowName",
+                    "-R",
+                    project,
+                ],
+                "Fetching Workflow",
+            )
+            .await
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| "actions".to_string());
+
         let raw = self
             .run_gh(
                 &[
@@ -1214,7 +1234,7 @@ impl Backend for GhBackend {
                 Job {
                     id: j.id,
                     status,
-                    stage: "build".to_string(),
+                    stage: workflow_name.clone(),
                     name: j.name,
                     matrix: None,
                 }


### PR DESCRIPTION
Fixes `GhBackend::list_pipeline_jobs` which was hardcoding `stage: "build"` for every GitHub Actions job. Now fetches the workflow name via `gh run view --json workflowName` and uses it as the stage, so jobs are grouped by workflow instead of all showing as a single fake "build" stage.

Closes #197