### PR TITLE
feat(issues): add 'm' keybinding to create MR/PR from selected issue (#185)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -668,6 +668,8 @@ pub struct KeybindingIssues {
     pub reopen_entity: String,
     #[serde(default = "def_delete_entity")]
     pub delete_entity: String,
+    #[serde(default)]
+    pub create_mr: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -847,6 +849,7 @@ keybind_defaults! {
     def_scroll_up = "K",
     def_save_view = "s",
     def_create_issue = "n",
+    def_create_mr_issue = "m",
     def_edit_entity = "e",
     def_close_entity = "c",
     def_reopen_entity = "r",
@@ -918,6 +921,7 @@ impl Default for KeybindingIssues {
             close_entity: def_close_entity(),
             reopen_entity: def_reopen_entity(),
             delete_entity: def_delete_entity(),
+            create_mr: def_create_mr_issue(),
         }
     }
 }
@@ -1207,6 +1211,7 @@ save_view = "s"
 
 [keybindings.issues]
 create_issue = "n"
+create_mr = "m"
 edit_entity = "e"
 close_entity = "c"
 reopen_entity = "r"

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -3,7 +3,9 @@ use crate::app::App;
 use crate::entity_editor::rebuild_edit_menu;
 use crate::event::Event;
 use crate::fetch::spawn_refresh_active_tab;
+use crate::git_helpers::{get_default_branch, slugify};
 use crate::keybinding::keybinding_matches;
+use crate::templates::get_default_template;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::ListState;
 use tokio::sync::mpsc::UnboundedSender;
@@ -166,6 +168,78 @@ pub async fn handle_active_tab_key(
                                 ));
                             });
                         }
+                    }
+                }
+            }
+            _ if keybinding_matches(&app.config.keybindings.issues.create_mr, key_event) => {
+                if let Some(selected_idx) = app.issues.state.selected() {
+                    let filtered = app.filtered_issues();
+                    if let Some(issue) = filtered.get(selected_idx) {
+                        let is_github = app.is_github();
+                        let pr_suffix = if is_github {
+                            "Pull Request"
+                        } else {
+                            "Merge Request"
+                        };
+
+                        let title_val = issue.title.clone();
+                        let source_branch_val = format!("{}-{}", issue.iid, slugify(&issue.title));
+                        let labels_val = if issue.labels.is_empty() {
+                            String::new()
+                        } else {
+                            issue.labels.join(", ")
+                        };
+                        let assignees_val = if issue.assignees.is_empty() {
+                            String::new()
+                        } else {
+                            issue
+                                .assignees
+                                .iter()
+                                .map(|a| format!("@{}", a.username))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        };
+                        let milestone_val = issue
+                            .milestone
+                            .as_ref()
+                            .map(|m| m.title.clone())
+                            .unwrap_or_default();
+                        let description_val = if let Some(ref d) = issue.description {
+                            format!("Closes #{}\n\n{}", issue.iid, d)
+                        } else {
+                            let mr_tmpl = get_default_template("mr").unwrap_or_default();
+                            if mr_tmpl.is_empty() {
+                                format!("Closes #{}", issue.iid)
+                            } else {
+                                format!("Closes #{}\n\n{}", issue.iid, mr_tmpl)
+                            }
+                        };
+
+                        app.edit_menu = Some(crate::app::EditMenu {
+                            title: format!("Create {} from #{}", pr_suffix, issue.iid),
+                            fields: vec![
+                                ("Title".to_string(), title_val),
+                                ("Source Branch".to_string(), source_branch_val),
+                                (
+                                    "Target Branch".to_string(),
+                                    get_default_branch().unwrap_or_else(|| "main".to_string()),
+                                ),
+                                ("Labels".to_string(), labels_val),
+                                ("Assignees".to_string(), assignees_val),
+                                ("Reviewers".to_string(), String::new()),
+                                ("Milestone".to_string(), milestone_val),
+                                ("Status (Draft/Ready)".to_string(), "Draft".to_string()),
+                                ("Description".to_string(), description_val),
+                            ],
+                            selected_idx: 0,
+                            entity_iid: issue.iid,
+                            entity_type: "new_mr".to_string(),
+                            state: {
+                                let mut s = ListState::default();
+                                s.select(Some(0));
+                                s
+                            },
+                        });
                     }
                 }
             }

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -633,6 +633,11 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
                 action: "Open selected Issue in browser",
             },
             Shortcut {
+                category: "Issues",
+                key: d(format!("{}", app.config.keybindings.issues.create_mr)),
+                action: "Create Merge Request from selected Issue",
+            },
+            Shortcut {
                 category: "Merge Requests",
                 key: d(format!("{}", app.config.keybindings.mrs.create_mr)),
                 action: "Create new Merge Request",


### PR DESCRIPTION
Closes #185

When an issue is selected in the Issues tab, pressing the configured keybinding (default: `m`) opens an EditMenu pre-filled with the issue's data, allowing the user to create a merge/pull request directly without switching to the MRs tab first.

The source branch is auto-generated from the issue IID and slugified title, labels/assignees/milestone/description are pre-populated, and the description includes a 'Closes #N' reference to the original issue.

## Changes
- **`src/config.rs`**: Added `create_mr` field to `KeybindingIssues` with default `"m"`, plus config template entry
- **`src/handlers/tabs.rs`**: Added handler for `create_mr` keybinding on Issues tab — builds the MR EditMenu pre-filled from the selected issue
- **`src/ui/overlays.rs`**: Added help shortcut entry for the new keybinding