### PR TITLE
feat(perf): cache repo attributes, reduce over-fetching, and fix mutation handlers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -146,6 +146,18 @@ impl Tab {
         }
     }
 
+    pub fn is_high_churn(&self) -> bool {
+        match self {
+            Tab::Issues | Tab::MergeRequests | Tab::Pipelines | Tab::Jobs | Tab::Todos => true,
+            Tab::Runners
+            | Tab::Releases
+            | Tab::Milestones
+            | Tab::Branches
+            | Tab::Environments
+            | Tab::Terminal => false,
+        }
+    }
+
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "issues" => Some(Tab::Issues),
@@ -1851,6 +1863,11 @@ pub struct App {
     pub content_rect: Option<Rect>,
     pub detail_rect: Option<Rect>,
     pub overlay_stack: Vec<(OverlayKind, Rect)>,
+    pub cached_labels: Vec<String>,
+    pub cached_members: Vec<String>,
+    pub last_attr_refresh: std::time::Instant,
+    pub pending_delete_milestone_iid: Option<u64>,
+    pub pending_delete_release_tag: Option<String>,
 }
 
 impl Default for App {
@@ -1949,6 +1966,11 @@ impl Default for App {
             content_rect: None,
             detail_rect: None,
             overlay_stack: vec![],
+            cached_labels: Vec::new(),
+            cached_members: Vec::new(),
+            last_attr_refresh: std::time::Instant::now(),
+            pending_delete_milestone_iid: None,
+            pending_delete_release_tag: None,
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,6 +21,10 @@ pub enum Event {
     RunnersFetched(Vec<crate::domain::runners::Runner>),
     ReleasesFetched(Vec<crate::domain::releases::Release>),
     SelectorItemsFetched(Vec<String>),
+    RepoAttributesFetched {
+        labels: Vec<String>,
+        members: Vec<String>,
+    },
     FetchFailed(crate::app::Tab, String),
     DiffFetched {
         mr_iid: u64,

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -3,6 +3,24 @@ use crate::domain;
 use crate::event::Event;
 use crate::git_helpers::get_current_branch;
 
+pub fn spawn_fetch_repo_attributes(
+    client: &domain::client::GitlabClient,
+    project_context: &str,
+    tx: tokio::sync::mpsc::UnboundedSender<Event>,
+) {
+    let client = client.clone();
+    let project_context = project_context.to_string();
+    tokio::spawn(async move {
+        let (labels_res, members_res) = tokio::join!(
+            client.fetch_labels(&project_context),
+            client.fetch_members(&project_context),
+        );
+        let labels = labels_res.unwrap_or_default();
+        let members = members_res.unwrap_or_default();
+        let _ = tx.send(Event::RepoAttributesFetched { labels, members });
+    });
+}
+
 pub fn spawn_refresh_active_tab(
     client: &domain::client::GitlabClient,
     project_context: &str,

--- a/src/handlers/overlays.rs
+++ b/src/handlers/overlays.rs
@@ -2,7 +2,7 @@ use crate::AppTerminal;
 use crate::app::App;
 use crate::entity_editor::{apply_field_text_change, rebuild_edit_menu};
 use crate::event::Event;
-use crate::fetch::spawn_refresh_active_tab;
+use crate::fetch::{spawn_fetch_repo_attributes, spawn_refresh_active_tab};
 use crate::keybinding::keybinding_matches;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::ListState;
@@ -72,6 +72,7 @@ pub fn handle_confirm_popup(
                 }
                 match confirm_action {
                     crate::app::ConfirmAction::DeleteMilestone(iid) => {
+                        app.pending_delete_milestone_iid = Some(iid);
                         let client = app.gitlab_client.clone().unwrap();
                         let project_path = app.project_context.clone();
                         tokio::spawn(async move {
@@ -99,6 +100,7 @@ pub fn handle_confirm_popup(
                         });
                     }
                     crate::app::ConfirmAction::DeleteRelease(tag_name) => {
+                        app.pending_delete_release_tag = Some(tag_name.clone());
                         let client = app.gitlab_client.clone().unwrap();
                         let project_path = app.project_context.clone();
                         tokio::spawn(async move {
@@ -369,11 +371,13 @@ pub fn handle_refresh(
         && app.selector.is_none()
     {
         *last_refresh = Instant::now();
+        app.last_attr_refresh = Instant::now();
         if let Some(client) = app.gitlab_client.clone() {
             if !app.loading_tabs.contains(&app.active_tab) {
                 app.start_loading_tab(app.active_tab);
-                spawn_refresh_active_tab(&client, &app.project_context, app.active_tab, tx);
+                spawn_refresh_active_tab(&client, &app.project_context, app.active_tab, tx.clone());
             }
+            spawn_fetch_repo_attributes(&client.muted(), &app.project_context, tx);
         }
         return true;
     }

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -1534,6 +1534,16 @@ pub async fn handle_active_tab_key(
                         };
                         let project_path = app.project_context.clone();
                         let milestone_iid = milestone.iid;
+                        // Optimistic local update
+                        app.project_cache.milestones = app.milestones.items.clone();
+                        if let Some(m) = app
+                            .milestones
+                            .items
+                            .iter_mut()
+                            .find(|m| m.iid == milestone_iid)
+                        {
+                            m.state = "closed".to_string();
+                        }
                         let tx = tx.clone();
                         tokio::spawn(async move {
                             let res = crate::domain::milestones::update_milestone_state(
@@ -1571,6 +1581,16 @@ pub async fn handle_active_tab_key(
                         };
                         let project_path = app.project_context.clone();
                         let milestone_iid = milestone.iid;
+                        // Optimistic local update
+                        app.project_cache.milestones = app.milestones.items.clone();
+                        if let Some(m) = app
+                            .milestones
+                            .items
+                            .iter_mut()
+                            .find(|m| m.iid == milestone_iid)
+                        {
+                            m.state = "active".to_string();
+                        }
                         let tx = tx.clone();
                         tokio::spawn(async move {
                             let res = crate::domain::milestones::update_milestone_state(

--- a/src/main.rs
+++ b/src/main.rs
@@ -698,6 +698,7 @@ pub use git_helpers::*;
 pub use keybinding::keybinding_matches;
 pub use templates::*;
 
+pub use fetch::spawn_fetch_repo_attributes;
 pub use fetch::spawn_refresh_active_tab;
 use handlers::overlays::*;
 
@@ -788,6 +789,8 @@ async fn main() -> Result<()> {
     app.branches.items = cache.branches;
     app.environments.items = cache.environments;
     app.milestone_issues_cache = cache.milestone_issues;
+    app.cached_labels = cache.labels;
+    app.cached_members = cache.members;
 
     let has_any_cached = !app.issues.items.is_empty()
         || !app.mrs.items.is_empty()
@@ -838,6 +841,7 @@ async fn main() -> Result<()> {
             app.start_loading_tab(app.active_tab);
         }
         spawn_refresh_active_tab(&client, &app.project_context, app.active_tab, tx.clone());
+        spawn_fetch_repo_attributes(&client.muted(), &app.project_context, tx);
     } else {
         let timestamp = chrono::Local::now().format("%H:%M:%S").to_string();
         app.terminal_commands.push(crate::app::TerminalCommand {
@@ -1005,23 +1009,42 @@ async fn main() -> Result<()> {
                     if app.active_tab != last_active_tab {
                         last_active_tab = app.active_tab;
                         last_refresh = std::time::Instant::now();
-                    } else if last_refresh.elapsed() >= std::time::Duration::from_secs(60) {
-                        if app.text_input.is_none()
+                        app.last_attr_refresh = std::time::Instant::now();
+                    } else {
+                        if last_refresh.elapsed() >= std::time::Duration::from_secs(60)
+                            && app.active_tab.is_high_churn()
+                        {
+                            if app.text_input.is_none()
+                                && app.edit_menu.is_none()
+                                && app.selector.is_none()
+                                && !app.loading_tabs.contains(&app.active_tab)
+                            {
+                                if let Some(client) = app.gitlab_client.clone() {
+                                    app.start_loading_tab(app.active_tab);
+                                    spawn_refresh_active_tab(
+                                        &client.muted(),
+                                        &app.project_context,
+                                        app.active_tab,
+                                        events.sender(),
+                                    );
+                                }
+                            }
+                            last_refresh = std::time::Instant::now();
+                        }
+                        if app.last_attr_refresh.elapsed() >= std::time::Duration::from_secs(300)
+                            && app.text_input.is_none()
                             && app.edit_menu.is_none()
                             && app.selector.is_none()
-                            && !app.loading_tabs.contains(&app.active_tab)
                         {
                             if let Some(client) = app.gitlab_client.clone() {
-                                app.start_loading_tab(app.active_tab);
-                                spawn_refresh_active_tab(
+                                spawn_fetch_repo_attributes(
                                     &client.muted(),
                                     &app.project_context,
-                                    app.active_tab,
                                     events.sender(),
                                 );
                             }
+                            app.last_attr_refresh = std::time::Instant::now();
                         }
-                        last_refresh = std::time::Instant::now();
                     }
                 }
                 Event::PipelineJobs(id, jobs) => {
@@ -1199,66 +1222,32 @@ async fn main() -> Result<()> {
                     }
                 }
                 Event::MilestoneUpdated | Event::MilestoneClosed | Event::MilestoneReopened => {
-                    app.complete_loading_tab(app::Tab::Milestones, "Success");
                     app.status_message = None;
-                    if let Some(client) = app.gitlab_client.clone() {
-                        if !app.loading_tabs.contains(&app::Tab::Milestones) {
-                            app.start_loading_tab(app::Tab::Milestones);
-                        }
-                        spawn_refresh_active_tab(
-                            &client,
-                            &app.project_context,
-                            app::Tab::Milestones,
-                            events.sender(),
-                        );
-                    }
+                    app.project_cache.milestones = app.milestones.items.clone();
+                    crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::MilestoneDeleted => {
                     app.complete_loading_tab(app::Tab::Milestones, "Success");
                     app.status_message = None;
-                    app.milestones.items.clear();
-                    if let Some(client) = app.gitlab_client.clone() {
-                        if !app.loading_tabs.contains(&app::Tab::Milestones) {
-                            app.start_loading_tab(app::Tab::Milestones);
-                        }
-                        spawn_refresh_active_tab(
-                            &client,
-                            &app.project_context,
-                            app::Tab::Milestones,
-                            events.sender(),
-                        );
+                    if let Some(iid) = app.pending_delete_milestone_iid.take() {
+                        app.milestones.items.retain(|m| m.iid != iid);
                     }
+                    app.project_cache.milestones = app.milestones.items.clone();
+                    crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::ReleaseUpdated => {
-                    app.complete_loading_tab(app::Tab::Releases, "Success");
                     app.status_message = None;
-                    if let Some(client) = app.gitlab_client.clone() {
-                        if !app.loading_tabs.contains(&app::Tab::Releases) {
-                            app.start_loading_tab(app::Tab::Releases);
-                        }
-                        spawn_refresh_active_tab(
-                            &client,
-                            &app.project_context,
-                            app::Tab::Releases,
-                            events.sender(),
-                        );
-                    }
+                    app.project_cache.releases = app.releases.items.clone();
+                    crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::ReleaseDeleted => {
                     app.complete_loading_tab(app::Tab::Releases, "Success");
                     app.status_message = None;
-                    app.releases.items.clear();
-                    if let Some(client) = app.gitlab_client.clone() {
-                        if !app.loading_tabs.contains(&app::Tab::Releases) {
-                            app.start_loading_tab(app::Tab::Releases);
-                        }
-                        spawn_refresh_active_tab(
-                            &client,
-                            &app.project_context,
-                            app::Tab::Releases,
-                            events.sender(),
-                        );
+                    if let Some(tag) = app.pending_delete_release_tag.take() {
+                        app.releases.items.retain(|r| r.tag_name != tag);
                     }
+                    app.project_cache.releases = app.releases.items.clone();
+                    crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::IssueDeleted => {
                     app.complete_loading_tab(app::Tab::Issues, "Success");
@@ -1313,21 +1302,67 @@ async fn main() -> Result<()> {
                     crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::SelectorItemsFetched(items) => {
-                    let mut fallback_success = false;
+                    let mut applied_from_cache = false;
                     if items.is_empty() {
-                        if let Some(cached) = &app.project_cache.selector_items {
-                            app.status_message =
-                                Some("Offline fallback: loaded cached selector items.".to_string());
-                            if let Some(mut selector) = app.selector.take() {
-                                selector.all_items = cached.clone();
-                                selector.is_loading = false;
-                                app.selector = Some(selector);
+                        // Determine which typed cache to fall back on
+                        if let Some(ref selector) = app.selector {
+                            let fallback = match selector.field_type.as_str() {
+                                "labels" => {
+                                    if !app.cached_labels.is_empty() {
+                                        Some(app.cached_labels.clone())
+                                    } else {
+                                        None
+                                    }
+                                }
+                                "assignees" | "reviewers" => {
+                                    if !app.cached_members.is_empty() {
+                                        Some(app.cached_members.clone())
+                                    } else {
+                                        None
+                                    }
+                                }
+                                "milestone" => Some(
+                                    app.milestones
+                                        .items
+                                        .iter()
+                                        .map(|m| m.title.clone())
+                                        .collect(),
+                                ),
+                                "source_branch" | "target_branch" | "pipeline_branch" => Some(
+                                    app.branches.items.iter().map(|b| b.name.clone()).collect(),
+                                ),
+                                _ => None,
+                            };
+                            if let Some(cached) = fallback {
+                                if !cached.is_empty() {
+                                    app.status_message = Some(
+                                        "Offline fallback: cached selector items.".to_string(),
+                                    );
+                                    if let Some(mut selector) = app.selector.take() {
+                                        selector.all_items = cached;
+                                        selector.is_loading = false;
+                                        app.selector = Some(selector);
+                                    }
+                                    applied_from_cache = true;
+                                }
                             }
-                            fallback_success = true;
                         }
                     }
-                    if !fallback_success {
-                        app.project_cache.selector_items = Some(items.clone());
+                    if !applied_from_cache {
+                        // Update typed cache based on field type
+                        if let Some(ref selector) = app.selector {
+                            match selector.field_type.as_str() {
+                                "labels" => {
+                                    app.cached_labels = items.clone();
+                                    app.project_cache.labels = items.clone();
+                                }
+                                "assignees" | "reviewers" => {
+                                    app.cached_members = items.clone();
+                                    app.project_cache.members = items.clone();
+                                }
+                                _ => {}
+                            }
+                        }
                         crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                         if let Some(mut selector) = app.selector.take() {
                             selector.all_items = items;
@@ -1335,6 +1370,17 @@ async fn main() -> Result<()> {
                             app.selector = Some(selector);
                         }
                     }
+                }
+                Event::RepoAttributesFetched { labels, members } => {
+                    if !labels.is_empty() {
+                        app.cached_labels = labels.clone();
+                        app.project_cache.labels = labels;
+                    }
+                    if !members.is_empty() {
+                        app.cached_members = members.clone();
+                        app.project_cache.members = members;
+                    }
+                    crate::utils::cache::save_cache(&app.project_context, &app.project_cache);
                 }
                 Event::DeploymentsFetched(deployments) => {
                     app.deployments.items = deployments;
@@ -4538,16 +4584,45 @@ async fn main() -> Result<()> {
                                                 current_set.insert("No".to_string());
                                             }
                                         }
+                                    } else if field_type == "labels" {
+                                        if !app.cached_labels.is_empty() {
+                                            all_items = app.cached_labels.clone();
+                                            is_loading = false;
+                                        }
+                                    } else if field_type == "assignees" || field_type == "reviewers"
+                                    {
+                                        if !app.cached_members.is_empty() {
+                                            all_items = app.cached_members.clone();
+                                            is_loading = false;
+                                        }
+                                    } else if field_type == "milestone" {
+                                        all_items = app
+                                            .milestones
+                                            .items
+                                            .iter()
+                                            .map(|m| m.title.clone())
+                                            .collect();
+                                        is_loading = false;
                                     } else if field_type == "source_branch"
                                         || field_type == "target_branch"
+                                        || field_type == "pipeline_branch"
                                     {
-                                        is_loading = true;
-                                    } else if field_type == "pipeline_branch" {
-                                        is_loading = true;
-                                        // Pre-select the current branch value
-                                        let current_val = menu.fields[menu.selected_idx].1.clone();
-                                        if !current_val.is_empty() {
-                                            current_set.insert(current_val);
+                                        let branch_names: Vec<String> = app
+                                            .branches
+                                            .items
+                                            .iter()
+                                            .map(|b| b.name.clone())
+                                            .collect();
+                                        if field_type == "pipeline_branch" {
+                                            let current_val =
+                                                menu.fields[menu.selected_idx].1.clone();
+                                            if !current_val.is_empty() {
+                                                current_set.insert(current_val);
+                                            }
+                                        }
+                                        if !branch_names.is_empty() {
+                                            all_items = branch_names;
+                                            is_loading = false;
                                         }
                                     } else if field_type == "workflow_file" {
                                         all_items = get_workflow_files(app.is_github());

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -18,7 +18,9 @@ pub struct ProjectCache {
     #[serde(default)]
     pub milestone_issues: HashMap<u64, Vec<crate::domain::issues::Issue>>,
     #[serde(default)]
-    pub selector_items: Option<Vec<String>>,
+    pub labels: Vec<String>,
+    #[serde(default)]
+    pub members: Vec<String>,
 }
 
 fn get_cache_file_path(project_context: &str) -> PathBuf {
@@ -370,11 +372,13 @@ mod tests {
     #[test]
     fn test_project_cache_roundtrip() {
         let mut cache = ProjectCache::default();
-        cache.selector_items = Some(vec!["assignee1".to_string(), "label1".to_string()]);
+        cache.labels = vec!["bug".to_string(), "enhancement".to_string()];
+        cache.members = vec!["@user1".to_string(), "@user2".to_string()];
 
         let serialized = serde_json::to_string(&cache).unwrap();
         let deserialized: ProjectCache = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(deserialized.selector_items.unwrap()[0], "assignee1");
+        assert_eq!(deserialized.labels[0], "bug");
+        assert_eq!(deserialized.members[1], "@user2");
     }
 }


### PR DESCRIPTION
## Summary

Closes #174

### Optimizations

**1. Cache repo attributes with typed fields** (B)
- Replace `selector_items: Option<Vec<String>>` with `labels: Vec<String>` and `members: Vec<String>` in `ProjectCache`
- Pre-fetch labels + members at startup via `spawn_fetch_repo_attributes()` (parallel `tokio::join!`)
- Re-fetch on explicit refresh (Ctrl+R/F5) and every 300s via tick
- Populate selectors from cache immediately — no loading spinner for labels, members, milestones, or branches selectors
- Milestone titles and branch names derived from existing domain caches (no extra API calls)

**2. Gate 60s auto-refresh to high-churn tabs** (A)
- Added `Tab::is_high_churn()` — true for Issues, MRs, Pipelines, Jobs, Todos; false for everything else
- Milestones, Branches, Runners, Releases, Environments, and Terminal skip the timer entirely

**3. Skip full re-fetch after milestone/release mutations** (C)
- `MilestoneUpdated`/`MilestoneClosed`/`MilestoneReopened` → save cache only (no re-fetch)
- `ReleaseUpdated` → save cache only (no re-fetch)
- `MilestoneDeleted`/`ReleaseDeleted` → remove from local list, save cache; `CommandCompleted` path handles re-fetch

**4. Guard against cache wipe on network failure** (C review fix)
- `RepoAttributesFetched` only updates on non-empty results

**5. Miscellaneous fixes**
- Optimistic local state update for milestone close/reopen (instant UI response)
- Deduplicate pipeline_branch pre-selection code in edit menu handler
- Remove misleading `complete_loading_tab` calls from update-only handlers

### Files changed
- `src/app.rs` — `is_high_churn()`, `cached_labels`, `cached_members`, `last_attr_refresh`, delete tracking fields
- `src/event.rs` — `RepoAttributesFetched { labels, members }`
- `src/fetch.rs` — `spawn_fetch_repo_attributes()`
- `src/utils/cache.rs` — typed `labels`/`members` replacing `selector_items`
- `src/main.rs` — instant selectors, selective auto-refresh, cache guards, mutation handler cleanup
- `src/handlers/overlays.rs` — attribute refresh on explicit refresh
- `src/handlers/tabs.rs` — optimistic milestone close/reopen state update

### Verification
- `cargo fmt` ✅ clean
- `cargo clippy -- -D warnings` ✅ zero warnings
- `cargo check` ✅ compiles
- `cargo test` ✅ 122 tests pass (51 unit + 71 e2e)