### PR TITLE
fix(terminal): unify milestone close/reopen terminal output

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -1697,6 +1697,11 @@ impl Backend for GhBackend {
         close: bool,
     ) -> Result<()> {
         let state = if close { "closed" } else { "open" };
+        let desc = if close {
+            "CLOSING MILESTONE"
+        } else {
+            "REOPENING MILESTONE"
+        };
         self.run_gh(
             &[
                 "api",
@@ -1706,7 +1711,7 @@ impl Backend for GhBackend {
                 "-f",
                 &format!("state={}", state),
             ],
-            "Updating Milestone State",
+            desc,
         )
         .await?;
         Ok(())

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -1734,6 +1734,11 @@ impl Backend for GlabBackend {
         close: bool,
     ) -> Result<()> {
         let action = if close { "close" } else { "reopen" };
+        let desc = if close {
+            "CLOSING MILESTONE"
+        } else {
+            "REOPENING MILESTONE"
+        };
         self.run_glab(
             &[
                 "milestone",
@@ -1742,7 +1747,7 @@ impl Backend for GlabBackend {
                 "-R",
                 project,
             ],
-            "Updating Milestone State",
+            desc,
         )
         .await?;
         Ok(())

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -1320,10 +1320,6 @@ pub async fn handle_active_tab_key(
                         let project_path = app.project_context.clone();
                         let milestone_iid = milestone.iid;
                         let tx = tx.clone();
-                        let _ = tx.send(Event::CommandStarted(format!(
-                            "Closing milestone #{}",
-                            milestone_iid
-                        )));
                         tokio::spawn(async move {
                             let res = crate::domain::milestones::update_milestone_state(
                                 &client,
@@ -1361,10 +1357,6 @@ pub async fn handle_active_tab_key(
                         let project_path = app.project_context.clone();
                         let milestone_iid = milestone.iid;
                         let tx = tx.clone();
-                        let _ = tx.send(Event::CommandStarted(format!(
-                            "Reopening milestone #{}",
-                            milestone_iid
-                        )));
                         tokio::spawn(async move {
                             let res = crate::domain::milestones::update_milestone_state(
                                 &client,


### PR DESCRIPTION
## Summary

Unifies terminal output for all operations that previously produced inconsistent or missing CLI commands in the terminal pane.

### Problem

Several operations sent `Event::CommandStarted` (which creates a "Running" terminal entry) alongside a backend method call (which emits its own `TerminalCommandLogged` via `run_glab()`/`run_gh()`/`raw_api()`). This produced duplicate entries, missing CLI commands, or stuck "Running" entries.

### Changes (3 commits)

**1. Milestone close/reopen** (`glab.rs`, `gh.rs`, `tabs.rs`)
- Backend `update_milestone_state()` now passes `"CLOSING MILESTONE"` / `"REOPENING MILESTONE"` (was `"Updating Milestone State"`)
- Removed `CommandStarted` from milestone close/reopen handlers in `tabs.rs`

**2. Deployments fetch + branch creation** (`tabs.rs`, `main.rs`)
- Removed `CommandStarted` sends — backend already emits properly formatted entries

**3. Diff fetch** (`tabs.rs`, `main.rs`)
- Added `CommandCompleted` after the diff CLI command completes, *before* the backend `list_mr_notes()` call
- Prevents the backend notes entry from corrupting the diff entry's terminal status via fallback matching

### Before / After

```
Before:  SUCCESS · CLOSING MILESTONE #123 ·            (no command shown)
After:   SUCCESS · CLOSING MILESTONE · glab milestone close 123 -R repo

Before:  SUCCESS · FETCHING DEPLOYMENTS FOR PROD ·     (no command shown)
After:   SUCCESS · FETCHING DEPLOYMENTS · glab api /projects/.../deployments

Before:  SUCCESS · CREATING BRANCH: FIX-XYZ ·          (no command shown)
After:   SUCCESS · CREATING BRANCH · glab api POST /projects/.../branches

Before:  RUNNING · FETCHING DIFF · gh pr diff 123      (stuck in Running forever)
After:   SUCCESS · FETCHING DIFF · gh pr diff 123
         SUCCESS · FETCHING MR NOTES · gh api /repos/.../pulls/123/comments  (separate entry)
```

Closes #217