### PR TITLE
fix: milestone issue cache staleness and GH branch metadata correctness

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -1860,21 +1860,32 @@ impl Backend for GhBackend {
         struct GhBrCommit {
             sha: String,
         }
-        let gh_branches: Vec<GhBr> = serde_json::from_str(&raw)?;
-        let mut branches: Vec<Branch> = gh_branches
+        #[derive(Deserialize)]
+        struct GhRepo {
+            default_branch: String,
+        }
+        let repo_raw = self
+            .raw_api(
+                &format!("/repos/{}", project),
+                "GET",
+                None,
+                "Fetching Repo Info",
+            )
+            .await?;
+        let repo: GhRepo = serde_json::from_str(&repo_raw)?;
+        let default_branch = repo.default_branch;
+
+        let branches: Vec<Branch> = serde_json::from_str::<Vec<GhBr>>(&raw)?
             .into_iter()
             .map(|b| Branch {
-                name: b.name.clone(),
-                default: false,
+                default: b.name == default_branch,
                 protected: b.protected,
-                web_url: String::new(),
+                web_url: format!("https://github.com/{}/tree/{}", project, b.name),
+                name: b.name,
                 can_push: false,
                 commit_sha: b.commit.as_ref().map(|c| c.sha.clone()).unwrap_or_default(),
             })
             .collect();
-        if let Some(first) = branches.first_mut() {
-            first.default = true;
-        }
         Ok(branches)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1200,6 +1200,10 @@ async fn main() -> Result<()> {
                     app.milestones.items = milestones;
                     app.update_filter_selection();
                     app.project_cache.milestones = app.milestones.items.clone();
+                    app.milestone_issues_cache.clear();
+                    app.selected_milestone_issues = None;
+                    app.selected_milestone_iid = None;
+                    app.project_cache.milestone_issues.clear();
                     crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::MilestoneIssuesFetched(iid, issues) => {


### PR DESCRIPTION
## Summary

Fixes two bugs:

### #231 — Milestone metadata not refetching
When milestones are refreshed (auto-refresh or tab switch), the `milestone_issues_cache` was never invalidated. This meant the completed/closed issue counts shown in the Progress column and detail pane remained stale from the initial fetch.

**Fix:** Clear `milestone_issues_cache`, `selected_milestone_issues`, `selected_milestone_iid`, and the cached `milestone_issues` in the project cache when `Event::MilestonesFetched` fires. This forces the issues to be re-fetched for the selected milestone on the next render cycle.

### #171 — GitHub branch metadata incorrect
Three problems in the GH backend's `list_branches`:
1. **default flag** — the first branch in the API response was blindly marked as default, but GitHub returns branches in arbitrary/alphabetical order. The real default is a repo-level property.
2. **web_url** — always empty string — never constructed from branch name.
3. **can_push** — always false (GitHub doesn't expose per-branch push permissions).

**Fix:** Fetch the repo info endpoint (`GET /repos/{owner}/{repo}`) to get `default_branch` and match each branch name against it. Construct proper `web_url` from the project path and branch name.

## Changes
- `src/main.rs`: Clear milestone issues cache on `MilestonesFetched` event
- `src/backend/gh.rs`: Fetch `default_branch` from repo API, construct correct `web_url", remove incorrect first-branch-as-default heuristic