### PR TITLE
fix: use confirm popup overlay for review submission instead of bare keybinds (#247)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1764,7 +1764,6 @@ pub enum OverlayKind {
     Configure,
     SaveMenu,
     ColumnFilter,
-    SubmitReview,
     ConfirmPopup,
 }
 
@@ -1778,6 +1777,7 @@ pub enum ConfirmAction {
     CloseIssue(u64),       // issue iid
     CloseMr(u64),          // mr iid
     MergeMr(u64),          // mr iid
+    SubmitReview(u64),     // mr iid
 }
 
 pub struct App {
@@ -1828,7 +1828,7 @@ pub struct App {
     pub diff_view: Option<DiffView>,
     pub current_comments: Vec<crate::domain::mr::DiscussionNote>,
     pub last_fetched_mr_iid: Option<u64>,
-    pub show_submit_review_prompt: Option<u64>,
+
     pub confirm_popup: Option<ConfirmAction>,
     pub confirm_popup_selected_yes: bool,
     pub diff_loading: bool,
@@ -1923,7 +1923,6 @@ impl Default for App {
             diff_view: None,
             current_comments: Vec::new(),
             last_fetched_mr_iid: None,
-            show_submit_review_prompt: None,
             confirm_popup: None,
             confirm_popup_selected_yes: false,
             diff_loading: false,
@@ -4538,14 +4537,6 @@ index abcdef..ffffff 100644
             side_by_side[3].right.as_ref().unwrap().content,
             " normal line"
         );
-    }
-
-    #[test]
-    fn test_show_submit_review_prompt_defaults() {
-        let app = App::default();
-        assert_eq!(app.show_submit_review_prompt, None);
-        assert!(!app.in_review_mode);
-        assert!(app.draft_comments.is_empty());
     }
 
     #[test]

--- a/src/handlers/overlays.rs
+++ b/src/handlers/overlays.rs
@@ -9,46 +9,6 @@ use ratatui::widgets::ListState;
 use std::time::Instant;
 use tokio::sync::mpsc::UnboundedSender;
 
-pub fn handle_submit_review_prompt(app: &mut App, key_event: &KeyEvent) -> bool {
-    if let Some(mr_iid) = app.show_submit_review_prompt {
-        match key_event.code {
-            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
-                app.show_submit_review_prompt = None;
-                app.selector = Some(crate::app::Selector {
-                    title: " Submit Pull Request Review ".to_string(),
-                    all_items: vec![
-                        "Approve".to_string(),
-                        "Request Changes".to_string(),
-                        "Comment".to_string(),
-                    ],
-                    selected_items: std::collections::HashSet::new(),
-                    cursor_idx: 0,
-                    search_query: String::new(),
-                    is_filtering: false,
-                    is_loading: false,
-                    entity_iid: mr_iid,
-                    entity_type: "mr".to_string(),
-                    field_type: "review_submit_status".to_string(),
-                    multi_select: false,
-                    state: ListState::default(),
-                });
-            }
-            KeyCode::Char('n') | KeyCode::Char('N') => {
-                app.show_submit_review_prompt = None;
-                app.draft_comments.clear();
-                app.in_review_mode = false;
-                app.diff_view = None;
-            }
-            KeyCode::Esc | KeyCode::Char('q') => {
-                app.show_submit_review_prompt = None;
-            }
-            _ => {}
-        }
-        return true;
-    }
-    false
-}
-
 pub fn handle_confirm_popup(
     app: &mut App,
     key_event: &KeyEvent,
@@ -67,7 +27,11 @@ pub fn handle_confirm_popup(
             }
             KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
                 if key_event.code == KeyCode::Enter && !app.confirm_popup_selected_yes {
-                    // Cancel
+                    if matches!(confirm_action, crate::app::ConfirmAction::SubmitReview(_)) {
+                        app.draft_comments.clear();
+                        app.in_review_mode = false;
+                        app.diff_view = None;
+                    }
                     return true;
                 }
                 match confirm_action {
@@ -252,9 +216,35 @@ pub fn handle_confirm_popup(
                             ));
                         });
                     }
+                    crate::app::ConfirmAction::SubmitReview(mr_iid) => {
+                        app.selector = Some(crate::app::Selector {
+                            title: " Submit Pull Request Review ".to_string(),
+                            all_items: vec![
+                                "Approve".to_string(),
+                                "Request Changes".to_string(),
+                                "Comment".to_string(),
+                            ],
+                            selected_items: std::collections::HashSet::new(),
+                            cursor_idx: 0,
+                            search_query: String::new(),
+                            is_filtering: false,
+                            is_loading: false,
+                            entity_iid: mr_iid,
+                            entity_type: "mr".to_string(),
+                            field_type: "review_submit_status".to_string(),
+                            multi_select: false,
+                            state: ListState::default(),
+                        });
+                    }
                 }
             }
-            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {}
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                if matches!(confirm_action, crate::app::ConfirmAction::SubmitReview(_)) {
+                    app.draft_comments.clear();
+                    app.in_review_mode = false;
+                    app.diff_view = None;
+                }
+            }
             _ => {
                 app.confirm_popup = Some(confirm_action);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,11 +199,6 @@ fn handle_mouse_event(app: &mut App, mouse_event: &crossterm::event::MouseEvent)
                         handle_confirm_popup_mouse(app, *rect, row, col);
                         return;
                     }
-                    OverlayKind::SubmitReview => {
-                        // Click anywhere on the prompt → close (same as Esc)
-                        app.show_submit_review_prompt = None;
-                        return;
-                    }
                     OverlayKind::ColumnFilter => {
                         handle_selector_mouse(app, inner, row, col, 3, 3);
                         return;
@@ -440,10 +435,36 @@ fn handle_confirm_popup_mouse(app: &mut App, rect: ratatui::layout::Rect, row: u
                             ));
                         });
                     }
+                    crate::app::ConfirmAction::SubmitReview(mr_iid) => {
+                        app.selector = Some(crate::app::Selector {
+                            title: " Submit Pull Request Review ".to_string(),
+                            all_items: vec![
+                                "Approve".to_string(),
+                                "Request Changes".to_string(),
+                                "Comment".to_string(),
+                            ],
+                            selected_items: std::collections::HashSet::new(),
+                            cursor_idx: 0,
+                            search_query: String::new(),
+                            is_filtering: false,
+                            is_loading: false,
+                            entity_iid: mr_iid,
+                            entity_type: "mr".to_string(),
+                            field_type: "review_submit_status".to_string(),
+                            multi_select: false,
+                            state: ratatui::widgets::ListState::default(),
+                        });
+                    }
                 }
             }
+        } else {
+            // NO clicked — if the confirm_action was SubmitReview, clean up
+            if matches!(confirm_action, crate::app::ConfirmAction::SubmitReview(_)) {
+                app.draft_comments.clear();
+                app.in_review_mode = false;
+                app.diff_view = None;
+            }
         }
-        // else: NO clicked — popup was already taken, so it's dismissed
     }
 }
 
@@ -1611,13 +1632,7 @@ async fn main() -> Result<()> {
                         continue;
                     }
 
-                    if handle_submit_review_prompt(&mut app, &key_event)
-                        || handle_confirm_popup(
-                            &mut app,
-                            &key_event,
-                            &mut terminal,
-                            events.sender(),
-                        )
+                    if handle_confirm_popup(&mut app, &key_event, &mut terminal, events.sender())
                         || handle_help_keybinding(&mut app, &key_event)
                         || handle_help_overlay(&mut app, &key_event)
                         || handle_switch_repo(&mut app, &key_event)
@@ -5217,7 +5232,10 @@ async fn main() -> Result<()> {
                                     diff_view.file_tree_visible = true;
                                 } else {
                                     if !app.draft_comments.is_empty() {
-                                        app.show_submit_review_prompt = Some(diff_view.mr_iid);
+                                        app.confirm_popup =
+                                            Some(crate::app::ConfirmAction::SubmitReview(
+                                                diff_view.mr_iid,
+                                            ));
                                     } else {
                                         app.diff_view = None;
                                         continue;
@@ -5278,7 +5296,10 @@ async fn main() -> Result<()> {
                                         diff_view.search_active = false;
                                     }
                                     if !app.draft_comments.is_empty() {
-                                        app.show_submit_review_prompt = Some(diff_view.mr_iid);
+                                        app.confirm_popup =
+                                            Some(crate::app::ConfirmAction::SubmitReview(
+                                                diff_view.mr_iid,
+                                            ));
                                     } else {
                                         app.diff_view = None;
                                         continue;

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1778,46 +1778,6 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
         }
     }
 
-    if app.show_submit_review_prompt.is_some() {
-        let block = Block::default()
-            .title(format!(" {} Submit Review? ", icons.action_review))
-            .title_style(
-                Style::default()
-                    .fg(THEME.read().unwrap().header_fg)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(THEME.read().unwrap().border_focused))
-            .border_type(BorderType::Double)
-            .style(Style::default().bg(Color::Reset));
-
-        let area = centered_rect_fixed(60, 9, size);
-        app.overlay_stack
-            .push((crate::app::OverlayKind::SubmitReview, area));
-
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints([
-                Constraint::Min(0), // Message
-            ])
-            .split(area);
-
-        let message_p = Paragraph::new(vec![
-            Line::from(""),
-            Line::from(
-                "You have pending draft comments. Would you like to submit your review now?",
-            ),
-        ])
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(THEME.read().unwrap().text_normal))
-        .wrap(ratatui::widgets::Wrap { trim: true });
-
-        f.render_widget(Clear, area);
-        f.render_widget(block, area);
-        f.render_widget(message_p, chunks[0]);
-    }
-
     if let Some(confirm) = &app.confirm_popup {
         let kind = app.kind();
         let (title, message) = match confirm {
@@ -1871,6 +1831,11 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
                     format!("Are you sure you want to merge {mr_short} #{}?", iid),
                 )
             }
+            crate::app::ConfirmAction::SubmitReview(_) => (
+                format!(" {} Submit Review? ", icons.action_review),
+                "You have pending draft comments. Would you like to submit your review now?"
+                    .to_string(),
+            ),
         };
 
         let block = Block::default()


### PR DESCRIPTION
Closes #247

Replace the standalone yes/no review prompt (hardcoded y/n keybinds, custom `OverlayKind::SubmitReview`, separate handler and renderer) with the standard `ConfirmPopup` overlay used by all other destructive actions (close, delete, merge).

Now shows styled **[ YES ]** / **[ NO ]** buttons with h/l to toggle, Enter/y to confirm, and n/Esc to cancel — consistent with the rest of the UI.

### Changes
- Removed `OverlayKind::SubmitReview` variant and `show_submit_review_prompt` field
- Removed `handle_submit_review_prompt` function and its render block
- Added `SubmitReview(u64)` to `ConfirmAction` enum
- Integrated review submission into existing `handle_confirm_popup` handler (both keyboard and mouse)
- Net: +75 / -108 lines