### PR TITLE
feat(todos): comprehensive tab cleanup — badges, Updated column, time_ago, fuzzy search

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -257,7 +257,7 @@ impl Tab {
                 "Assets",
                 "Description",
             ],
-            Tab::Todos => vec!["State", "Project", "Type", "ID", "Title"],
+            Tab::Todos => vec!["State", "Project", "Type", "ID", "Title", "Updated"],
             Tab::Milestones => vec!["ID", "State", "Title", "Progress", "Due Date"],
             Tab::Branches => vec!["Name", "Default", "Protected", "SHA"],
             Tab::Environments => vec!["Name", "State", "Deployment Status", "URL"],
@@ -291,7 +291,7 @@ impl Tab {
             }
             Tab::Runners => vec!["ID", "Description", "Status", "Active"],
             Tab::Releases => vec!["Tag", "Release Name", "Date"],
-            Tab::Todos => vec!["State", "Project", "Type", "ID", "Title"],
+            Tab::Todos => vec!["State", "Project", "Type", "ID", "Title", "Updated"],
             Tab::Milestones => vec!["ID", "State", "Title", "Progress", "Due Date"],
             Tab::Branches => vec!["Name", "Default", "Protected"],
             Tab::Environments => vec!["Name", "State", "Deployment Status"],
@@ -2993,35 +2993,49 @@ impl App {
         if query.trim().is_empty() {
             return items.iter().collect();
         }
-        let q = query.trim().to_lowercase();
-        items
+        let matcher = SkimMatcherV2::default();
+        let mut scored: Vec<(i64, &'a crate::domain::notifications::Notification)> = items
             .iter()
-            .filter(|item| {
-                let mut matches = false;
-                let mut check_match = |text: &str| {
-                    if text.to_lowercase().contains(&q) {
-                        matches = true;
+            .filter_map(|item| {
+                let mut best: i64 = i64::MIN;
+                let mut try_match = |text: &str| {
+                    if let Some((score, _)) = matcher.fuzzy_indices(text, query) {
+                        best = best.max(score);
                     }
                 };
                 if enabled_cols.contains("State") {
-                    check_match(&item.state);
+                    try_match(&item.state);
+                    try_match(if item.state == "unread" || item.state == "pending" {
+                        "NEW"
+                    } else {
+                        "READ"
+                    });
                 }
                 if enabled_cols.contains("Project") {
-                    check_match(&item.project_path);
+                    try_match(&item.project_path);
                 }
                 if enabled_cols.contains("Type") {
-                    check_match(&item.target_type);
+                    try_match(&item.target_type);
                 }
                 if enabled_cols.contains("ID") {
-                    check_match(&item.target_iid.to_string());
-                    check_match(&format!("#{}", item.target_iid));
+                    try_match(&item.target_iid.to_string());
+                    try_match(&format!("#{}", item.target_iid));
                 }
                 if enabled_cols.contains("Title") {
-                    check_match(&item.title);
+                    try_match(&item.title);
                 }
-                matches
+                if enabled_cols.contains("Updated") {
+                    try_match(&crate::utils::format::time_ago(&item.updated_at));
+                }
+                if best > i64::MIN {
+                    Some((best, item))
+                } else {
+                    None
+                }
             })
-            .collect()
+            .collect();
+        scored.sort_by_key(|(score, _)| -(*score));
+        scored.into_iter().map(|(_, item)| item).collect()
     }
 
     pub fn filtered_todos_list<'a>(
@@ -3042,6 +3056,7 @@ impl App {
                     "Project" => a.project_path.clone(),
                     "ID" => a.target_iid.to_string(),
                     "Title" => a.title.clone(),
+                    "Updated" => a.updated_at.clone(),
                     _ => String::new(),
                 };
                 let val_b = match col.as_str() {
@@ -3050,6 +3065,7 @@ impl App {
                     "Project" => b.project_path.clone(),
                     "ID" => b.target_iid.to_string(),
                     "Title" => b.title.clone(),
+                    "Updated" => b.updated_at.clone(),
                     _ => String::new(),
                 };
                 let cmp = match (val_a.parse::<u64>(), val_b.parse::<u64>()) {
@@ -3080,6 +3096,7 @@ impl App {
                 "Type" => vec![item.target_type.clone()],
                 "ID" => vec![item.id.clone()],
                 "Title" => vec![item.title.clone()],
+                "Updated" => vec![crate::utils::format::time_ago(&item.updated_at)],
                 _ => vec![],
             }
         });
@@ -3544,6 +3561,9 @@ impl App {
                         "Title" => {
                             values.insert(item.title.clone());
                         }
+                        "Updated" => {
+                            values.insert(crate::utils::format::time_ago(&item.updated_at));
+                        }
                         _ => {}
                     }
                 }
@@ -3731,6 +3751,7 @@ impl App {
                             let c = n.title.chars().next().unwrap_or('?');
                             c.to_uppercase().to_string()
                         }
+                        "Updated" => crate::utils::format::time_ago(&n.updated_at),
                         _ => "Unknown".to_string(),
                     };
                     map.entry(key).or_default().push(idx);

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -2705,14 +2705,32 @@ pub(crate) fn render_tab_todos(
     header_style: Style,
 ) {
     let icons = crate::config::ICONS.read().unwrap();
-    if app.todos.items.is_empty() && app.loading_tabs.contains(&app.active_tab) {
-        f.render_widget(
-            Paragraph::new(format!("\n\n {} Loading todos...", icons.label_loading))
+    if app.todos.items.is_empty() {
+        let entity_label = if app.kind().is_github() {
+            "notifications"
+        } else {
+            "todos"
+        };
+        if app.loading_tabs.contains(&app.active_tab) {
+            f.render_widget(
+                Paragraph::new(format!(
+                    "\n\n {} Loading {}...",
+                    icons.label_loading, entity_label
+                ))
                 .alignment(Alignment::Center)
                 .block(main_block.clone())
                 .style(Style::default().fg(THEME.read().unwrap().text_muted)),
-            content_area,
-        );
+                content_area,
+            );
+        } else {
+            f.render_widget(
+                Paragraph::new(format!("\n\n {} No {}", icons.label_details, entity_label))
+                    .alignment(Alignment::Center)
+                    .block(main_block.clone())
+                    .style(Style::default().fg(THEME.read().unwrap().text_muted)),
+                content_area,
+            );
+        }
         f.render_widget(
             Paragraph::new("Select a todo...")
                 .block(
@@ -2745,6 +2763,7 @@ pub(crate) fn render_tab_todos(
                 "Type" => vec![item.target_type.clone()],
                 "ID" => vec![item.id.to_string()],
                 "Title" => vec![item.title.clone()],
+                "Updated" => vec![crate::utils::format::time_ago(&item.updated_at)],
                 _ => vec![],
             },
         );
@@ -2752,14 +2771,19 @@ pub(crate) fn render_tab_todos(
         let rows = filtered_todos.iter().enumerate().map(|(idx, n)| {
             let is_row_highlighted = app.todos.state.selected() == Some(idx);
 
-            let state_str = if n.state == "unread" || n.state == "pending" {
-                "•"
+            let (state_str, state_style) = if n.state == "unread" || n.state == "pending" {
+                (
+                    " NEW",
+                    Style::default()
+                        .fg(THEME.read().unwrap().green)
+                        .add_modifier(Modifier::BOLD),
+                )
             } else {
-                " "
+                (
+                    " READ",
+                    Style::default().fg(THEME.read().unwrap().text_muted),
+                )
             };
-            let state_style = Style::default()
-                .fg(THEME.read().unwrap().green)
-                .add_modifier(Modifier::BOLD);
 
             let type_style = if n.target_type == "MergeRequest" {
                 Style::default()
@@ -2822,6 +2846,16 @@ pub(crate) fn render_tab_todos(
                     Alignment::Left,
                 ));
             }
+            if app.is_column_visible(Tab::Todos, "Updated") {
+                row_cells.push(super::helpers::render_fuzzy_cell(
+                    &time_ago(&n.updated_at),
+                    &app.search_query,
+                    is_row_highlighted,
+                    false,
+                    Style::default().fg(THEME.read().unwrap().yellow),
+                    Alignment::Left,
+                ));
+            }
             let row_style = if is_row_highlighted {
                 Style::default().bg(THEME.read().unwrap().highlight_bg)
             } else {
@@ -2834,8 +2868,8 @@ pub(crate) fn render_tab_todos(
         let mut widths = Vec::new();
 
         if app.is_column_visible(Tab::Todos, "State") {
-            header_cells.push(Cell::from(""));
-            widths.push(Constraint::Length(10));
+            header_cells.push(Cell::from("State"));
+            widths.push(Constraint::Length(6));
         }
         if app.is_column_visible(Tab::Todos, "Project") {
             header_cells.push(Cell::from("Project"));
@@ -2852,6 +2886,10 @@ pub(crate) fn render_tab_todos(
         if app.is_column_visible(Tab::Todos, "Title") {
             header_cells.push(Cell::from("Title"));
             widths.push(Constraint::Fill(1));
+        }
+        if app.is_column_visible(Tab::Todos, "Updated") {
+            header_cells.push(Cell::from("Updated"));
+            widths.push(Constraint::Length(16));
         }
 
         if widths.is_empty() {
@@ -2916,7 +2954,11 @@ pub(crate) fn render_tab_todos(
                         Style::default().fg(THEME.read().unwrap().text_muted),
                     ),
                     Span::styled(
-                        &n.state,
+                        if n.state == "unread" || n.state == "pending" {
+                            "NEW"
+                        } else {
+                            "READ"
+                        },
                         Style::default().fg(if n.state == "unread" || n.state == "pending" {
                             THEME.read().unwrap().green
                         } else {
@@ -2930,17 +2972,26 @@ pub(crate) fn render_tab_todos(
                         Style::default().fg(THEME.read().unwrap().text_muted),
                     ),
                     Span::styled(
-                        &n.updated_at,
+                        time_ago(&n.updated_at),
                         Style::default().fg(THEME.read().unwrap().yellow),
                     ),
                 ]));
                 text.push(Line::from(""));
-                text.push(Line::from(Span::styled(
-                    " Press Enter to mark read and switch to item",
-                    Style::default()
-                        .fg(THEME.read().unwrap().text_muted)
-                        .add_modifier(Modifier::ITALIC),
-                )));
+                if n.state == "unread" || n.state == "pending" {
+                    text.push(Line::from(Span::styled(
+                        " Press Enter to mark read and switch to item",
+                        Style::default()
+                            .fg(THEME.read().unwrap().text_muted)
+                            .add_modifier(Modifier::ITALIC),
+                    )));
+                } else {
+                    text.push(Line::from(Span::styled(
+                        " Press Enter to switch to item",
+                        Style::default()
+                            .fg(THEME.read().unwrap().text_muted)
+                            .add_modifier(Modifier::ITALIC),
+                    )));
+                }
                 f.render_widget(
                     Paragraph::new(text)
                         .block(preview_block)


### PR DESCRIPTION
Closes #158

Comprehensive cleanup of the TODOs/Notifications tab:

### Changes
1. **State column badges** — Replaced bullet indicator (`•`/` `) with colored `NEW`/`READ` text badges. Shrunk column from 10→6 chars and added proper "State" header.
2. **Updated column** — Added `Updated` as a configurable table column showing relative time via `time_ago()`.
3. **Date formatting in detail pane** — Uses `time_ago()` instead of raw ISO timestamps.
4. **Better empty states** — Shows "Loading todos..." while fetching vs "No notifications" when loaded but empty.
5. **Conditional hint text** — Shows "Press Enter to mark read and switch to item" for unread items, "Press Enter to switch to item" for read items.
6. **Fuzzy search** — Replaced substring matching with `SkimMatcherV2` fuzzy matching for the search filter, matching patterns across columns.
7. **Polished detail pane** — State label now shows capitalized `NEW`/`READ` instead of raw state strings.