### PR TITLE
fix: Input selector not writing back selected value to edit menu field

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -744,7 +744,6 @@ async fn main() -> Result<()> {
 
     if let Some(ref dir) = custom_dir {
         if let Err(e) = std::env::set_current_dir(dir) {
-            eprintln!("Error changing directory to '{}': {}", dir, e);
             std::process::exit(1);
         }
     }
@@ -3832,13 +3831,6 @@ async fn main() -> Result<()> {
 
                                     if entity_iid == 0 || entity_type.starts_with("new_") {
                                         // Write the values directly to the active field of app.edit_menu
-                                        eprintln!(
-                                            "SELECTOR-CONFIRM-ENTER entity_type={} entity_iid={} field_type={} menu_present={}",
-                                            entity_type,
-                                            entity_iid,
-                                            field_type,
-                                            app.edit_menu.is_some()
-                                        );
                                         if let Some(ref mut menu) = app.edit_menu {
                                             let target_field_name = match field_type.as_str() {
                                                 "labels" => "Labels",
@@ -3888,10 +3880,6 @@ async fn main() -> Result<()> {
                                                         && !display_val.is_empty();
 
                                                     f.1 = display_val.clone();
-                                                    eprintln!(
-                                                        "SELECTOR-CONFIRM field updated: target={} new_value={}",
-                                                        target_field_name, display_val
-                                                    );
 
                                                     let _ = f; // release borrow before modifying fields
 
@@ -4590,13 +4578,7 @@ async fn main() -> Result<()> {
                                     String::new()
                                 };
 
-                                if field_name.starts_with("Input: ")
-                                {
-                                    eprintln!(
-                                        "EDITMENU-ENTER Input field field_name={} menu.workflow_inputs.len={}",
-                                        field_name,
-                                        menu.workflow_inputs.len()
-                                    );
+                                if field_name == "Labels"
                                     || field_name == "Assignees"
                                     || field_name == "Reviewers"
                                     || field_name == "Milestone"
@@ -4610,6 +4592,7 @@ async fn main() -> Result<()> {
                                     || field_name == "Tag"
                                     || field_name.starts_with("Input: ")
                                 {
+                                    if field_name.starts_with("Input: ") {}
                                     let mut current_set = std::collections::HashSet::new();
                                     let field_type = match field_name.as_str() {
                                         "Labels" => "labels",
@@ -5186,7 +5169,11 @@ async fn main() -> Result<()> {
                                             crate::app::TextInputAction::EditField {
                                                 entity_iid,
                                                 entity_type: entity_type.clone(),
-                                                field_type: field_type.to_string(),
+                                                field_type: if field_name.starts_with("Input: ") {
+                                                    field_name.clone()
+                                                } else {
+                                                    field_type.to_string()
+                                                },
                                             }
                                         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3832,6 +3832,13 @@ async fn main() -> Result<()> {
 
                                     if entity_iid == 0 || entity_type.starts_with("new_") {
                                         // Write the values directly to the active field of app.edit_menu
+                                        eprintln!(
+                                            "SELECTOR-CONFIRM-ENTER entity_type={} entity_iid={} field_type={} menu_present={}",
+                                            entity_type,
+                                            entity_iid,
+                                            field_type,
+                                            app.edit_menu.is_some()
+                                        );
                                         if let Some(ref mut menu) = app.edit_menu {
                                             let target_field_name = match field_type.as_str() {
                                                 "labels" => "Labels",
@@ -3881,6 +3888,10 @@ async fn main() -> Result<()> {
                                                         && !display_val.is_empty();
 
                                                     f.1 = display_val.clone();
+                                                    eprintln!(
+                                                        "SELECTOR-CONFIRM field updated: target={} new_value={}",
+                                                        target_field_name, display_val
+                                                    );
 
                                                     let _ = f; // release borrow before modifying fields
 
@@ -4579,7 +4590,13 @@ async fn main() -> Result<()> {
                                     String::new()
                                 };
 
-                                if field_name == "Labels"
+                                if field_name.starts_with("Input: ")
+                                {
+                                    eprintln!(
+                                        "EDITMENU-ENTER Input field field_name={} menu.workflow_inputs.len={}",
+                                        field_name,
+                                        menu.workflow_inputs.len()
+                                    );
                                     || field_name == "Assignees"
                                     || field_name == "Reviewers"
                                     || field_name == "Milestone"

--- a/src/main.rs
+++ b/src/main.rs
@@ -744,6 +744,7 @@ async fn main() -> Result<()> {
 
     if let Some(ref dir) = custom_dir {
         if let Err(e) = std::env::set_current_dir(dir) {
+            eprintln!("Error changing directory to '{}': {}", dir, e);
             std::process::exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4592,7 +4592,6 @@ async fn main() -> Result<()> {
                                     || field_name == "Tag"
                                     || field_name.starts_with("Input: ")
                                 {
-                                    if field_name.starts_with("Input: ") {}
                                     let mut current_set = std::collections::HashSet::new();
                                     let field_type = match field_name.as_str() {
                                         "Labels" => "labels",
@@ -4859,7 +4858,11 @@ async fn main() -> Result<()> {
                                         is_loading,
                                         entity_iid,
                                         entity_type: entity_type.clone(),
-                                        field_type: field_type.to_string(),
+                                        field_type: if field_name.starts_with("Input: ") {
+                                            field_name.clone()
+                                        } else {
+                                            field_type.to_string()
+                                        },
                                         multi_select,
                                         state: {
                                             let mut s = ListState::default();


### PR DESCRIPTION
## Root cause

The selector for `Input: *` fields was created at two sites. Only the async-loading path (line 4979) correctly set `field_type` to `field_name.clone()` for Input fields. The primary creation path (line 4885) used `field_type.to_string()` which resolves to `""` since the match falls to `_ => ""` for unknown field names.

At selector confirmation time:
- `selector.field_type` = `""` (not `"Input: version_increment"`)
- `target_field_name` match falls to `_ => ""`
- Empty target means the field is never found in `menu.fields`
- The value is never written back — field stays at its default

## Fix

Apply the same `if field_name.starts_with("Input: ") { field_name.clone() } else { field_type.to_string() }` pattern to the primary selector creation path.