### PR TITLE
fix: preserve nested subgroups when parsing remote project path

### DIFF
--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -579,23 +579,10 @@ pub async fn get_project_context() -> Result<String> {
         return Ok("unknown/unknown".to_string());
     }
 
-    let url = String::from_utf8(output.stdout)?.trim().to_string();
+    let url = String::from_utf8(output.stdout)?;
 
-    // Parse url to extract namespace/repo
-    let path = if url.starts_with("git@") {
-        url.split(':').nth(1).unwrap_or("unknown/unknown")
-    } else if url.starts_with("http") {
-        let parts: Vec<&str> = url.split('/').collect();
-        if parts.len() >= 2 {
-            let p = format!("{}/{}", parts[parts.len() - 2], parts[parts.len() - 1]);
-            return Ok(p.trim_end_matches(".git").to_string());
-        }
-        "unknown/unknown"
-    } else {
-        "unknown/unknown"
-    };
-
-    Ok(path.trim_end_matches(".git").to_string())
+    Ok(crate::git_helpers::parse_project_path(&url)
+        .unwrap_or_else(|| "unknown/unknown".to_string()))
 }
 
 #[cfg(test)]

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -22,6 +22,31 @@ pub fn get_current_branch() -> Option<String> {
     None
 }
 
+/// Extracts the `namespace/project` path from a git remote URL.
+///
+/// Accepts `scheme://[user[:pass]@]host[:port]/namespace/project[.git]` and
+/// scp-style `git@host:namespace/project[.git]`. Every segment after the host
+/// is preserved, because GitLab namespaces can nest arbitrarily deep
+/// (`group/subgroup/subsubgroup/project`).
+///
+/// Returns `None` when the URL has no parseable namespace.
+pub fn parse_project_path(url: &str) -> Option<String> {
+    let url = url.trim();
+    // Drop everything up to and including the host, keeping the rest intact.
+    // Splitting on "://" must be tried first, since those URLs also contain ':'.
+    let path = if let Some((_scheme, rest)) = url.split_once("://") {
+        rest.split_once('/')?.1
+    } else if let Some((_host, rest)) = url.split_once(':') {
+        rest
+    } else {
+        return None;
+    };
+
+    let path = path.trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    path.contains('/').then(|| path.to_string())
+}
+
 pub fn slugify(s: &str) -> String {
     let mut slug = String::with_capacity(s.len());
     for c in s.to_lowercase().chars() {
@@ -154,5 +179,84 @@ pub fn get_workflow_files(is_github: bool) -> Vec<String> {
             .collect();
         files.sort();
         files
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_project_path;
+
+    #[test]
+    fn keeps_nested_subgroups_over_https() {
+        assert_eq!(
+            parse_project_path("https://gitlab.example.com/dev/cbr/salesforce/salesforce.git")
+                .as_deref(),
+            Some("dev/cbr/salesforce/salesforce")
+        );
+    }
+
+    #[test]
+    fn keeps_nested_subgroups_over_scp_style_ssh() {
+        assert_eq!(
+            parse_project_path("git@gitlab.example.com:dev/cbr/salesforce/salesforce.git")
+                .as_deref(),
+            Some("dev/cbr/salesforce/salesforce")
+        );
+    }
+
+    #[test]
+    fn parses_single_namespace_https() {
+        assert_eq!(
+            parse_project_path("https://gitlab.com/group/repo.git").as_deref(),
+            Some("group/repo")
+        );
+    }
+
+    #[test]
+    fn parses_ssh_scheme_with_port() {
+        assert_eq!(
+            parse_project_path("ssh://git@gitlab.example.com:2222/group/sub/repo.git").as_deref(),
+            Some("group/sub/repo")
+        );
+    }
+
+    #[test]
+    fn parses_https_with_port() {
+        assert_eq!(
+            parse_project_path("https://gitlab.example.com:8443/group/sub/repo.git").as_deref(),
+            Some("group/sub/repo")
+        );
+    }
+
+    #[test]
+    fn ignores_embedded_credentials() {
+        assert_eq!(
+            parse_project_path("https://user:token@gitlab.example.com/group/sub/repo.git")
+                .as_deref(),
+            Some("group/sub/repo")
+        );
+    }
+
+    #[test]
+    fn tolerates_missing_git_suffix_and_trailing_slash() {
+        assert_eq!(
+            parse_project_path("https://gitlab.example.com/group/sub/repo/").as_deref(),
+            Some("group/sub/repo")
+        );
+    }
+
+    #[test]
+    fn preserves_project_names_containing_git() {
+        assert_eq!(
+            parse_project_path("https://gitlab.example.com/group/my.github.git").as_deref(),
+            Some("group/my.github")
+        );
+    }
+
+    #[test]
+    fn rejects_urls_without_a_namespace() {
+        assert_eq!(parse_project_path("https://gitlab.example.com/"), None);
+        assert_eq!(parse_project_path("not-a-url"), None);
+        assert_eq!(parse_project_path(""), None);
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -198,20 +198,8 @@ fn get_project_context_for_path(repo_path: &str) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let path = if url.starts_with("git@") {
-        url.split(':').nth(1).unwrap_or("").to_string()
-    } else if url.starts_with("http") {
-        let parts: Vec<&str> = url.split('/').collect();
-        if parts.len() >= 2 {
-            format!("{}/{}", parts[parts.len() - 2], parts[parts.len() - 1])
-        } else {
-            return None;
-        }
-    } else {
-        return None;
-    };
-    Some(path.trim_end_matches(".git").to_string())
+    let url = String::from_utf8_lossy(&output.stdout);
+    crate::git_helpers::parse_project_path(&url)
 }
 
 pub fn is_git_repo(path: &str) -> bool {


### PR DESCRIPTION
## Problem

The HTTPS branch of the remote-URL parser keeps only the **last two** path segments, so a project in a nested GitLab namespace loses its parent groups:

```
https://gitlab.example.com/group/sub/repo.git
  → group/repo       ❌ 404 Project Not Found
  → group/sub/repo   ✅ expected
```

For `https://host/group/sub/repo.git`, `split('/')` yields
`[https:, "", host, group, sub, repo.git]`; taking the last two
drops `group/subgroup` silently.

That value becomes `app.project_context` (`src/main.rs:788`) and is passed as
`-R <project>` to every `glab`/`gh` invocation (~40 call sites in
`src/backend/glab.rs`). On self-hosted GitLab with subgroups, **every tab fails
to load** — MRs, pipelines, issues, branches. `glab-tui doctor` shows it
directly:

```
Repository context
  Remote:  group/repo     ← truncated
```

Reproduced against a real instance:

```
$ glab mr list -R group/repo
ERROR  404 Not Found.

$ glab mr list -R group/sub/repo
Showing 4 open merge requests on group/sub/repo. (Page 1)
```

### Why this hasn't been noticed

Two conditions must coincide, and the common cases are both immune:

1. **HTTPS remote.** The `git@` branch used `url.split(':').nth(1)`, which
   already preserved the whole path — scp-style SSH remotes were never affected.
2. **Nested subgroups.** On gitlab.com and GitHub, `group/repo` is *exactly*
   two segments, so the truncation is a no-op.

Only self-hosted GitLab with subgroups + an HTTPS remote hits it.

## Fix

Replace the segment counting with a shared `git_helpers::parse_project_path`
that strips the scheme and host and keeps everything after it, so namespaces of
any depth survive.

Both copies of the logic are updated:

- `src/domain/client.rs` — `get_project_context`
- `src/utils/cache.rs` — `get_project_context_for_path`

Fixing only the first would leave the offline cache keyed on the truncated path.

Incidental correctness improvements, each covered by a test:

| Input | Before | After |
|---|---|---|
| `ssh://git@host:2222/group/sub/repo.git` | `None` | `group/sub/repo` |
| `https://host:8443/group/sub/repo.git` | `sub/repo` | `group/sub/repo` |
| `https://user:token@host/group/sub/repo.git` | `sub/repo` | `group/sub/repo` |
| `https://host/group/sub/repo/` (trailing `/`) | `repo/` | `group/sub/repo` |
| `https://host/group/my.github.git` | `group/my.github` | `group/my.github` |

The last row is why the fix uses `strip_suffix(".git")` rather than
`trim_end_matches(".git")` — the latter strips repeated suffixes, so a project
legitimately ending in `.git` would be mangled.

Unparseable remotes now return `None`, and each caller applies its existing
fallback (`"unknown/unknown"` in `client.rs`, skip-the-repo in `cache.rs`) —
matching the previous behaviour.

## Testing

9 unit tests added in `src/git_helpers.rs` covering nested subgroups over both
HTTPS and scp-style SSH, single-namespace paths, ports, embedded credentials,
trailing slashes, `.git`-suffixed project names, and rejection of malformed
input.

These tests were written **against the old logic first** and 6 of the 9 failed,
confirming they pin the actual bug rather than the new implementation.
Notably `keeps_nested_subgroups_over_scp_style_ssh` passed before the change,
which is what established that SSH remotes were unaffected.

```
cargo fmt                          ✅
cargo clippy --all-targets -- -D warnings   ✅ zero warnings
cargo test                         ✅ 71 passed
cargo test --bins                  ✅ 60 passed
cargo build --release              ✅
```

Verified end-to-end with the release binary in a repo four namespace levels
deep on a self-hosted instance:

```
Repository context
  Remote:  group/sub/repo   ← full path
  Backend: GitLab
```

No new dependencies; the parser stays pure and CLI-delegating per `AGENTS.md`.
