### PR TITLE
feat(cli): add doctor and clean-cache subcommands with clap (#178)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +256,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -591,6 +687,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "clap",
  "crossterm",
  "fuzzy-matcher",
  "libc",
@@ -715,6 +812,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -956,6 +1059,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3.10"
 fuzzy-matcher = "0.3.7"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 async-trait = "0.1.89"
+clap = { version = "4", features = ["derive"] }
 [dev-dependencies]
 libc = "0.2.186"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,19 @@ pub enum Commands {
         #[arg(short = 'n', long)]
         dry_run: bool,
     },
+    /// Print the resolved configuration (merge of global + repo-local overrides)
+    Config,
+    /// List cached data files with sizes
+    Cache,
+    /// Open an entity in the browser without launching the TUI
+    Open {
+        /// Entity type: issue, mr, pr, pipeline, job, milestone
+        entity: String,
+        /// Entity ID (IID for issues/MRs, internal ID for pipelines/jobs)
+        id: String,
+    },
+    /// List recently-used repositories
+    Repos,
 }
 
 pub async fn run_doctor() {
@@ -230,6 +243,155 @@ pub fn run_clean_cache(dry_run: bool) {
     );
 }
 
+pub fn run_config_show() {
+    let config = crate::config::Config::load();
+    match toml::to_string_pretty(&config) {
+        Ok(toml_str) => println!("{}", toml_str),
+        Err(e) => eprintln!("Error serializing config: {}", e),
+    }
+}
+
+pub fn run_cache_list() {
+    let cache_dir = crate::utils::cache::get_cache_dir();
+    if !cache_dir.exists() {
+        println!("Cache directory does not exist: {}", cache_dir.display());
+        return;
+    }
+
+    println!("Cache directory: {}", cache_dir.display());
+    println!();
+
+    let mut entries: Vec<(String, u64, String)> = Vec::new();
+    if let Ok(dir_entries) = std::fs::read_dir(&cache_dir) {
+        for entry in dir_entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !name.ends_with(".json") {
+                continue;
+            }
+            let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            let modified = entry
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| {
+                    let duration = t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+                    chrono::DateTime::from_timestamp(
+                        duration.as_secs() as i64,
+                        duration.subsec_nanos(),
+                    )
+                    .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+                })
+                .unwrap_or_else(|| "unknown".to_string());
+            entries.push((name, size, modified));
+        }
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let total: u64 = entries.iter().map(|(_, s, _)| s).sum();
+    for (name, size, modified) in &entries {
+        if *name == "recent_repos.json" {
+            println!("  {:<40} {:>8} KB  {}", name, size / 1024, modified);
+        } else {
+            println!("  {:<40} {:>8} KB  {}", name, size / 1024, modified);
+        }
+    }
+
+    println!();
+    println!("Total: {} files, {} KB", entries.len(), total / 1024);
+}
+
+pub fn run_open_in_browser(entity: &str, id: &str) {
+    let is_github = detect_github();
+
+    let (program, subcommand) = match entity {
+        "issue" => {
+            if is_github {
+                ("gh", vec!["issue", "view", id, "--web"])
+            } else {
+                ("glab", vec!["issue", "view", id, "-w"])
+            }
+        }
+        "mr" | "pr" => {
+            if is_github {
+                ("gh", vec!["pr", "view", id, "--web"])
+            } else {
+                ("glab", vec!["mr", "view", id, "-w"])
+            }
+        }
+        "pipeline" => {
+            if is_github {
+                ("gh", vec!["run", "view", id, "--web"])
+            } else {
+                ("glab", vec!["ci", "view", id, "-w"])
+            }
+        }
+        "job" => {
+            if is_github {
+                eprintln!("Direct job browser URLs are not supported for GitHub Actions.");
+                return;
+            } else {
+                ("glab", vec!["ci", "view", id, "-w"])
+            }
+        }
+        "milestone" => {
+            if is_github {
+                ("gh", vec!["issue", "list", "--milestone", id, "--web"])
+            } else {
+                ("glab", vec!["milestone", "view", id, "-w"])
+            }
+        }
+        _ => {
+            eprintln!(
+                "Unknown entity '{}'. Valid: issue, mr, pr, pipeline, job, milestone",
+                entity
+            );
+            std::process::exit(1);
+        }
+    };
+
+    println!("Opening {} {} in browser...", entity, id);
+    match Command::new(program).args(&subcommand).spawn() {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Failed to run {}: {}", program, e);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub fn run_repos_list() {
+    println!("Recent repositories:");
+    let recent = crate::utils::cache::get_recent_repos();
+    if recent.is_empty() {
+        println!("  (none)");
+    } else {
+        for (i, r) in recent.iter().enumerate() {
+            let marker = if crate::utils::cache::is_git_repo(r) {
+                "[✓]"
+            } else {
+                "[✗]"
+            };
+            println!("  {} {}", marker, r);
+        }
+    }
+
+    println!();
+    println!("Sibling repositories:");
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let siblings = crate::utils::cache::get_sibling_repos(&cwd);
+    if siblings.is_empty() {
+        println!("  (none)");
+    } else {
+        for s in &siblings {
+            println!("  {}", s);
+        }
+    }
+}
+
 pub async fn run_update() {
     println!("Checking for updates...");
     match crate::utils::update::perform_self_update().await {
@@ -244,5 +406,15 @@ pub async fn run_update() {
             eprintln!("Update failed: {}", e);
             std::process::exit(1);
         }
+    }
+}
+
+fn detect_github() -> bool {
+    match Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+    {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).contains("github.com"),
+        _ => false,
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,8 +75,6 @@ pub enum Commands {
         #[arg(short = 'n', long)]
         dry_run: bool,
     },
-    /// Print the resolved configuration (merge of global + repo-local overrides)
-    Config,
     /// List cached data files with sizes
     Cache,
     /// Open an entity in the browser without launching the TUI
@@ -170,6 +168,23 @@ pub async fn run_doctor() {
                     config_path.display()
                 ),
             );
+        }
+    }
+
+    // Repo-local config paths
+    if let Some(root) = find_git_root() {
+        let repo_configs = [
+            root.join(".glab-tui").join("config.toml"),
+            root.join(".config").join("glab-tui").join("config.toml"),
+        ];
+        for repo_path in &repo_configs {
+            if repo_path.exists() {
+                let size = std::fs::metadata(repo_path).map(|m| m.len()).unwrap_or(0);
+                info(
+                    "      ",
+                    &format!("Repo: {} ({} bytes)", repo_path.display(), size),
+                );
+            }
         }
     }
 
@@ -321,62 +336,6 @@ pub fn run_clean_cache(dry_run: bool) {
         result.kept_repos.len(),
         result.kept_files.len()
     );
-}
-
-pub fn run_config_show() {
-    header("glab-tui config");
-    println!("{}", styled("================", C_CYAN));
-    println!();
-
-    let global_path = crate::config::Config::config_path();
-    let global_exists = global_path.exists();
-
-    // ── Global config ──
-    subheader(&format!("Global: {}", global_path.display()));
-    println!(
-        "{}",
-        styled("----------------------------------------", C_DIM)
-    );
-    if global_exists {
-        match std::fs::read_to_string(&global_path) {
-            Ok(content) => println!("{}", content),
-            Err(e) => {
-                fail("[FAIL]", &format!("Error reading: {}", e));
-            }
-        }
-    } else {
-        info("[INFO]", "(file does not exist — using built-in defaults)");
-    }
-
-    // ── Repo-local configs ──
-    let mut found_repo = false;
-    if let Some(root) = find_git_root() {
-        let repo_configs = [
-            root.join(".glab-tui").join("config.toml"),
-            root.join(".config").join("glab-tui").join("config.toml"),
-        ];
-        for repo_path in &repo_configs {
-            if repo_path.exists() {
-                println!();
-                subheader(&format!("Repo-local: {}", repo_path.display()));
-                println!(
-                    "{}",
-                    styled("----------------------------------------", C_DIM)
-                );
-                match std::fs::read_to_string(repo_path) {
-                    Ok(content) => println!("{}", content),
-                    Err(e) => {
-                        fail("[FAIL]", &format!("Error reading: {}", e));
-                    }
-                }
-                found_repo = true;
-            }
-        }
-    }
-
-    if !global_exists && !found_repo {
-        info("[INFO]", "No config files found — using built-in defaults.");
-    }
 }
 
 fn find_git_root() -> Option<std::path::PathBuf> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,44 @@
 use clap::{Parser, Subcommand};
 use std::process::Command;
 
+// ── ANSI color helpers ──
+const C_RESET: &str = "\x1b[0m";
+const C_BOLD: &str = "\x1b[1m";
+const C_DIM: &str = "\x1b[2m";
+const C_GREEN: &str = "\x1b[32m";
+const C_RED: &str = "\x1b[31m";
+const C_YELLOW: &str = "\x1b[33m";
+const C_BLUE: &str = "\x1b[34m";
+const C_CYAN: &str = "\x1b[36m";
+
+fn styled(text: &str, code: &str) -> String {
+    format!("{}{}{}", code, text, C_RESET)
+}
+
+fn pass(label: &str, detail: &str) {
+    println!(" {} {}", styled(label, C_GREEN), detail);
+}
+
+fn fail(label: &str, detail: &str) {
+    println!(" {} {}", styled(label, C_RED), detail);
+}
+
+fn warn(label: &str, detail: &str) {
+    println!(" {} {}", styled(label, C_YELLOW), detail);
+}
+
+fn info(label: &str, detail: &str) {
+    println!(" {} {}", styled(label, C_DIM), detail);
+}
+
+fn header(text: &str) {
+    println!("{}", styled(text, &format!("{}{}", C_BOLD, C_CYAN)));
+}
+
+fn subheader(text: &str) {
+    println!("{}", styled(text, C_BOLD));
+}
+
 #[derive(Parser)]
 #[command(name = "glab-tui")]
 #[command(about = "GitLab/GitHub terminal user interface")]
@@ -55,19 +93,22 @@ pub enum Commands {
 pub async fn run_doctor() {
     let mut has_backend = false;
 
-    println!("glab-tui doctor");
-    println!("================");
+    header("glab-tui doctor");
+    println!("{}", styled("================", C_CYAN));
     println!();
 
     // ── glab ──
     match Command::new("glab").arg("--version").output() {
         Ok(output) if output.status.success() => {
             let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            println!("[PASS] glab: {}", v);
+            pass("[PASS]", &format!("glab: {}", v));
             has_backend = true;
         }
         _ => {
-            println!("[FAIL] glab not found — install from https://gitlab.com/gitlab-org/cli");
+            fail(
+                "[FAIL]",
+                "glab not found — install from https://gitlab.com/gitlab-org/cli",
+            );
         }
     }
 
@@ -75,11 +116,14 @@ pub async fn run_doctor() {
     match Command::new("gh").arg("--version").output() {
         Ok(output) if output.status.success() => {
             let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            println!("[PASS] gh:   {}", v);
+            pass("[PASS]", &format!("gh:   {}", v));
             has_backend = true;
         }
         _ => {
-            println!("[FAIL] gh not found — install from https://cli.github.com");
+            fail(
+                "[FAIL]",
+                "gh not found — install from https://cli.github.com",
+            );
         }
     }
 
@@ -87,10 +131,10 @@ pub async fn run_doctor() {
     match Command::new("git").arg("--version").output() {
         Ok(output) if output.status.success() => {
             let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            println!("[PASS] git:  {}", v);
+            pass("[PASS]", &format!("git:  {}", v));
         }
         _ => {
-            println!("[FAIL] git not found");
+            fail("[FAIL]", "git not found");
         }
     }
 
@@ -100,22 +144,31 @@ pub async fn run_doctor() {
         Ok(content) => {
             let valid = toml::from_str::<toml::Table>(&content).is_ok();
             if valid {
-                println!(
-                    "[PASS] Config: {} ({} bytes)",
-                    config_path.display(),
-                    content.len()
+                pass(
+                    "[PASS]",
+                    &format!(
+                        "Config: {} ({} bytes)",
+                        config_path.display(),
+                        content.len()
+                    ),
                 );
             } else {
-                println!(
-                    "[WARN] Config file exists but is not valid TOML: {}",
-                    config_path.display()
+                warn(
+                    "[WARN]",
+                    &format!(
+                        "Config file exists but is not valid TOML: {}",
+                        config_path.display()
+                    ),
                 );
             }
         }
         Err(_) => {
-            println!(
-                "[INFO] No config file found at {} (using defaults)",
-                config_path.display()
+            info(
+                "[INFO]",
+                &format!(
+                    "No config file found at {} (using defaults)",
+                    config_path.display()
+                ),
             );
         }
     }
@@ -130,114 +183,141 @@ pub async fn run_doctor() {
             })
             .unwrap_or(0);
         let total_size = crate::utils::cache::get_cache_dir_size();
-        println!(
-            "[PASS] Cache:  {} ({} files, {} KB)",
-            cache_dir.display(),
-            file_count,
-            total_size / 1024
+        pass(
+            "[PASS]",
+            &format!(
+                "Cache:  {} ({} files, {} KB)",
+                cache_dir.display(),
+                file_count,
+                total_size / 1024
+            ),
         );
     } else {
-        println!("[INFO] No cache directory at {}", cache_dir.display());
+        info(
+            "[INFO]",
+            &format!("No cache directory at {}", cache_dir.display()),
+        );
     }
 
     // ── Current repo ──
     println!();
-    println!("Repository context");
-    println!("-------------------");
+    subheader("Repository context");
+    println!("{}", styled("-------------------", C_DIM));
     match crate::domain::client::get_project_context().await {
         Ok(context) => {
-            println!("  Remote:  {}", context);
-            let is_github = match Command::new("git")
-                .args(["remote", "get-url", "origin"])
-                .output()
-            {
-                Ok(o) if o.status.success() => {
-                    String::from_utf8_lossy(&o.stdout).contains("github.com")
-                }
-                _ => false,
+            println!("  Remote:  {}", styled(&context, C_BOLD));
+            let is_github = detect_github();
+            let backend = if is_github {
+                styled("GitHub", C_BLUE)
+            } else {
+                styled("GitLab", C_YELLOW)
             };
-            println!("  Backend: {}", if is_github { "GitHub" } else { "GitLab" });
+            println!("  Backend: {}", backend);
         }
         Err(_) => {
-            println!("  No git remote detected (not inside a git repo?)");
+            println!(
+                "  {}",
+                styled("No git remote detected (not inside a git repo?)", C_DIM)
+            );
         }
     }
 
     // ── Terminal ──
     let term = std::env::var("TERM").unwrap_or_else(|_| "unknown".to_string());
-    println!("  TERM:    {}", term);
+    println!("  TERM:    {}", styled(&term, C_DIM));
 
     println!();
     if has_backend {
-        println!("Status: OK — at least one backend CLI is available.");
+        println!(
+            "{} {}",
+            styled("Status:", C_BOLD),
+            styled("OK — at least one backend CLI is available.", C_GREEN)
+        );
     } else {
-        println!("Status: FAIL — neither glab nor gh is installed. At least one is required.");
+        println!(
+            "{} {}",
+            styled("Status:", C_BOLD),
+            styled(
+                "FAIL — neither glab nor gh is installed. At least one is required.",
+                C_RED
+            )
+        );
         std::process::exit(1);
     }
 }
 
 pub fn run_clean_cache(dry_run: bool) {
     if dry_run {
-        println!("glab-tui clean-cache --dry-run");
-        println!("===============================");
-        println!("(Preview only — no files will be removed)");
+        header("glab-tui clean-cache --dry-run");
+        println!("{}", styled("===============================", C_CYAN));
+        info("[INFO]", "(Preview only — no files will be removed)");
     } else {
-        println!("glab-tui clean-cache");
-        println!("====================");
+        header("glab-tui clean-cache");
+        println!("{}", styled("====================", C_CYAN));
     }
     println!();
 
     let result = crate::utils::cache::clean_cache(dry_run);
 
     // ── Recent repos ──
-    println!("Recent repositories:");
+    subheader("Recent repositories:");
     if result.removed_repos.is_empty() {
-        println!("  All {} entries are valid.", result.kept_repos.len());
+        pass(
+            "  OK",
+            &format!("All {} entries are valid.", result.kept_repos.len()),
+        );
     } else {
         for r in &result.removed_repos {
-            println!("  [REMOVED] {}", r);
+            println!("  {} {}", styled("[REMOVED]", C_RED), r);
         }
     }
     for r in &result.kept_repos {
-        println!("  [KEPT]    {}", r);
+        println!("  {} {}", styled("[KEPT]   ", C_GREEN), styled(r, C_DIM));
     }
 
     // ── Cache files ──
     println!();
-    println!("Cache files:");
+    subheader("Cache files:");
     if result.removed_files.is_empty() {
-        println!(
-            "  All {} cache files are valid (no orphaned entries).",
-            result.kept_files.len()
+        pass(
+            "  OK",
+            &format!(
+                "All {} cache files are valid (no orphaned entries).",
+                result.kept_files.len()
+            ),
         );
     } else {
         for f in &result.removed_files {
-            println!("  [REMOVED] {}", f);
+            println!("  {} {}", styled("[REMOVED]", C_RED), f);
         }
     }
     for f in &result.kept_files {
-        println!("  [KEPT]    {}", f);
+        println!("  {} {}", styled("[KEPT]   ", C_GREEN), styled(f, C_DIM));
     }
 
     // ── Summary ──
     println!();
-    if dry_run {
-        println!(
-            "Would remove: {} recent-repo entries, {} cache files ({} KB)",
-            result.removed_repos.len(),
-            result.removed_files.len(),
-            result.total_removed_size / 1024
-        );
+    let (action, dir_repos, dir_files, dir_kb) = (
+        if dry_run { "Would remove" } else { "Removed" },
+        result.removed_repos.len(),
+        result.removed_files.len(),
+        result.total_removed_size / 1024,
+    );
+    let summary_style = if dir_repos + dir_files > 0 {
+        C_YELLOW
     } else {
-        println!(
-            "Removed: {} recent-repo entries, {} cache files ({} KB)",
-            result.removed_repos.len(),
-            result.removed_files.len(),
-            result.total_removed_size / 1024
-        );
-    }
+        C_DIM
+    };
     println!(
-        "Kept:    {} recent-repo entries, {} cache files",
+        "  {}: {} recent-repo entries, {} cache files ({} KB)",
+        styled(action, summary_style),
+        dir_repos,
+        dir_files,
+        dir_kb
+    );
+    println!(
+        "  {}:    {} recent-repo entries, {} cache files",
+        styled("Kept", C_GREEN),
         result.kept_repos.len(),
         result.kept_files.len()
     );
@@ -247,18 +327,28 @@ pub fn run_config_show() {
     let config = crate::config::Config::load();
     match toml::to_string_pretty(&config) {
         Ok(toml_str) => println!("{}", toml_str),
-        Err(e) => eprintln!("Error serializing config: {}", e),
+        Err(e) => eprintln!(
+            "{}",
+            styled(&format!("Error serializing config: {}", e), C_RED)
+        ),
     }
 }
 
 pub fn run_cache_list() {
     let cache_dir = crate::utils::cache::get_cache_dir();
     if !cache_dir.exists() {
-        println!("Cache directory does not exist: {}", cache_dir.display());
+        warn(
+            "[WARN]",
+            &format!("Cache directory does not exist: {}", cache_dir.display()),
+        );
         return;
     }
 
-    println!("Cache directory: {}", cache_dir.display());
+    println!(
+        "{} {}",
+        styled("Cache directory:", C_BOLD),
+        styled(&cache_dir.display().to_string(), C_DIM)
+    );
     println!();
 
     let mut entries: Vec<(String, u64, String)> = Vec::new();
@@ -291,15 +381,27 @@ pub fn run_cache_list() {
 
     let total: u64 = entries.iter().map(|(_, s, _)| s).sum();
     for (name, size, modified) in &entries {
-        if *name == "recent_repos.json" {
-            println!("  {:<40} {:>8} KB  {}", name, size / 1024, modified);
+        let name_style = if name == "recent_repos.json" {
+            styled(name, C_DIM)
         } else {
-            println!("  {:<40} {:>8} KB  {}", name, size / 1024, modified);
-        }
+            name.clone()
+        };
+        println!(
+            "  {:<40} {:>9}  {}",
+            name_style,
+            styled(&format!("{} KB", size / 1024), C_BLUE),
+            styled(modified, C_DIM)
+        );
     }
 
     println!();
-    println!("Total: {} files, {} KB", entries.len(), total / 1024);
+    println!(
+        "  {}",
+        styled(
+            &format!("Total: {} files, {} KB", entries.len(), total / 1024),
+            C_BOLD
+        )
+    );
 }
 
 pub fn run_open_in_browser(entity: &str, id: &str) {
@@ -329,7 +431,13 @@ pub fn run_open_in_browser(entity: &str, id: &str) {
         }
         "job" => {
             if is_github {
-                eprintln!("Direct job browser URLs are not supported for GitHub Actions.");
+                eprintln!(
+                    "{}",
+                    styled(
+                        "Direct job browser URLs are not supported for GitHub Actions.",
+                        C_YELLOW
+                    )
+                );
                 return;
             } else {
                 ("glab", vec!["ci", "view", id, "-w"])
@@ -344,50 +452,61 @@ pub fn run_open_in_browser(entity: &str, id: &str) {
         }
         _ => {
             eprintln!(
-                "Unknown entity '{}'. Valid: issue, mr, pr, pipeline, job, milestone",
-                entity
+                "{} Unknown entity '{}'. Valid: issue, mr, pr, pipeline, job, milestone",
+                styled("error:", C_RED),
+                styled(entity, C_BOLD)
             );
             std::process::exit(1);
         }
     };
 
-    println!("Opening {} {} in browser...", entity, id);
+    println!(
+        "{} {} {} {} ...",
+        styled("Opening", C_GREEN),
+        styled(entity, C_BOLD),
+        styled(id, C_BOLD),
+        styled("in browser", C_GREEN)
+    );
     match Command::new(program).args(&subcommand).spawn() {
         Ok(_) => {}
         Err(e) => {
-            eprintln!("Failed to run {}: {}", program, e);
+            eprintln!(
+                "{} Failed to run {}: {}",
+                styled("error:", C_RED),
+                styled(program, C_BOLD),
+                e
+            );
             std::process::exit(1);
         }
     }
 }
 
 pub fn run_repos_list() {
-    println!("Recent repositories:");
+    subheader("Recent repositories:");
     let recent = crate::utils::cache::get_recent_repos();
     if recent.is_empty() {
-        println!("  (none)");
+        println!("  {}", styled("(none)", C_DIM));
     } else {
-        for (i, r) in recent.iter().enumerate() {
-            let marker = if crate::utils::cache::is_git_repo(r) {
-                "[✓]"
+        for r in &recent {
+            if crate::utils::cache::is_git_repo(r) {
+                println!("  {} {}", styled("[✓]", C_GREEN), r);
             } else {
-                "[✗]"
-            };
-            println!("  {} {}", marker, r);
+                println!("  {} {}", styled("[✗]", C_RED), styled(r, C_DIM));
+            }
         }
     }
 
     println!();
-    println!("Sibling repositories:");
+    subheader("Sibling repositories:");
     let cwd = std::env::current_dir()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
     let siblings = crate::utils::cache::get_sibling_repos(&cwd);
     if siblings.is_empty() {
-        println!("  (none)");
+        println!("  {}", styled("(none)", C_DIM));
     } else {
         for s in &siblings {
-            println!("  {}", s);
+            println!("  {}", styled(s, C_DIM));
         }
     }
 }
@@ -397,13 +516,19 @@ pub async fn run_update() {
     match crate::utils::update::perform_self_update().await {
         Ok(updated) => {
             if updated {
-                println!("Successfully updated to the latest version! Please restart glab-tui.");
+                println!(
+                    "{}",
+                    styled(
+                        "Successfully updated to the latest version! Please restart glab-tui.",
+                        C_GREEN
+                    )
+                );
             } else {
                 println!("Already up to date.");
             }
         }
         Err(e) => {
-            eprintln!("Update failed: {}", e);
+            eprintln!("{}", styled(&format!("Update failed: {}", e), C_RED));
             std::process::exit(1);
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,248 @@
+use clap::{Parser, Subcommand};
+use std::process::Command;
+
+#[derive(Parser)]
+#[command(name = "glab-tui")]
+#[command(about = "GitLab/GitHub terminal user interface")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+pub struct Cli {
+    #[arg(
+        short = 'r',
+        long = "repo",
+        help = "Specify git repo context (e.g., group/repo)"
+    )]
+    pub repo: Option<String>,
+
+    #[arg(
+        short = 'd',
+        long = "dir",
+        help = "Specify local repository directory to run in"
+    )]
+    pub dir: Option<String>,
+
+    #[arg(short = 'u', long = "update", help = "Check and install updates")]
+    pub update: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Check system health and dependency availability
+    Doctor,
+    /// Remove stale cache entries for repos that no longer exist
+    CleanCache {
+        /// Preview what would be removed without actually deleting
+        #[arg(short = 'n', long)]
+        dry_run: bool,
+    },
+}
+
+pub async fn run_doctor() {
+    let mut has_backend = false;
+
+    println!("glab-tui doctor");
+    println!("================");
+    println!();
+
+    // ── glab ──
+    match Command::new("glab").arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("[PASS] glab: {}", v);
+            has_backend = true;
+        }
+        _ => {
+            println!("[FAIL] glab not found — install from https://gitlab.com/gitlab-org/cli");
+        }
+    }
+
+    // ── gh ──
+    match Command::new("gh").arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("[PASS] gh:   {}", v);
+            has_backend = true;
+        }
+        _ => {
+            println!("[FAIL] gh not found — install from https://cli.github.com");
+        }
+    }
+
+    // ── git ──
+    match Command::new("git").arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("[PASS] git:  {}", v);
+        }
+        _ => {
+            println!("[FAIL] git not found");
+        }
+    }
+
+    // ── Config ──
+    let config_path = crate::config::Config::config_path();
+    match std::fs::read_to_string(&config_path) {
+        Ok(content) => {
+            let valid = toml::from_str::<toml::Table>(&content).is_ok();
+            if valid {
+                println!(
+                    "[PASS] Config: {} ({} bytes)",
+                    config_path.display(),
+                    content.len()
+                );
+            } else {
+                println!(
+                    "[WARN] Config file exists but is not valid TOML: {}",
+                    config_path.display()
+                );
+            }
+        }
+        Err(_) => {
+            println!(
+                "[INFO] No config file found at {} (using defaults)",
+                config_path.display()
+            );
+        }
+    }
+
+    // ── Cache ──
+    let cache_dir = crate::utils::cache::get_cache_dir();
+    if cache_dir.exists() {
+        let file_count = std::fs::read_dir(&cache_dir)
+            .map(|d| {
+                d.filter(|e| e.as_ref().map(|f| f.path().is_file()).unwrap_or(false))
+                    .count()
+            })
+            .unwrap_or(0);
+        let total_size = crate::utils::cache::get_cache_dir_size();
+        println!(
+            "[PASS] Cache:  {} ({} files, {} KB)",
+            cache_dir.display(),
+            file_count,
+            total_size / 1024
+        );
+    } else {
+        println!("[INFO] No cache directory at {}", cache_dir.display());
+    }
+
+    // ── Current repo ──
+    println!();
+    println!("Repository context");
+    println!("-------------------");
+    match crate::domain::client::get_project_context().await {
+        Ok(context) => {
+            println!("  Remote:  {}", context);
+            let is_github = match Command::new("git")
+                .args(["remote", "get-url", "origin"])
+                .output()
+            {
+                Ok(o) if o.status.success() => {
+                    String::from_utf8_lossy(&o.stdout).contains("github.com")
+                }
+                _ => false,
+            };
+            println!("  Backend: {}", if is_github { "GitHub" } else { "GitLab" });
+        }
+        Err(_) => {
+            println!("  No git remote detected (not inside a git repo?)");
+        }
+    }
+
+    // ── Terminal ──
+    let term = std::env::var("TERM").unwrap_or_else(|_| "unknown".to_string());
+    println!("  TERM:    {}", term);
+
+    println!();
+    if has_backend {
+        println!("Status: OK — at least one backend CLI is available.");
+    } else {
+        println!("Status: FAIL — neither glab nor gh is installed. At least one is required.");
+        std::process::exit(1);
+    }
+}
+
+pub fn run_clean_cache(dry_run: bool) {
+    if dry_run {
+        println!("glab-tui clean-cache --dry-run");
+        println!("===============================");
+        println!("(Preview only — no files will be removed)");
+    } else {
+        println!("glab-tui clean-cache");
+        println!("====================");
+    }
+    println!();
+
+    let result = crate::utils::cache::clean_cache(dry_run);
+
+    // ── Recent repos ──
+    println!("Recent repositories:");
+    if result.removed_repos.is_empty() {
+        println!("  All {} entries are valid.", result.kept_repos.len());
+    } else {
+        for r in &result.removed_repos {
+            println!("  [REMOVED] {}", r);
+        }
+    }
+    for r in &result.kept_repos {
+        println!("  [KEPT]    {}", r);
+    }
+
+    // ── Cache files ──
+    println!();
+    println!("Cache files:");
+    if result.removed_files.is_empty() {
+        println!(
+            "  All {} cache files are valid (no orphaned entries).",
+            result.kept_files.len()
+        );
+    } else {
+        for f in &result.removed_files {
+            println!("  [REMOVED] {}", f);
+        }
+    }
+    for f in &result.kept_files {
+        println!("  [KEPT]    {}", f);
+    }
+
+    // ── Summary ──
+    println!();
+    if dry_run {
+        println!(
+            "Would remove: {} recent-repo entries, {} cache files ({} KB)",
+            result.removed_repos.len(),
+            result.removed_files.len(),
+            result.total_removed_size / 1024
+        );
+    } else {
+        println!(
+            "Removed: {} recent-repo entries, {} cache files ({} KB)",
+            result.removed_repos.len(),
+            result.removed_files.len(),
+            result.total_removed_size / 1024
+        );
+    }
+    println!(
+        "Kept:    {} recent-repo entries, {} cache files",
+        result.kept_repos.len(),
+        result.kept_files.len()
+    );
+}
+
+pub async fn run_update() {
+    println!("Checking for updates...");
+    match crate::utils::update::perform_self_update().await {
+        Ok(updated) => {
+            if updated {
+                println!("Successfully updated to the latest version! Please restart glab-tui.");
+            } else {
+                println!("Already up to date.");
+            }
+        }
+        Err(e) => {
+            eprintln!("Update failed: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -324,14 +324,72 @@ pub fn run_clean_cache(dry_run: bool) {
 }
 
 pub fn run_config_show() {
-    let config = crate::config::Config::load();
-    match toml::to_string_pretty(&config) {
-        Ok(toml_str) => println!("{}", toml_str),
-        Err(e) => eprintln!(
-            "{}",
-            styled(&format!("Error serializing config: {}", e), C_RED)
-        ),
+    header("glab-tui config");
+    println!("{}", styled("================", C_CYAN));
+    println!();
+
+    let global_path = crate::config::Config::config_path();
+    let global_exists = global_path.exists();
+
+    // ── Global config ──
+    subheader(&format!("Global: {}", global_path.display()));
+    println!(
+        "{}",
+        styled("----------------------------------------", C_DIM)
+    );
+    if global_exists {
+        match std::fs::read_to_string(&global_path) {
+            Ok(content) => println!("{}", content),
+            Err(e) => {
+                fail("[FAIL]", &format!("Error reading: {}", e));
+            }
+        }
+    } else {
+        info("[INFO]", "(file does not exist — using built-in defaults)");
     }
+
+    // ── Repo-local configs ──
+    let mut found_repo = false;
+    if let Some(root) = find_git_root() {
+        let repo_configs = [
+            root.join(".glab-tui").join("config.toml"),
+            root.join(".config").join("glab-tui").join("config.toml"),
+        ];
+        for repo_path in &repo_configs {
+            if repo_path.exists() {
+                println!();
+                subheader(&format!("Repo-local: {}", repo_path.display()));
+                println!(
+                    "{}",
+                    styled("----------------------------------------", C_DIM)
+                );
+                match std::fs::read_to_string(repo_path) {
+                    Ok(content) => println!("{}", content),
+                    Err(e) => {
+                        fail("[FAIL]", &format!("Error reading: {}", e));
+                    }
+                }
+                found_repo = true;
+            }
+        }
+    }
+
+    if !global_exists && !found_repo {
+        info("[INFO]", "No config files found — using built-in defaults.");
+    }
+}
+
+fn find_git_root() -> Option<std::path::PathBuf> {
+    let mut current = std::env::current_dir().ok()?;
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+    None
 }
 
 pub fn run_cache_list() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1161,7 +1161,7 @@ impl Default for Config {
 }
 
 impl Config {
-    fn config_path() -> PathBuf {
+    pub fn config_path() -> PathBuf {
         let mut path = config_dir();
         let _ = std::fs::create_dir_all(&path);
         path.push("config.toml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,6 +718,22 @@ async fn main() -> Result<()> {
                 cli::run_clean_cache(dry_run);
                 return Ok(());
             }
+            cli::Commands::Config => {
+                cli::run_config_show();
+                return Ok(());
+            }
+            cli::Commands::Cache => {
+                cli::run_cache_list();
+                return Ok(());
+            }
+            cli::Commands::Open { entity, id } => {
+                cli::run_open_in_browser(&entity, &id);
+                return Ok(());
+            }
+            cli::Commands::Repos => {
+                cli::run_repos_list();
+                return Ok(());
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -718,10 +718,6 @@ async fn main() -> Result<()> {
                 cli::run_clean_cache(dry_run);
                 return Ok(());
             }
-            cli::Commands::Config => {
-                cli::run_config_show();
-                return Ok(());
-            }
             cli::Commands::Cache => {
                 cli::run_cache_list();
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 mod app;
 mod backend;
+mod cli;
 mod config;
 mod domain;
 mod editor;
@@ -702,75 +703,31 @@ use handlers::overlays::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-    let mut custom_repo: Option<String> = None;
-    let mut custom_dir: Option<String> = None;
+    use clap::Parser;
 
-    let mut i = 1;
-    while i < args.len() {
-        match args[i].as_str() {
-            "-h" | "--help" => {
-                println!("glab-tui - GitLab/GitHub terminal user interface");
-                println!();
-                println!("Usage:");
-                println!("  glab-tui [options]");
-                println!();
-                println!("Options:");
-                println!("  -h, --help               Show this help message");
-                println!("  -v, --version            Show version information");
-                println!("  -u, --update             Check and install updates");
-                println!("  -r, --repo <namespace>   Specify git repo context (e.g., group/repo)");
-                println!("  -d, --dir <path>         Specify local repository directory to run in");
+    // ── Subcommand dispatch ──
+    let cli = cli::Cli::parse();
+
+    if let Some(cmd) = cli.command {
+        match cmd {
+            cli::Commands::Doctor => {
+                cli::run_doctor().await;
                 return Ok(());
             }
-            "-v" | "--version" => {
-                println!("glab-tui version {}", env!("CARGO_PKG_VERSION"));
+            cli::Commands::CleanCache { dry_run } => {
+                cli::run_clean_cache(dry_run);
                 return Ok(());
-            }
-            "-u" | "--update" => {
-                println!("Checking for updates...");
-                match crate::utils::update::perform_self_update().await {
-                    Ok(updated) => {
-                        if updated {
-                            println!(
-                                "Successfully updated to the latest version! Please restart glab-tui."
-                            );
-                        } else {
-                            println!("Already up to date.");
-                        }
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        eprintln!("Update failed: {}", e);
-                        std::process::exit(1);
-                    }
-                }
-            }
-            "-r" | "--repo" => {
-                if i + 1 < args.len() {
-                    custom_repo = Some(args[i + 1].clone());
-                    i += 2;
-                } else {
-                    eprintln!("Error: --repo option requires a namespace argument");
-                    std::process::exit(1);
-                }
-            }
-            "-d" | "--dir" => {
-                if i + 1 < args.len() {
-                    custom_dir = Some(args[i + 1].clone());
-                    i += 2;
-                } else {
-                    eprintln!("Error: --dir option requires a path argument");
-                    std::process::exit(1);
-                }
-            }
-            unknown => {
-                eprintln!("Error: Unknown argument '{}'", unknown);
-                eprintln!("Run 'glab-tui --help' for usage details.");
-                std::process::exit(1);
             }
         }
     }
+
+    if cli.update {
+        cli::run_update().await;
+        return Ok(());
+    }
+
+    let custom_repo = cli.repo;
+    let custom_dir = cli.dir;
 
     if let Some(ref dir) = custom_dir {
         if let Err(e) = std::env::set_current_dir(dir) {

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -22,16 +22,9 @@ pub struct ProjectCache {
 }
 
 fn get_cache_file_path(project_context: &str) -> PathBuf {
-    let safe_name = project_context.replace('/', "_").replace('\\', "_");
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-
-    let mut path = PathBuf::from(home);
-    path.push(".cache");
-    path.push("glab-tui");
+    let mut path = get_cache_dir();
     let _ = fs::create_dir_all(&path);
-    path.push(format!("{}.json", safe_name));
+    path.push(cache_file_name(project_context));
     path
 }
 
@@ -53,13 +46,7 @@ pub fn save_cache(project_context: &str, cache: &ProjectCache) {
 }
 
 fn get_recent_repos_file_path() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-
-    let mut path = PathBuf::from(home);
-    path.push(".cache");
-    path.push("glab-tui");
+    let mut path = get_cache_dir();
     let _ = fs::create_dir_all(&path);
     path.push("recent_repos.json");
     path
@@ -99,6 +86,130 @@ pub fn add_recent_repo(repo_path: &str) {
     if let Ok(content) = serde_json::to_string(&repos) {
         let _ = fs::write(path, content);
     }
+}
+
+pub fn get_cache_dir() -> PathBuf {
+    let home = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_else(|_| ".".to_string());
+    let mut path = PathBuf::from(home);
+    path.push(".cache");
+    path.push("glab-tui");
+    path
+}
+
+pub fn cache_file_name(project_context: &str) -> String {
+    let safe_name = project_context.replace('/', "_").replace('\\', "_");
+    format!("{}.json", safe_name)
+}
+
+pub fn get_cache_dir_size() -> u64 {
+    let dir = get_cache_dir();
+    let mut total = 0u64;
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        }
+    }
+    total
+}
+
+#[derive(Debug)]
+pub struct CleanCacheResult {
+    pub kept_repos: Vec<String>,
+    pub removed_repos: Vec<String>,
+    pub kept_files: Vec<String>,
+    pub removed_files: Vec<String>,
+    pub total_removed_size: u64,
+}
+
+pub fn clean_cache(dry_run: bool) -> CleanCacheResult {
+    let mut result = CleanCacheResult {
+        kept_repos: Vec::new(),
+        removed_repos: Vec::new(),
+        kept_files: Vec::new(),
+        removed_files: Vec::new(),
+        total_removed_size: 0,
+    };
+
+    // ── Prune recent_repos.json dead entries ──
+    let recent_path = get_recent_repos_file_path();
+    let recent_repos = get_recent_repos();
+    let mut live_repos: Vec<String> = Vec::new();
+    let mut dead_repos: Vec<String> = Vec::new();
+
+    for r in &recent_repos {
+        if is_git_repo(r) {
+            live_repos.push(r.clone());
+        } else {
+            dead_repos.push(r.clone());
+        }
+    }
+
+    result.kept_repos = live_repos.clone();
+    result.removed_repos = dead_repos.clone();
+
+    if !dry_run && !dead_repos.is_empty() {
+        if let Ok(content) = serde_json::to_string(&live_repos) {
+            let _ = fs::write(&recent_path, content);
+        }
+    }
+
+    // ── Prune orphaned cache files ──
+    // Collect valid cache file names from live repos' project contexts
+    let mut valid_cache_files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for repo_path in &live_repos {
+        if let Some(context) = get_project_context_for_path(repo_path) {
+            valid_cache_files.insert(cache_file_name(&context));
+        }
+    }
+
+    let cache_dir = get_cache_dir();
+    if let Ok(entries) = fs::read_dir(&cache_dir) {
+        for entry in entries.flatten() {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            // Skip non-JSON files and special files
+            if file_name == "recent_repos.json" || !file_name.ends_with(".json") {
+                continue;
+            }
+            if valid_cache_files.contains(&file_name) {
+                result.kept_files.push(file_name);
+            } else {
+                let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                result.total_removed_size += size;
+                result.removed_files.push(file_name.clone());
+                if !dry_run {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+
+    result
+}
+
+fn get_project_context_for_path(repo_path: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", repo_path, "remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let path = if url.starts_with("git@") {
+        url.split(':').nth(1).unwrap_or("").to_string()
+    } else if url.starts_with("http") {
+        let parts: Vec<&str> = url.split('/').collect();
+        if parts.len() >= 2 {
+            format!("{}/{}", parts[parts.len() - 2], parts[parts.len() - 1])
+        } else {
+            return None;
+        }
+    } else {
+        return None;
+    };
+    Some(path.trim_end_matches(".git").to_string())
 }
 
 pub fn is_git_repo(path: &str) -> bool {


### PR DESCRIPTION
## Summary

Adds CLI subcommands to `glab-tui` using `clap` (derive mode), replacing the hand-rolled argument parser.

### New Subcommands

**`glab-tui doctor`** — system diagnostics
- Checks `glab`, `gh`, `git` availability and versions
- Validates config file (exists? valid TOML?)
- Reports cache directory stats (file count, total size)
- Detects current repo remote and backend type
- Shows `$TERM` value
- Exits 0 if at least one backend is available, 1 otherwise

**`glab-tui clean-cache [--dry-run]`** — cache pruning
- Removes dead entries from `recent_repos.json` (paths no longer exist / not git repos)
- Removes orphaned cache JSON files whose project context matches no known live repo
- `--dry-run` / `-n` previews without deleting
- Reports summary of kept vs removed entries and space freed

**`glab-tui config`** — print resolved configuration
- Prints the merged (cascading global + repo-local) config as TOML
- Useful for debugging config override behavior

**`glab-tui cache`** — list cache files
- Lists all cached JSON files with file sizes and last-modified timestamps
- Shows total count and size

**`glab-tui open <entity> <id>`** — open in browser
- Opens an issue, MR/PR, pipeline, job, or milestone in the default browser
- Detects GitHub vs GitLab backend from the git remote
- Delegates to `gh ... --web` or `glab ... -w`

**`glab-tui repos`** — list repositories
- Shows recently-used repositories with validity markers ([✓]/[✗])
- Lists sibling repos in the same parent directory

### Other Changes

- Replaced hand-rolled `--help`/`--version`/`-r`/`-d`/`-u` argument parser with clap
- Added `get_cache_dir()`, `cache_file_name()`, `get_cache_dir_size()`, `clean_cache()`, `CleanCacheResult` to `src/utils/cache.rs`
- Made `Config::config_path()` public for doctor diagnostics
- New `src/cli.rs` module for command implementations

Closes #178