### PR TITLE
feat: add bulk editing for issues and merge requests (#215)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1788,6 +1788,8 @@ pub struct App {
     pub detail_scroll: u16,
     pub selected_pipelines: std::collections::HashSet<u64>,
     pub selected_jobs: std::collections::HashSet<u64>,
+    pub selected_issues: std::collections::HashSet<u64>,
+    pub selected_mrs: std::collections::HashSet<u64>,
     pub details_zoomed: bool,
     pub detail_visible: bool,
     pub job_trace_needs_scroll_to_bottom: bool,
@@ -1875,6 +1877,8 @@ impl Default for App {
             detail_scroll: 0,
             selected_pipelines: std::collections::HashSet::new(),
             selected_jobs: std::collections::HashSet::new(),
+            selected_issues: std::collections::HashSet::new(),
+            selected_mrs: std::collections::HashSet::new(),
             details_zoomed: false,
             detail_visible: false,
             job_trace_needs_scroll_to_bottom: false,
@@ -2158,6 +2162,8 @@ impl App {
         self.active_tab = tabs[next_index];
         self.selected_pipelines.clear();
         self.selected_jobs.clear();
+        self.selected_issues.clear();
+        self.selected_mrs.clear();
         self.details_zoomed = false;
         self.detail_visible = false;
         self.update_filter_selection();
@@ -2177,6 +2183,8 @@ impl App {
         self.active_tab = tabs[prev_index];
         self.selected_pipelines.clear();
         self.selected_jobs.clear();
+        self.selected_issues.clear();
+        self.selected_mrs.clear();
         self.details_zoomed = false;
         self.detail_visible = false;
         self.update_filter_selection();

--- a/src/config.rs
+++ b/src/config.rs
@@ -668,6 +668,8 @@ pub struct KeybindingIssues {
     pub reopen_entity: String,
     #[serde(default = "def_delete_entity")]
     pub delete_entity: String,
+    #[serde(default)]
+    pub select_issue: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -692,6 +694,8 @@ pub struct KeybindingMrs {
     pub reopen_entity: String,
     #[serde(default = "def_delete_entity")]
     pub delete_entity: String,
+    #[serde(default)]
+    pub select_mr: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -847,11 +851,13 @@ keybind_defaults! {
     def_scroll_up = "K",
     def_save_view = "s",
     def_create_issue = "n",
+    def_select_issue = "Space",
     def_edit_entity = "e",
     def_close_entity = "c",
     def_reopen_entity = "r",
     def_delete_entity = "d",
     def_create_mr = "n",
+    def_select_mr = "Space",
     def_approve_mr = "a",
     def_merge_mr = "m",
     def_toggle_draft = "s",
@@ -918,6 +924,7 @@ impl Default for KeybindingIssues {
             close_entity: def_close_entity(),
             reopen_entity: def_reopen_entity(),
             delete_entity: def_delete_entity(),
+            select_issue: def_select_issue(),
         }
     }
 }
@@ -935,6 +942,7 @@ impl Default for KeybindingMrs {
             close_entity: def_close_entity(),
             reopen_entity: def_reopen_entity(),
             delete_entity: def_delete_entity(),
+            select_mr: def_select_mr(),
         }
     }
 }
@@ -1207,6 +1215,7 @@ save_view = "s"
 
 [keybindings.issues]
 create_issue = "n"
+select_issue = "Space"
 edit_entity = "e"
 close_entity = "c"
 reopen_entity = "r"
@@ -1214,6 +1223,7 @@ delete_entity = "d"
 
 [keybindings.mrs]
 create_mr = "n"
+select_mr = "Space"
 approve_mr = "a"
 merge_mr = "m"
 toggle_draft = "s"

--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -421,6 +421,122 @@ impl GitlabClient {
     pub async fn open_milestone_in_browser(&self, project: &str, id: &str) -> Result<()> {
         self.backend.open_milestone_in_browser(project, id).await
     }
+
+    pub async fn bulk_update_issues_labels(
+        &self,
+        project: &str,
+        iids: &[u64],
+        labels: &str,
+    ) -> Result<()> {
+        if labels.trim().is_empty() {
+            return Ok(());
+        }
+        let add: Vec<String> = labels
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        for &iid in iids {
+            self.backend
+                .update_issue_labels(project, iid, &add, &[])
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn bulk_update_issues_assignees(
+        &self,
+        project: &str,
+        iids: &[u64],
+        assignees: &str,
+    ) -> Result<()> {
+        if assignees.trim().is_empty() {
+            return Ok(());
+        }
+        let add: Vec<String> = assignees
+            .split(',')
+            .map(|s| s.trim().trim_start_matches('@').to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        for &iid in iids {
+            self.backend
+                .update_issue_assignees(project, iid, &add, &[])
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn bulk_update_issues_milestone(
+        &self,
+        project: &str,
+        iids: &[u64],
+        milestone: &str,
+    ) -> Result<()> {
+        for &iid in iids {
+            self.backend
+                .update_issue_milestone(project, iid, milestone)
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn bulk_update_mrs_labels(
+        &self,
+        project: &str,
+        iids: &[u64],
+        labels: &str,
+    ) -> Result<()> {
+        if labels.trim().is_empty() {
+            return Ok(());
+        }
+        let add: Vec<String> = labels
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        for &iid in iids {
+            self.backend
+                .update_mr_labels(project, iid, &add, &[])
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn bulk_update_mrs_assignees(
+        &self,
+        project: &str,
+        iids: &[u64],
+        assignees: &str,
+    ) -> Result<()> {
+        if assignees.trim().is_empty() {
+            return Ok(());
+        }
+        let add: Vec<String> = assignees
+            .split(',')
+            .map(|s| s.trim().trim_start_matches('@').to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        for &iid in iids {
+            self.backend
+                .update_mr_assignees(project, iid, &add, &[])
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn bulk_update_mrs_milestone(
+        &self,
+        project: &str,
+        iids: &[u64],
+        milestone: &str,
+    ) -> Result<()> {
+        for &iid in iids {
+            self.backend
+                .update_mr_milestone(project, iid, milestone)
+                .await?;
+        }
+        Ok(())
+    }
 }
 
 impl Clone for GitlabClient {

--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -472,6 +472,9 @@ impl GitlabClient {
         iids: &[u64],
         milestone: &str,
     ) -> Result<()> {
+        if milestone.trim().is_empty() {
+            return Ok(());
+        }
         for &iid in iids {
             self.backend
                 .update_issue_milestone(project, iid, milestone)
@@ -530,6 +533,9 @@ impl GitlabClient {
         iids: &[u64],
         milestone: &str,
     ) -> Result<()> {
+        if milestone.trim().is_empty() {
+            return Ok(());
+        }
         for &iid in iids {
             self.backend
                 .update_mr_milestone(project, iid, milestone)

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -342,7 +342,7 @@ pub async fn handle_active_tab_key(
                         }
                     }
                 }
-            } else if keybinding_matches(&app.config.keybindings.mrs.edit_entity, key_event) && {
+            } else if keybinding_matches(&app.config.keybindings.mrs.edit_entity, key_event) {
                 let cursor_iid = app
                     .mrs
                     .state
@@ -351,26 +351,93 @@ pub async fn handle_active_tab_key(
                 if let Some(iid) = cursor_iid {
                     app.selected_mrs.insert(iid);
                 }
-                app.selected_mrs.len() > 1
-            } {
-                let count = app.selected_mrs.len();
-                let pr_suffix = if app.is_github() { "PR" } else { "MR" };
-                app.edit_menu = Some(crate::app::EditMenu {
-                    title: format!("Bulk Edit {} {}s", count, pr_suffix),
-                    fields: vec![
-                        ("Labels".to_string(), String::new()),
-                        ("Assignees".to_string(), String::new()),
-                        ("Milestone".to_string(), String::new()),
-                    ],
-                    selected_idx: 0,
-                    entity_iid: 0,
-                    entity_type: "new_bulk_edit_mrs".to_string(),
-                    state: {
-                        let mut s = ListState::default();
-                        s.select(Some(0));
-                        s
-                    },
-                });
+                if app.selected_mrs.len() > 1 {
+                    let count = app.selected_mrs.len();
+                    let pr_suffix = if app.is_github() { "PR" } else { "MR" };
+                    app.edit_menu = Some(crate::app::EditMenu {
+                        title: format!("Bulk Edit {} {}s", count, pr_suffix),
+                        fields: vec![
+                            ("Labels".to_string(), String::new()),
+                            ("Assignees".to_string(), String::new()),
+                            ("Milestone".to_string(), String::new()),
+                        ],
+                        selected_idx: 0,
+                        entity_iid: 0,
+                        entity_type: "new_bulk_edit_mrs".to_string(),
+                        state: {
+                            let mut s = ListState::default();
+                            s.select(Some(0));
+                            s
+                        },
+                    });
+                } else if let Some(selected_idx) = app.mrs.state.selected() {
+                    let filtered = app.filtered_mrs();
+                    if let Some(mr) = filtered.get(selected_idx) {
+                        let labels = if mr.labels.is_empty() {
+                            "None".to_string()
+                        } else {
+                            mr.labels.join(", ")
+                        };
+                        let milestone = mr
+                            .milestone
+                            .as_ref()
+                            .map(|m| m.title.clone())
+                            .unwrap_or_else(|| "None".to_string());
+                        let assignees = if mr.assignees.is_empty() {
+                            "None".to_string()
+                        } else {
+                            mr.assignees
+                                .iter()
+                                .map(|a| format!("@{}", a.username))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        };
+                        let reviewers = if mr.reviewers.is_empty() {
+                            "None".to_string()
+                        } else {
+                            mr.reviewers
+                                .iter()
+                                .map(|r| format!("@{}", r.username))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        };
+                        let draft_status = if mr.draft { "Draft" } else { "Ready" };
+                        let pr_suffix = if app
+                            .gitlab_client
+                            .as_ref()
+                            .map(|c| c.is_github)
+                            .unwrap_or(false)
+                        {
+                            "PR"
+                        } else {
+                            "MR"
+                        };
+                        app.edit_menu = Some(crate::app::EditMenu {
+                            title: format!("Edit {} #{}", pr_suffix, mr.iid),
+                            fields: vec![
+                                ("Title".to_string(), mr.title.clone()),
+                                ("Labels".to_string(), labels),
+                                ("Assignees".to_string(), assignees),
+                                ("Reviewers".to_string(), reviewers),
+                                ("Milestone".to_string(), milestone),
+                                ("Target Branch".to_string(), mr.target_branch.clone()),
+                                ("Status (Draft/Ready)".to_string(), draft_status.to_string()),
+                                (
+                                    "Description".to_string(),
+                                    mr.description.clone().unwrap_or_default(),
+                                ),
+                            ],
+                            selected_idx: 0,
+                            entity_iid: mr.iid,
+                            entity_type: "mr".to_string(),
+                            state: {
+                                let mut s = ListState::default();
+                                s.select(Some(0));
+                                s
+                            },
+                        });
+                    }
+                }
             } else if let Some(selected_idx) = app.mrs.state.selected() {
                 let filtered = app.filtered_mrs();
                 let mr_ref = filtered.get(selected_idx);
@@ -378,75 +445,6 @@ pub async fn handle_active_tab_key(
                     let mr_iid = mr.iid;
                     let mr_title = mr.title.clone();
                     match key_event.code {
-                        _ if keybinding_matches(
-                            &app.config.keybindings.mrs.edit_entity,
-                            key_event,
-                        ) =>
-                        {
-                            let labels = if mr.labels.is_empty() {
-                                "None".to_string()
-                            } else {
-                                mr.labels.join(", ")
-                            };
-                            let milestone = mr
-                                .milestone
-                                .as_ref()
-                                .map(|m| m.title.clone())
-                                .unwrap_or_else(|| "None".to_string());
-                            let assignees = if mr.assignees.is_empty() {
-                                "None".to_string()
-                            } else {
-                                mr.assignees
-                                    .iter()
-                                    .map(|a| format!("@{}", a.username))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            };
-                            let reviewers = if mr.reviewers.is_empty() {
-                                "None".to_string()
-                            } else {
-                                mr.reviewers
-                                    .iter()
-                                    .map(|r| format!("@{}", r.username))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            };
-                            let draft_status = if mr.draft { "Draft" } else { "Ready" };
-                            let pr_suffix = if app
-                                .gitlab_client
-                                .as_ref()
-                                .map(|c| c.is_github)
-                                .unwrap_or(false)
-                            {
-                                "PR"
-                            } else {
-                                "MR"
-                            };
-                            app.edit_menu = Some(crate::app::EditMenu {
-                                title: format!("Edit {} #{}", pr_suffix, mr.iid),
-                                fields: vec![
-                                    ("Title".to_string(), mr.title.clone()),
-                                    ("Labels".to_string(), labels),
-                                    ("Assignees".to_string(), assignees),
-                                    ("Reviewers".to_string(), reviewers),
-                                    ("Milestone".to_string(), milestone),
-                                    ("Target Branch".to_string(), mr.target_branch.clone()),
-                                    ("Status (Draft/Ready)".to_string(), draft_status.to_string()),
-                                    (
-                                        "Description".to_string(),
-                                        mr.description.clone().unwrap_or_default(),
-                                    ),
-                                ],
-                                selected_idx: 0,
-                                entity_iid: mr.iid,
-                                entity_type: "mr".to_string(),
-                                state: {
-                                    let mut s = ListState::default();
-                                    s.select(Some(0));
-                                    s
-                                },
-                            });
-                        }
                         _ if keybinding_matches(
                             &app.config.keybindings.mrs.approve_mr,
                             key_event,

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -1698,7 +1698,16 @@ pub async fn handle_active_tab_key(
             }
 
             KeyCode::Esc | KeyCode::Backspace => {
-                if app.job_trace_loading {
+                let has_selections = !app.selected_issues.is_empty()
+                    || !app.selected_mrs.is_empty()
+                    || !app.selected_pipelines.is_empty()
+                    || !app.selected_jobs.is_empty();
+                if has_selections {
+                    app.selected_issues.clear();
+                    app.selected_mrs.clear();
+                    app.selected_pipelines.clear();
+                    app.selected_jobs.clear();
+                } else if app.job_trace_loading {
                     app.job_trace_loading = false;
                 } else if app.details_zoomed {
                     app.details_zoomed = false;

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -47,6 +47,14 @@ pub async fn handle_active_tab_key(
                 });
             }
             _ if keybinding_matches(&app.config.keybindings.issues.edit_entity, key_event) => {
+                let cursor_iid = app
+                    .issues
+                    .state
+                    .selected()
+                    .and_then(|idx| app.filtered_issues().get(idx).map(|i| i.iid));
+                if let Some(iid) = cursor_iid {
+                    app.selected_issues.insert(iid);
+                }
                 if app.selected_issues.len() > 1 {
                     let count = app.selected_issues.len();
                     app.edit_menu = Some(crate::app::EditMenu {
@@ -334,9 +342,17 @@ pub async fn handle_active_tab_key(
                         }
                     }
                 }
-            } else if keybinding_matches(&app.config.keybindings.mrs.edit_entity, key_event)
-                && app.selected_mrs.len() > 1
-            {
+            } else if keybinding_matches(&app.config.keybindings.mrs.edit_entity, key_event) && {
+                let cursor_iid = app
+                    .mrs
+                    .state
+                    .selected()
+                    .and_then(|idx| app.filtered_mrs().get(idx).map(|m| m.iid));
+                if let Some(iid) = cursor_iid {
+                    app.selected_mrs.insert(iid);
+                }
+                app.selected_mrs.len() > 1
+            } {
                 let count = app.selected_mrs.len();
                 let pr_suffix = if app.is_github() { "PR" } else { "MR" };
                 app.edit_menu = Some(crate::app::EditMenu {

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -45,7 +45,25 @@ pub async fn handle_active_tab_key(
                 });
             }
             _ if keybinding_matches(&app.config.keybindings.issues.edit_entity, key_event) => {
-                if let Some(selected_idx) = app.issues.state.selected() {
+                if app.selected_issues.len() > 1 {
+                    let count = app.selected_issues.len();
+                    app.edit_menu = Some(crate::app::EditMenu {
+                        title: format!("Bulk Edit {} Issues", count),
+                        fields: vec![
+                            ("Labels".to_string(), String::new()),
+                            ("Assignees".to_string(), String::new()),
+                            ("Milestone".to_string(), String::new()),
+                        ],
+                        selected_idx: 0,
+                        entity_iid: 0,
+                        entity_type: "new_bulk_edit_issues".to_string(),
+                        state: {
+                            let mut s = ListState::default();
+                            s.select(Some(0));
+                            s
+                        },
+                    });
+                } else if let Some(selected_idx) = app.issues.state.selected() {
                     let filtered = app.filtered_issues();
                     if let Some(issue) = filtered.get(selected_idx) {
                         let labels = if issue.labels.is_empty() {
@@ -219,6 +237,38 @@ pub async fn handle_active_tab_key(
                         );
                     }
                 }
+            } else if keybinding_matches(&app.config.keybindings.mrs.select_mr, key_event) {
+                if let Some(selected_idx) = app.mrs.state.selected() {
+                    let iid = app.filtered_mrs().get(selected_idx).map(|m| m.iid);
+                    if let Some(iid) = iid {
+                        if app.selected_mrs.contains(&iid) {
+                            app.selected_mrs.remove(&iid);
+                        } else {
+                            app.selected_mrs.insert(iid);
+                        }
+                    }
+                }
+            } else if keybinding_matches(&app.config.keybindings.mrs.edit_entity, key_event)
+                && app.selected_mrs.len() > 1
+            {
+                let count = app.selected_mrs.len();
+                let pr_suffix = if app.is_github() { "PR" } else { "MR" };
+                app.edit_menu = Some(crate::app::EditMenu {
+                    title: format!("Bulk Edit {} {}s", count, pr_suffix),
+                    fields: vec![
+                        ("Labels".to_string(), String::new()),
+                        ("Assignees".to_string(), String::new()),
+                        ("Milestone".to_string(), String::new()),
+                    ],
+                    selected_idx: 0,
+                    entity_iid: 0,
+                    entity_type: "new_bulk_edit_mrs".to_string(),
+                    state: {
+                        let mut s = ListState::default();
+                        s.select(Some(0));
+                        s
+                    },
+                });
             } else if let Some(selected_idx) = app.mrs.state.selected() {
                 let filtered = app.filtered_mrs();
                 let mr_ref = filtered.get(selected_idx);
@@ -544,6 +594,22 @@ pub async fn handle_active_tab_key(
                                         result.map_err(|e| e.to_string()),
                                     ));
                                 });
+                            }
+                        }
+                        _ if keybinding_matches(
+                            &app.config.keybindings.issues.select_issue,
+                            key_event,
+                        ) =>
+                        {
+                            if let Some(selected_idx) = app.issues.state.selected() {
+                                let iid = app.filtered_issues().get(selected_idx).map(|i| i.iid);
+                                if let Some(iid) = iid {
+                                    if app.selected_issues.contains(&iid) {
+                                        app.selected_issues.remove(&iid);
+                                    } else {
+                                        app.selected_issues.insert(iid);
+                                    }
+                                }
                             }
                         }
                         _ => handled = false,

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -187,6 +187,18 @@ pub async fn handle_active_tab_key(
                     }
                 }
             }
+            _ if keybinding_matches(&app.config.keybindings.issues.select_issue, key_event) => {
+                if let Some(selected_idx) = app.issues.state.selected() {
+                    let iid = app.filtered_issues().get(selected_idx).map(|i| i.iid);
+                    if let Some(iid) = iid {
+                        if app.selected_issues.contains(&iid) {
+                            app.selected_issues.remove(&iid);
+                        } else {
+                            app.selected_issues.insert(iid);
+                        }
+                    }
+                }
+            }
             _ => handled = false,
         },
         crate::app::Tab::MergeRequests => {
@@ -594,22 +606,6 @@ pub async fn handle_active_tab_key(
                                         result.map_err(|e| e.to_string()),
                                     ));
                                 });
-                            }
-                        }
-                        _ if keybinding_matches(
-                            &app.config.keybindings.issues.select_issue,
-                            key_event,
-                        ) =>
-                        {
-                            if let Some(selected_idx) = app.issues.state.selected() {
-                                let iid = app.filtered_issues().get(selected_idx).map(|i| i.iid);
-                                if let Some(iid) = iid {
-                                    if app.selected_issues.contains(&iid) {
-                                        app.selected_issues.remove(&iid);
-                                    } else {
-                                        app.selected_issues.insert(iid);
-                                    }
-                                }
                             }
                         }
                         _ => handled = false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3601,6 +3601,14 @@ async fn main() -> Result<()> {
                                             .map(|(_, v)| v.trim().to_string())
                                             .unwrap_or_default();
 
+                                        if labels.is_empty()
+                                            && assignees.is_empty()
+                                            && milestone.is_empty()
+                                        {
+                                            app.edit_menu = None;
+                                            continue;
+                                        }
+
                                         let selected: Vec<u64> =
                                             app.selected_issues.iter().copied().collect();
                                         app.edit_menu = None;
@@ -3674,6 +3682,14 @@ async fn main() -> Result<()> {
                                             .find(|(k, _)| k == "Milestone")
                                             .map(|(_, v)| v.trim().to_string())
                                             .unwrap_or_default();
+
+                                        if labels.is_empty()
+                                            && assignees.is_empty()
+                                            && milestone.is_empty()
+                                        {
+                                            app.edit_menu = None;
+                                            continue;
+                                        }
 
                                         let selected: Vec<u64> =
                                             app.selected_mrs.iter().copied().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3581,6 +3581,154 @@ async fn main() -> Result<()> {
                                             }
                                         });
                                         continue;
+                                    } else if entity_type == "new_bulk_edit_issues" {
+                                        let labels = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Labels")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let assignees = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Assignees")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let milestone = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Milestone")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+
+                                        let selected: Vec<u64> =
+                                            app.selected_issues.iter().copied().collect();
+                                        app.edit_menu = None;
+                                        app.selected_issues.clear();
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project = app.project_context.clone();
+                                        let tx = events.sender();
+                                        let tab = app.active_tab;
+                                        tokio::spawn(async move {
+                                            if !labels.is_empty() {
+                                                if let Err(e) = client
+                                                    .bulk_update_issues_labels(
+                                                        &project, &selected, &labels,
+                                                    )
+                                                    .await
+                                                {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                    return;
+                                                }
+                                            }
+                                            if !assignees.is_empty() {
+                                                if let Err(e) = client
+                                                    .bulk_update_issues_assignees(
+                                                        &project, &selected, &assignees,
+                                                    )
+                                                    .await
+                                                {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                    return;
+                                                }
+                                            }
+                                            if !milestone.is_empty() {
+                                                if let Err(e) = client
+                                                    .bulk_update_issues_milestone(
+                                                        &project, &selected, &milestone,
+                                                    )
+                                                    .await
+                                                {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                    return;
+                                                }
+                                            }
+                                            let _ = tx.send(Event::CommandCompleted(tab, Ok(())));
+                                        });
+                                        continue;
+                                    } else if entity_type == "new_bulk_edit_mrs" {
+                                        let labels = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Labels")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let assignees = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Assignees")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+                                        let milestone = menu
+                                            .fields
+                                            .iter()
+                                            .find(|(k, _)| k == "Milestone")
+                                            .map(|(_, v)| v.trim().to_string())
+                                            .unwrap_or_default();
+
+                                        let selected: Vec<u64> =
+                                            app.selected_mrs.iter().copied().collect();
+                                        app.edit_menu = None;
+                                        app.selected_mrs.clear();
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project = app.project_context.clone();
+                                        let tx = events.sender();
+                                        let tab = app.active_tab;
+                                        tokio::spawn(async move {
+                                            if !labels.is_empty() {
+                                                if let Err(e) = client
+                                                    .bulk_update_mrs_labels(
+                                                        &project, &selected, &labels,
+                                                    )
+                                                    .await
+                                                {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                    return;
+                                                }
+                                            }
+                                            if !assignees.is_empty() {
+                                                if let Err(e) = client
+                                                    .bulk_update_mrs_assignees(
+                                                        &project, &selected, &assignees,
+                                                    )
+                                                    .await
+                                                {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                    return;
+                                                }
+                                            }
+                                            if !milestone.is_empty() {
+                                                if let Err(e) = client
+                                                    .bulk_update_mrs_milestone(
+                                                        &project, &selected, &milestone,
+                                                    )
+                                                    .await
+                                                {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                    return;
+                                                }
+                                            }
+                                            let _ = tx.send(Event::CommandCompleted(tab, Ok(())));
+                                        });
+                                        continue;
                                     } else if entity_type == "new_milestone" {
                                         let title = menu
                                             .fields

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -609,6 +609,11 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             },
             Shortcut {
                 category: "Issues",
+                key: d(format!("{}", app.config.keybindings.issues.select_issue)),
+                action: "Toggle issue selection (bulk edit with e)",
+            },
+            Shortcut {
+                category: "Issues",
                 key: d(format!("{}", app.config.keybindings.issues.edit_entity)),
                 action: "Open parameter edit menu",
             },
@@ -636,6 +641,11 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
                 category: "Merge Requests",
                 key: d(format!("{}", app.config.keybindings.mrs.create_mr)),
                 action: "Create new Merge Request",
+            },
+            Shortcut {
+                category: "Merge Requests",
+                key: d(format!("{}", app.config.keybindings.mrs.select_mr)),
+                action: "Toggle MR/PR selection (bulk edit with e)",
             },
             Shortcut {
                 category: "Merge Requests",

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -776,6 +776,8 @@ pub(crate) fn render_tab_merge_requests(
                         };
                         let bg = if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             pipe_bg
                         };
@@ -783,7 +785,7 @@ pub(crate) fn render_tab_merge_requests(
                             &pipe_text,
                             &app.search_query,
                             is_selected,
-                            false,
+                            is_checked,
                             Style::default()
                                 .fg(pipe_color)
                                 .bg(bg)
@@ -795,7 +797,7 @@ pub(crate) fn render_tab_merge_requests(
                             &stages_dots,
                             &app.search_query,
                             is_selected,
-                            false,
+                            is_checked,
                             Style::default().fg(THEME.read().unwrap().text_normal),
                             Alignment::Left,
                         ));
@@ -805,7 +807,7 @@ pub(crate) fn render_tab_merge_requests(
                         "—",
                         &app.search_query,
                         is_selected,
-                        false,
+                        is_checked,
                         Style::default().fg(THEME.read().unwrap().text_muted),
                         Alignment::Center,
                     ));
@@ -821,7 +823,7 @@ pub(crate) fn render_tab_merge_requests(
                     &truncate(&mr_milestone_str, 18),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().yellow),
                     Alignment::Left,
                 ));
@@ -832,7 +834,7 @@ pub(crate) fn render_tab_merge_requests(
                     &truncate(&author_str, 15),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().blue),
                     Alignment::Left,
                 ));

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -83,6 +83,7 @@ pub(crate) fn render_tab_issues(
 
         let rows = filtered_issues.iter().enumerate().map(|(idx, i)| {
             let is_selected = app.issues.state.selected() == Some(idx);
+            let is_checked = app.selected_issues.contains(&i.iid);
             let (state_text, state_style) = if i.state == "opened" {
                 (
                     format!("{} OPEN", icons.state_open),
@@ -90,6 +91,8 @@ pub(crate) fn render_tab_issues(
                         .fg(THEME.read().unwrap().green)
                         .bg(if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             THEME.read().unwrap().green_bg
                         })
@@ -102,6 +105,8 @@ pub(crate) fn render_tab_issues(
                         .fg(THEME.read().unwrap().red)
                         .bg(if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             THEME.read().unwrap().red_bg
                         })
@@ -124,7 +129,7 @@ pub(crate) fn render_tab_issues(
                     &state_text,
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     state_style,
                     Alignment::Center,
                 ));
@@ -134,7 +139,7 @@ pub(crate) fn render_tab_issues(
                     &truncate(&i.title, 100),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().text_normal),
                     Alignment::Left,
                 ));
@@ -153,7 +158,7 @@ pub(crate) fn render_tab_issues(
                     &truncate(&assignees_str, 20),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().blue),
                     Alignment::Left,
                 ));
@@ -163,7 +168,7 @@ pub(crate) fn render_tab_issues(
                     &i.labels,
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     24,
                 ));
             }
@@ -177,7 +182,7 @@ pub(crate) fn render_tab_issues(
                     &truncate(&milestone_str, 18),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().yellow),
                     Alignment::Left,
                 ));
@@ -188,7 +193,7 @@ pub(crate) fn render_tab_issues(
                     due_str,
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().yellow),
                     Alignment::Left,
                 ));
@@ -199,13 +204,15 @@ pub(crate) fn render_tab_issues(
                     &truncate(&author_str, 15),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().blue),
                     Alignment::Left,
                 ));
             }
             let row_style = if is_selected {
                 Style::default().bg(THEME.read().unwrap().highlight_bg)
+            } else if is_checked {
+                Style::default().bg(THEME.read().unwrap().checked_bg)
             } else {
                 Style::default()
             };
@@ -525,6 +532,7 @@ pub(crate) fn render_tab_merge_requests(
 
         let rows = filtered_mrs.iter().enumerate().map(|(idx, m)| {
             let is_selected = app.mrs.state.selected() == Some(idx);
+            let is_checked = app.selected_mrs.contains(&m.iid);
             let (prefix, clean_title) = crate::utils::format::parse_mr_title_prefix(&m.title);
 
             let (state_text, state_style) = if m.state == "opened" {
@@ -534,6 +542,8 @@ pub(crate) fn render_tab_merge_requests(
                         .fg(THEME.read().unwrap().green)
                         .bg(if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             THEME.read().unwrap().green_bg
                         })
@@ -546,6 +556,8 @@ pub(crate) fn render_tab_merge_requests(
                         .fg(THEME.read().unwrap().purple)
                         .bg(if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             THEME.read().unwrap().purple_bg
                         })
@@ -558,6 +570,8 @@ pub(crate) fn render_tab_merge_requests(
                         .fg(THEME.read().unwrap().red)
                         .bg(if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             THEME.read().unwrap().red_bg
                         })
@@ -572,6 +586,8 @@ pub(crate) fn render_tab_merge_requests(
                         .fg(THEME.read().unwrap().yellow)
                         .bg(if is_selected {
                             THEME.read().unwrap().highlight_bg
+                        } else if is_checked {
+                            THEME.read().unwrap().checked_bg
                         } else {
                             THEME.read().unwrap().yellow_bg
                         })
@@ -586,6 +602,8 @@ pub(crate) fn render_tab_merge_requests(
                             .fg(THEME.read().unwrap().yellow)
                             .bg(if is_selected {
                                 THEME.read().unwrap().highlight_bg
+                            } else if is_checked {
+                                THEME.read().unwrap().checked_bg
                             } else {
                                 THEME.read().unwrap().yellow_bg
                             })
@@ -598,6 +616,8 @@ pub(crate) fn render_tab_merge_requests(
                             .fg(THEME.read().unwrap().green)
                             .bg(if is_selected {
                                 THEME.read().unwrap().highlight_bg
+                            } else if is_checked {
+                                THEME.read().unwrap().checked_bg
                             } else {
                                 THEME.read().unwrap().green_bg
                             })
@@ -622,7 +642,7 @@ pub(crate) fn render_tab_merge_requests(
                     &state_text,
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     state_style,
                     Alignment::Center,
                 ));
@@ -632,7 +652,7 @@ pub(crate) fn render_tab_merge_requests(
                     &status_styled,
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     status_style,
                     Alignment::Center,
                 ));
@@ -642,7 +662,7 @@ pub(crate) fn render_tab_merge_requests(
                     &truncate(&clean_title, 100),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().text_normal),
                     Alignment::Left,
                 ));
@@ -661,7 +681,7 @@ pub(crate) fn render_tab_merge_requests(
                     &truncate(&assignees_str, 20),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().blue),
                     Alignment::Left,
                 ));
@@ -680,7 +700,7 @@ pub(crate) fn render_tab_merge_requests(
                     &truncate(&reviewers_str, 20),
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     Style::default().fg(THEME.read().unwrap().blue),
                     Alignment::Left,
                 ));
@@ -690,7 +710,7 @@ pub(crate) fn render_tab_merge_requests(
                     &m.labels,
                     &app.search_query,
                     is_selected,
-                    false,
+                    is_checked,
                     24,
                 ));
             }
@@ -819,6 +839,8 @@ pub(crate) fn render_tab_merge_requests(
             }
             let row_style = if is_selected {
                 Style::default().bg(THEME.read().unwrap().highlight_bg)
+            } else if is_checked {
+                Style::default().bg(THEME.read().unwrap().checked_bg)
             } else {
                 Style::default()
             };


### PR DESCRIPTION
Closes #215

Users can now select multiple issues or MRs via **Space** (configurable as `select_issue` / `select_mr`) and press **e** to bulk edit their labels, assignees, and milestone.

## How it works

1. Press `Space` on items in the Issues or MRs tab to toggle selection — selected rows highlight with the `checked_bg` theme color
2. With 2+ items selected, press `e` to open a bulk edit form with fields: **Labels**, **Assignees**, **Milestone**
3. Edit fields using the same selector-based UI (multi-select for labels/assignees, single-select for milestone)
4. Submit to apply changes to all selected items at once

## Design decisions

- Single-edit flow is preserved: `e` still opens the regular edit menu when 0-1 items are selected
- Empty fields mean "no change" — only filled fields are applied
- Labels/assignees are additive (existing labels are preserved, new ones are added)
- Selection state is per-tab and cleared on tab switch (same pattern as pipelines/jobs)
- Backend methods iterate over selected IIDs individually — no new backend trait methods needed

## Changes
- **`src/app.rs`**: Add `selected_issues` + `selected_mrs` `HashSet` fields, cleared on tab switch
- **`src/config.rs`**: Add `select_issue` + `select_mr` keybindings (default: Space)  
- **`src/domain/client.rs`**: Add 6 `bulk_update_*` methods for labels/assignees/milestone on issues and MRs
- **`src/handlers/tabs.rs`**: Space toggles selection; `e` opens bulk edit when 2+ items selected
- **`src/main.rs`**: Submit handlers for `new_bulk_edit_issues` / `new_bulk_edit_mrs` entity types
- **`src/ui/overlays.rs`**: Help entries for select keybindings
- **`src/ui/tabs.rs`**: Checkbox rendering with `checked_bg` for selected rows in Issues + MRs tabs