### PR TITLE
feat(config): add UiConfig with configurable sidebar and terminal pane

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1090,6 +1090,24 @@ fn def_page_size() -> usize {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+pub struct UiConfig {
+    pub sidebar_width: u16,
+    pub sidebar_visible: bool,
+    pub terminal_pane_visible: bool,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            sidebar_width: 22,
+            sidebar_visible: true,
+            terminal_pane_visible: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub theme_preset: Option<String>,
     pub active_tab: Option<String>,
@@ -1098,6 +1116,7 @@ pub struct Config {
     #[serde(default = "def_page_size")]
     pub page_size: usize,
     pub disabled_tabs: Option<Vec<String>>,
+    pub ui: UiConfig,
     pub issues: PaneConfig,
     pub mrs: PaneConfig,
     pub pipelines: PaneConfig,
@@ -1120,6 +1139,7 @@ impl Default for Config {
             keybindings: KeybindingConfig::default(),
             page_size: def_page_size(),
             disabled_tabs: None,
+            ui: UiConfig::default(),
             issues: PaneConfig::default(),
             mrs: PaneConfig::default(),
             pipelines: PaneConfig::default(),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -222,8 +222,8 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // Middle: Sidebar | Main Area | Preview Area
     let can_zoom = app.active_tab != Tab::Pipelines || !app.jobs.items.is_empty();
 
-    let sidebar_width = if size.width >= 80 {
-        Constraint::Length(22)
+    let sidebar_width = if size.width >= 80 && app.config.ui.sidebar_visible {
+        Constraint::Length(app.config.ui.sidebar_width)
     } else {
         Constraint::Length(0)
     };
@@ -268,7 +268,10 @@ pub fn render(f: &mut Frame, app: &mut App) {
     }
 
     // Split middle column vertically: main content area + compact terminal pane
-    let term_height = if app.active_tab != Tab::Terminal && size.height >= 18 {
+    let term_height = if app.active_tab != Tab::Terminal
+        && size.height >= 18
+        && app.config.ui.terminal_pane_visible
+    {
         6
     } else {
         0


### PR DESCRIPTION
Adds `[ui]` config section with `sidebar_width`, `sidebar_visible`, and `terminal_pane_visible` options. Wired into the rendering layout.

Closes #202