### PR TITLE
feat(ui): wire up BackendKind::term() for adaptive labels

### DIFF
--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1739,6 +1739,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
     }
 
     if let Some(confirm) = &app.confirm_popup {
+        let kind = app.kind();
         let (title, message) = match confirm {
             crate::app::ConfirmAction::DeleteMilestone(iid) => (
                 format!(" {} Delete Milestone? ", icons.action_delete),
@@ -1763,21 +1764,33 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
                     iid
                 ),
             ),
-            crate::app::ConfirmAction::CloseMr(iid) => (
-                format!(" {} Close Merge Request? ", icons.action_close),
-                format!("Are you sure you want to close MR/PR #{}?", iid),
-            ),
-            crate::app::ConfirmAction::DeleteMr(iid) => (
-                format!(" {} Delete Merge Request? ", icons.action_delete),
-                format!(
-                    "Are you sure you want to delete MR #{}? This action is permanent.",
-                    iid
-                ),
-            ),
-            crate::app::ConfirmAction::MergeMr(iid) => (
-                format!(" {} Merge Request? ", icons.action_merge),
-                format!("Are you sure you want to merge MR/PR #{}?", iid),
-            ),
+            crate::app::ConfirmAction::CloseMr(iid) => {
+                let mr = kind.term("mr");
+                let mr_short = kind.term("mr_short");
+                (
+                    format!(" {} Close {mr}? ", icons.action_close),
+                    format!("Are you sure you want to close {mr_short} #{}?", iid),
+                )
+            }
+            crate::app::ConfirmAction::DeleteMr(iid) => {
+                let mr = kind.term("mr");
+                let mr_short = kind.term("mr_short");
+                (
+                    format!(" {} Delete {mr}? ", icons.action_delete),
+                    format!(
+                        "Are you sure you want to delete {mr_short} #{}? This action is permanent.",
+                        iid
+                    ),
+                )
+            }
+            crate::app::ConfirmAction::MergeMr(iid) => {
+                let mr = kind.term("mr");
+                let mr_short = kind.term("mr_short");
+                (
+                    format!(" {} Merge {mr}? ", icons.action_merge),
+                    format!("Are you sure you want to merge {mr_short} #{}?", iid),
+                )
+            }
         };
 
         let block = Block::default()

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -1499,7 +1499,11 @@ pub(crate) fn render_tab_pipelines(
                 let mut text = Vec::new();
                 text.push(Line::from(vec![
                     Span::styled(
-                        "Pipeline ID: ",
+                        if is_github {
+                            "Run ID:     "
+                        } else {
+                            "Pipeline ID: "
+                        },
                         Style::default().fg(THEME.read().unwrap().text_muted),
                     ),
                     Span::styled(
@@ -1554,8 +1558,13 @@ pub(crate) fn render_tab_pipelines(
                 text.push(Line::from(""));
 
                 if let Some(jobs) = app.pipeline_jobs.get(&p.id()) {
+                    let stage_label = if is_github {
+                        "Jobs Status:"
+                    } else {
+                        "Stages Success Rate:"
+                    };
                     text.push(Line::from(vec![Span::styled(
-                        format!("{} Stages Success Rate:", icons.label_stages),
+                        format!("{} {stage_label}", icons.label_stages),
                         Style::default()
                             .fg(THEME.read().unwrap().header_fg)
                             .add_modifier(Modifier::BOLD),
@@ -1564,7 +1573,11 @@ pub(crate) fn render_tab_pipelines(
                     super::helpers::append_stage_summaries(&mut text, jobs);
                 } else {
                     text.push(Line::from(vec![Span::styled(
-                        "Loading stages...",
+                        if is_github {
+                            "Loading jobs..."
+                        } else {
+                            "Loading stages..."
+                        },
                         Style::default()
                             .fg(THEME.read().unwrap().text_muted)
                             .add_modifier(Modifier::ITALIC),
@@ -1985,8 +1998,13 @@ pub(crate) fn render_tab_jobs(
                 )
                 .border_style(Style::default().fg(THEME.read().unwrap().border));
             let mut text = Vec::new();
+            let stage_label = if is_github {
+                "Jobs Status:"
+            } else {
+                "Stages Success Rate:"
+            };
             text.push(Line::from(vec![Span::styled(
-                "Stages Success Rate:",
+                stage_label,
                 Style::default()
                     .fg(THEME.read().unwrap().header_fg)
                     .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
Wires up `BackendKind::term()` across the UI to eliminate hardcoded GitLab terminology.

Changes:
- Add `mr_plural`, `run`, and `backend` terms to `BackendKind::term()`
- Loading/empty states: "Loading merge requests..." → "Loading pull requests..." on GitHub
- Loading/empty states: "Loading todos..." → "Loading notifications...", "Select a todo..." → "Select a notification..."
- Confirm popup: "Close/Delete/Merge Merge Request?" → "Pull Request?" on GitHub
- Help overlay: category names adapt (Merge Requests→Pull Requests, Pipelines→Actions, TODOs→Notifications)
- Help overlay: action descriptions adapt (Approve MR→Approve PR, etc.)
- Selector loading: "Loading options from GitLab..." → "Loading options from {GitHub/GitLab}..."
- Pipeline detail: "Pipeline ID"→"Run ID", "Stages Success Rate"→"Jobs Status", "Loading stages"→"Loading jobs"

Closes #200