### PR TITLE
feat: detect and prompt for workflow_dispatch inputs in pipeline run form

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -74,10 +74,16 @@ jobs:
 
                       Save and write these file modifications directly back into the working directory.
 
+            - name: Install Rust toolchain
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Build glab-tui binary
+              run: cargo build --release && cp target/release/glab-tui /usr/local/bin/
+
             - name: Install VHS & Nerd Fonts
               run: |
                 sudo apt-get update -y
-                sudo apt-get install -y golang-go ffmpeg unzip
+                sudo apt-get install -y golang-go ffmpeg unzip ttyd
                 go install github.com/charmbracelet/vhs@latest
                 echo "$HOME/go/bin" >> "$GITHUB_PATH"
                 wget -q https://github.com/ryanoasis/nerd-fonts/releases/latest/download/JetBrainsMono.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "serde_yaml",
  "syntect",
  "tempfile",
  "tokio",
@@ -1559,6 +1560,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2024,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ fuzzy-matcher = "0.3.7"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 async-trait = "0.1.89"
 clap = { version = "4", features = ["derive"] }
+serde_yaml = "0.9"
 [dev-dependencies]
 libc = "0.2.186"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@
 
 use crate::backend::BackendKind;
 use crate::config::Config;
+use crate::domain::workflow_inputs::WorkflowInput;
 use crate::utils::ui::StatefulTable;
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
@@ -324,6 +325,7 @@ pub struct EditMenu {
     pub entity_iid: u64,
     pub entity_type: String, // "issue", "mr"
     pub state: ListState,
+    pub workflow_inputs: Vec<WorkflowInput>,
 }
 
 impl EditMenu {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -8,3 +8,4 @@ pub mod notifications;
 pub mod pipelines;
 pub mod releases;
 pub mod runners;
+pub mod workflow_inputs;

--- a/src/domain/workflow_inputs.rs
+++ b/src/domain/workflow_inputs.rs
@@ -1,0 +1,90 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct WorkflowInput {
+    pub name: String,
+    pub description: String,
+    pub required: bool,
+    pub default: Option<String>,
+    pub input_type: WorkflowInputType,
+    pub options: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WorkflowInputType {
+    String,
+    Choice,
+    Boolean,
+    Environment,
+}
+
+#[derive(Deserialize)]
+struct WorkflowTop {
+    on: Option<WorkflowOn>,
+    #[serde(rename = "true")]
+    true_on: Option<WorkflowOn>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowOn {
+    workflow_dispatch: Option<WorkflowDispatch>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowDispatch {
+    inputs: Option<HashMap<String, WorkflowInputDef>>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowInputDef {
+    description: Option<String>,
+    required: Option<bool>,
+    default: Option<serde_yaml::Value>,
+    #[serde(rename = "type")]
+    input_type: Option<String>,
+    options: Option<Vec<String>>,
+}
+
+pub fn parse_workflow_inputs(yaml_path: &str) -> Option<Vec<WorkflowInput>> {
+    let content = std::fs::read_to_string(yaml_path).ok()?;
+    let wf: WorkflowTop = serde_yaml::from_str(&content).ok()?;
+    let on = wf.on.or(wf.true_on)?;
+    let inputs = on.workflow_dispatch?.inputs?;
+
+    let result: Vec<WorkflowInput> = inputs
+        .into_iter()
+        .map(|(name, def)| {
+            let description = def.description.unwrap_or_default();
+            let required = def.required.unwrap_or(false);
+            let default = def.default.map(|v| match v {
+                serde_yaml::Value::String(s) => s,
+                serde_yaml::Value::Bool(b) => b.to_string(),
+                serde_yaml::Value::Number(n) => n.to_string(),
+                _ => String::new(),
+            });
+            let input_type = match def.input_type.as_deref() {
+                Some("choice") => WorkflowInputType::Choice,
+                Some("boolean") => WorkflowInputType::Boolean,
+                Some("environment") => WorkflowInputType::Environment,
+                _ => WorkflowInputType::String,
+            };
+            let options = def.options.unwrap_or_default();
+
+            WorkflowInput {
+                name,
+                description,
+                required,
+                default,
+                input_type,
+                options,
+            }
+        })
+        .collect();
+
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}

--- a/src/domain/workflow_inputs.rs
+++ b/src/domain/workflow_inputs.rs
@@ -48,7 +48,9 @@ struct WorkflowInputDef {
 
 pub fn parse_workflow_inputs(yaml_path: &str) -> Option<Vec<WorkflowInput>> {
     let content = std::fs::read_to_string(yaml_path).ok()?;
-    let wf: WorkflowTop = serde_yaml::from_str(&content).ok()?;
+    let wf: WorkflowTop = serde_yaml::from_str(&content)
+        .inspect_err(|e| eprintln!("workflow YAML parse error for {}: {}", yaml_path, e))
+        .ok()?;
     let on = wf.on.or(wf.true_on)?;
     let inputs = on.workflow_dispatch?.inputs?;
 
@@ -86,5 +88,30 @@ pub fn parse_workflow_inputs(yaml_path: &str) -> Option<Vec<WorkflowInput>> {
         None
     } else {
         Some(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_prepare_release_workflow() {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let yaml_path = format!("{}/.github/workflows/prepare-release.yml", manifest_dir);
+        let inputs = parse_workflow_inputs(&yaml_path);
+        assert!(
+            inputs.is_some(),
+            "Failed to parse prepare-release.yml — inputs should not be None"
+        );
+        let inputs = inputs.unwrap();
+        assert_eq!(inputs.len(), 1, "Expected 1 input, got {}", inputs.len());
+
+        let version = &inputs[0];
+        assert_eq!(version.name, "version_increment");
+        assert_eq!(version.required, true);
+        assert_eq!(version.default, Some("patch".to_string()));
+        assert_eq!(version.input_type, WorkflowInputType::Choice);
+        assert_eq!(version.options, vec!["patch", "minor", "major"]);
     }
 }

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -585,6 +585,7 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
                     s.select(Some(selected_idx));
                     s
                 },
+                workflow_inputs: vec![],
             });
         }
     } else if entity_type == "mr" {
@@ -650,6 +651,7 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
                     s.select(Some(selected_idx));
                     s
                 },
+                workflow_inputs: vec![],
             });
         }
     } else if entity_type == "milestone" {
@@ -689,6 +691,7 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
                     s.select(Some(selected_idx));
                     s
                 },
+                workflow_inputs: vec![],
             });
         }
     }

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -44,6 +44,7 @@ pub async fn handle_active_tab_key(
                         s.select(Some(0));
                         s
                     },
+                    workflow_inputs: vec![],
                 });
             }
             _ if keybinding_matches(&app.config.keybindings.issues.edit_entity, key_event) => {
@@ -72,6 +73,7 @@ pub async fn handle_active_tab_key(
                             s.select(Some(0));
                             s
                         },
+                        workflow_inputs: vec![],
                     });
                 } else if let Some(selected_idx) = app.issues.state.selected() {
                     let filtered = app.filtered_issues();
@@ -130,6 +132,7 @@ pub async fn handle_active_tab_key(
                                 s.select(Some(0));
                                 s
                             },
+                            workflow_inputs: vec![],
                         });
                     }
                 }
@@ -277,6 +280,7 @@ pub async fn handle_active_tab_key(
                                 s.select(Some(0));
                                 s
                             },
+                            workflow_inputs: vec![],
                         });
                     }
                 }
@@ -369,6 +373,7 @@ pub async fn handle_active_tab_key(
                             s.select(Some(0));
                             s
                         },
+                        workflow_inputs: vec![],
                     });
                 } else if let Some(selected_idx) = app.mrs.state.selected() {
                     let filtered = app.filtered_mrs();
@@ -435,6 +440,7 @@ pub async fn handle_active_tab_key(
                                 s.select(Some(0));
                                 s
                             },
+                            workflow_inputs: vec![],
                         });
                     }
                 }
@@ -733,6 +739,7 @@ pub async fn handle_active_tab_key(
                         s.select(Some(0));
                         s
                     },
+                    workflow_inputs: vec![],
                 });
             } else if key_event.code == KeyCode::Char('p')
                 || keybinding_matches(
@@ -1337,6 +1344,7 @@ pub async fn handle_active_tab_key(
                         s.select(Some(0));
                         s
                     },
+                    workflow_inputs: vec![],
                 });
             }
             _ if keybinding_matches(&app.config.keybindings.releases.edit_release, key_event) => {
@@ -1504,6 +1512,7 @@ pub async fn handle_active_tab_key(
                         s.select(Some(0));
                         s
                     },
+                    workflow_inputs: vec![],
                 });
             }
             _ if keybinding_matches(

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -717,16 +717,14 @@ pub async fn handle_active_tab_key(
                     crate::git_helpers::get_current_branch().unwrap_or_else(|| "main".to_string());
 
                 let is_github = app.is_github();
-                let mut fields = vec![
-                    ("Branch / Ref".to_string(), current_branch.clone()),
-                    ("Variables".to_string(), String::new()),
-                    ("Inputs".to_string(), String::new()),
-                ];
+                let mut fields = vec![("Branch / Ref".to_string(), current_branch.clone())];
                 if is_github {
                     fields.push(("Workflow File".to_string(), String::new()));
                 } else {
-                    fields.insert(1, ("Merge Request Pipeline".to_string(), "No".to_string()));
+                    fields.push(("Merge Request Pipeline".to_string(), "No".to_string()));
                 }
+                fields.push(("Inputs".to_string(), String::new()));
+                fields.push(("Variables".to_string(), String::new()));
 
                 app.edit_menu = Some(crate::app::EditMenu {
                     title: "Run Pipeline".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3255,6 +3255,7 @@ async fn main() -> Result<()> {
                                                 s.select(Some(0));
                                                 s
                                             },
+                                            workflow_inputs: vec![],
                                         });
                                         continue;
                                     }
@@ -3845,6 +3846,7 @@ async fn main() -> Result<()> {
                                                 "pipeline_branch" => "Branch / Ref",
                                                 "workflow_file" => "Workflow File",
                                                 "tag" => "Tag",
+                                                other if other.starts_with("Input: ") => other,
                                                 _ => "",
                                             };
                                             if !target_field_name.is_empty() {
@@ -3873,7 +3875,55 @@ async fn main() -> Result<()> {
                                                     } else {
                                                         selected_list.join(", ")
                                                     };
-                                                    f.1 = display_val;
+
+                                                    let is_workflow_file = field_type
+                                                        == "workflow_file"
+                                                        && !display_val.is_empty();
+
+                                                    f.1 = display_val.clone();
+
+                                                    let _ = f; // release borrow before modifying fields
+
+                                                    // When a workflow file is selected, parse
+                                                    // its workflow_dispatch inputs and rebuild
+                                                    // the edit menu fields to show per-input fields.
+                                                    if is_workflow_file {
+                                                        let repo_root =
+                                                            std::process::Command::new("git")
+                                                                .args([
+                                                                    "rev-parse",
+                                                                    "--show-toplevel",
+                                                                ])
+                                                                .output()
+                                                                .ok()
+                                                                .and_then(|o| {
+                                                                    String::from_utf8(o.stdout).ok()
+                                                                })
+                                                                .map(|s| s.trim().to_string());
+
+                                                        if let Some(root) = repo_root {
+                                                            let yaml_path = format!(
+                                                                "{}/.github/workflows/{}",
+                                                                root, display_val
+                                                            );
+                                                            if let Some(inputs) =
+                                                                crate::domain::workflow_inputs::parse_workflow_inputs(&yaml_path)
+                                                            {
+                                                                menu.workflow_inputs = inputs.clone();
+                                                                menu.fields.retain(|(l, _)| l != "Inputs");
+                                                                let insert_pos = menu
+                                                                    .fields
+                                                                    .iter()
+                                                                    .position(|(l, _)| l == "Variables")
+                                                                    .unwrap_or(menu.fields.len());
+                                                                for input in inputs.iter().rev() {
+                                                                    let label = format!("Input: {}", input.name);
+                                                                    let default_val = input.default.clone().unwrap_or_default();
+                                                                    menu.fields.insert(insert_pos, (label, default_val));
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -4413,7 +4463,29 @@ async fn main() -> Result<()> {
                                             .unwrap_or_default();
 
                                         let var_pairs = parse_key_value_pairs(&variables);
-                                        let input_pairs = parse_key_value_pairs(&inputs);
+                                        // Collect per-input fields when workflow_dispatch inputs
+                                        // were detected; otherwise fall back to the generic
+                                        // "Inputs" field.
+                                        let per_input_fields: Vec<&(String, String)> = menu
+                                            .fields
+                                            .iter()
+                                            .filter(|(k, _)| k.starts_with("Input: "))
+                                            .collect();
+                                        let input_pairs: Vec<(String, String)> =
+                                            if !per_input_fields.is_empty() {
+                                                per_input_fields
+                                                    .iter()
+                                                    .map(|(label, value)| {
+                                                        let name = label
+                                                            .strip_prefix("Input: ")
+                                                            .unwrap_or(label);
+                                                        (name.to_string(), value.trim().to_string())
+                                                    })
+                                                    .filter(|(_, v)| !v.is_empty())
+                                                    .collect()
+                                            } else {
+                                                parse_key_value_pairs(&inputs)
+                                            };
                                         let mr_flag = mr.to_lowercase() == "yes";
 
                                         app.edit_menu = None;
@@ -4519,6 +4591,7 @@ async fn main() -> Result<()> {
                                     || field_name == "Branch / Ref"
                                     || field_name == "Workflow File"
                                     || field_name == "Tag"
+                                    || field_name.starts_with("Input: ")
                                 {
                                     let mut current_set = std::collections::HashSet::new();
                                     let field_type = match field_name.as_str() {
@@ -4628,6 +4701,35 @@ async fn main() -> Result<()> {
                                         all_items = get_workflow_files(app.is_github());
                                         is_loading = false;
                                         // Pre-select any already-typed value
+                                        let current_val = menu.fields[menu.selected_idx].1.clone();
+                                        if !current_val.is_empty() {
+                                            current_set.insert(current_val);
+                                        }
+                                    } else if field_name.starts_with("Input: ") {
+                                        if let Some(ref menu) = app.edit_menu {
+                                            let input_name =
+                                                field_name.strip_prefix("Input: ").unwrap_or("");
+                                            if let Some(input) = menu
+                                                .workflow_inputs
+                                                .iter()
+                                                .find(|i| i.name == input_name)
+                                            {
+                                                use crate::domain::workflow_inputs::WorkflowInputType;
+                                                match input.input_type {
+                                                    WorkflowInputType::Choice => {
+                                                        all_items = input.options.clone();
+                                                    }
+                                                    WorkflowInputType::Boolean => {
+                                                        all_items = vec![
+                                                            "true".to_string(),
+                                                            "false".to_string(),
+                                                        ];
+                                                    }
+                                                    _ => {}
+                                                }
+                                                is_loading = false;
+                                            }
+                                        }
                                         let current_val = menu.fields[menu.selected_idx].1.clone();
                                         if !current_val.is_empty() {
                                             current_set.insert(current_val);
@@ -4853,7 +4955,12 @@ async fn main() -> Result<()> {
                                                     is_loading: false,
                                                     entity_iid: 0,
                                                     entity_type: entity_type.clone(),
-                                                    field_type: field_type.to_string(),
+                                                    field_type: if field_name.starts_with("Input: ")
+                                                    {
+                                                        field_name.clone()
+                                                    } else {
+                                                        field_type.to_string()
+                                                    },
                                                     multi_select: false,
                                                     state: {
                                                         let mut s = ListState::default();


### PR DESCRIPTION
## What

### Workflow dispatch input detection (#242)

When selecting a GitHub Actions workflow file in the **Run Pipeline** form (press `n` on the Pipelines tab), the app now parses the workflow YAML for `workflow_dispatch.inputs` definitions. If inputs are found:

- The generic **Inputs** free-text field is replaced with per-input fields (e.g., `Input: version_increment`)
- **Choice**-type inputs open a fuzzy-searchable selector with available options
- **Boolean** inputs offer `true`/`false` selection
- Default values are pre-filled from the workflow definition
- Form submission collects per-input values and passes them as `-f key=value` flags to `gh workflow run`

See the `prepare-release.yml` workflow for an example — it has a `version_increment` choice input with `patch`/`minor`/`major` options.

### CI fix: prepare-release workflow

The **prepare-release** CI workflow was broken:
- **`ttyd` not installed**: VHS (Charmbracelet) needs `ttyd` to record terminal sessions in headless CI
- **No binary built**: The `.tape` files type `glab-tui` but the binary was never compiled — added Rust toolchain + `cargo build --release`

## Files changed

| File | Change |
|---|---|
| `.github/workflows/prepare-release.yml` | Add `ttyd`, Rust toolchain, binary build |
| `Cargo.toml` | Add `serde_yaml` for workflow YAML parsing |
| `src/domain/workflow_inputs.rs` | New module: YAML parsing + `WorkflowInput` types |
| `src/app.rs` | Add `workflow_inputs` field to `EditMenu` |
| `src/main.rs` | Parse inputs after workflow file selection, per-input selectors, form submission collection |

Closes #242