### PR TITLE
feat(ui): add FieldType enum and fix Edit menu terminology

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -307,7 +307,7 @@ impl Tab {
 #[derive(Clone, Debug)]
 pub struct EditMenu {
     pub title: String,
-    pub fields: Vec<(String, String)>, // (Label, Value)
+    pub fields: Vec<(String, String)>, // (Label, Value) — TODO: migrate to Vec<Field>
     pub selected_idx: usize,
     pub entity_iid: u64,
     pub entity_type: String, // "issue", "mr"
@@ -317,6 +317,60 @@ pub struct EditMenu {
 impl EditMenu {
     pub fn is_new(&self) -> bool {
         self.entity_type.starts_with("new_")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FieldType {
+    Text,
+    MultiSelect,
+    Date,
+    Toggle,
+    Ref,
+}
+
+#[derive(Clone, Debug)]
+pub struct Field {
+    pub label: String,
+    pub kind: FieldType,
+    pub value: String,
+}
+
+impl Field {
+    pub fn text(label: &str, value: String) -> Self {
+        Self {
+            label: label.to_string(),
+            kind: FieldType::Text,
+            value,
+        }
+    }
+    pub fn multi_select(label: &str, value: String) -> Self {
+        Self {
+            label: label.to_string(),
+            kind: FieldType::MultiSelect,
+            value,
+        }
+    }
+    pub fn toggle(label: &str, value: String) -> Self {
+        Self {
+            label: label.to_string(),
+            kind: FieldType::Toggle,
+            value,
+        }
+    }
+    pub fn ref_field(label: &str, value: String) -> Self {
+        Self {
+            label: label.to_string(),
+            kind: FieldType::Ref,
+            value,
+        }
+    }
+    pub fn date(label: &str, value: String) -> Self {
+        Self {
+            label: label.to_string(),
+            kind: FieldType::Date,
+            value,
+        }
     }
 }
 

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -638,8 +638,9 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
                 mr.description.clone().unwrap_or_default(),
             ));
 
+            let mr_label = app.kind().term("mr_short");
             app.edit_menu = Some(crate::app::EditMenu {
-                title: format!("Edit MR #{}", mr.iid),
+                title: format!("Edit {} #{}", mr_label, mr.iid),
                 fields,
                 selected_idx,
                 entity_iid: mr.iid,
@@ -653,11 +654,7 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
         }
     } else if entity_type == "milestone" {
         if let Some(milestone) = app.milestones.items.iter().find(|m| m.iid == entity_iid) {
-            let is_github = app
-                .gitlab_client
-                .as_ref()
-                .map(|c| c.is_github)
-                .unwrap_or(false);
+            let is_github = app.is_github();
             let selected_idx = app.edit_menu.as_ref().map(|m| m.selected_idx).unwrap_or(0);
             let mut fields = vec![("Title".to_string(), milestone.title.clone())];
             if !is_github {


### PR DESCRIPTION
Adds FieldType enum and Field struct for typed edit menu fields. Fixes "Edit MR #N" → "Edit PR #N" for GitHub. Replaces remaining scattered is_github pattern in entity_editor.rb.

Closes #194