### PR TITLE
fix: preserve nested GitLab subgroups when parsing project path from remote URL

### DIFF
--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -579,23 +579,12 @@ pub async fn get_project_context() -> Result<String> {
         return Ok("unknown/unknown".to_string());
     }
 
-    let url = String::from_utf8(output.stdout)?.trim().to_string();
+    let url = String::from_utf8(output.stdout)?;
 
-    // Parse url to extract namespace/repo
-    let path = if url.starts_with("git@") {
-        url.split(':').nth(1).unwrap_or("unknown/unknown")
-    } else if url.starts_with("http") {
-        let parts: Vec<&str> = url.split('/').collect();
-        if parts.len() >= 2 {
-            let p = format!("{}/{}", parts[parts.len() - 2], parts[parts.len() - 1]);
-            return Ok(p.trim_end_matches(".git").to_string());
-        }
-        "unknown/unknown"
-    } else {
-        "unknown/unknown"
-    };
-
-    Ok(path.trim_end_matches(".git").to_string())
+    // Parse the remote URL to extract the full namespace/repo path,
+    // preserving any GitLab subgroups (e.g. `group/subgroup/project`).
+    Ok(crate::git_helpers::parse_project_path_from_remote_url(&url)
+        .unwrap_or_else(|| "unknown/unknown".to_string()))
 }
 
 #[cfg(test)]

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -1,3 +1,42 @@
+/// Parses a git remote URL into a GitLab/GitHub project path
+/// (e.g. `"group/subgroup/project"`), preserving *all* subgroups.
+///
+/// Naively taking the last two `/`-separated segments of an HTTP(S) remote
+/// truncates any GitLab project that lives under one or more subgroups
+/// (e.g. `https://gitlab.example.com/group/subgroup/project.git` would be
+/// misread as `subgroup/project`, which does not exist on the server and
+/// causes every API call to 404). This function keeps the full path after
+/// the host instead.
+///
+/// Supports:
+/// - SSH shorthand: `git@host:group/subgroup/project.git`
+/// - SSH URL: `ssh://git@host[:port]/group/subgroup/project.git`
+/// - HTTP(S): `https://host[:port]/group/subgroup/project.git`
+pub fn parse_project_path_from_remote_url(url: &str) -> Option<String> {
+    let url = url.trim();
+    if url.is_empty() {
+        return None;
+    }
+
+    let path = if let Some(rest) = url.strip_prefix("git@") {
+        // git@host:group/subgroup/project.git
+        rest.split_once(':').map(|(_, path)| path)
+    } else if let Some(rest) = url
+        .strip_prefix("ssh://")
+        .or_else(|| url.strip_prefix("http://"))
+        .or_else(|| url.strip_prefix("https://"))
+    {
+        // Strip the "user@host[:port]" portion; keep everything after the
+        // first '/' as the (possibly multi-segment) project path.
+        rest.split_once('/').map(|(_, path)| path)
+    } else {
+        None
+    };
+
+    path.map(|p| p.trim_end_matches(".git").trim_matches('/').to_string())
+        .filter(|p| !p.is_empty())
+}
+
 pub fn get_current_branch() -> Option<String> {
     let output = std::process::Command::new("git")
         .args(["symbolic-ref", "--short", "HEAD"])
@@ -154,5 +193,98 @@ pub fn get_workflow_files(is_github: bool) -> Vec<String> {
             .collect();
         files.sort();
         files
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_https_remote() {
+        assert_eq!(
+            parse_project_path_from_remote_url("https://github.com/rcieri/glab-tui.git"),
+            Some("rcieri/glab-tui".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_remote_with_nested_subgroups() {
+        assert_eq!(
+            parse_project_path_from_remote_url(
+                "https://onl-nfv-git.osc.tac.net/cloudhealth/exporters/bigip-ndal.git"
+            ),
+            Some("cloudhealth/exporters/bigip-ndal".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_remote_with_deeply_nested_subgroups() {
+        assert_eq!(
+            parse_project_path_from_remote_url("https://gitlab.example.com/a/b/c/d/project.git"),
+            Some("a/b/c/d/project".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_remote_without_dot_git_suffix() {
+        assert_eq!(
+            parse_project_path_from_remote_url("https://gitlab.com/group/subgroup/project"),
+            Some("group/subgroup/project".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_remote_with_port() {
+        assert_eq!(
+            parse_project_path_from_remote_url(
+                "https://gitlab.example.com:8443/group/sub/project.git"
+            ),
+            Some("group/sub/project".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_shorthand_remote() {
+        assert_eq!(
+            parse_project_path_from_remote_url("git@github.com:rcieri/glab-tui.git"),
+            Some("rcieri/glab-tui".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_shorthand_remote_with_nested_subgroups() {
+        assert_eq!(
+            parse_project_path_from_remote_url(
+                "git@onl-nfv-git.osc.tac.net:cloudhealth/exporters/bigip-ndal.git"
+            ),
+            Some("cloudhealth/exporters/bigip-ndal".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_url_remote() {
+        assert_eq!(
+            parse_project_path_from_remote_url(
+                "ssh://git@gitlab.example.com/group/sub/project.git"
+            ),
+            Some("group/sub/project".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_url_remote_with_port() {
+        assert_eq!(
+            parse_project_path_from_remote_url(
+                "ssh://git@gitlab.example.com:2222/group/sub/project.git"
+            ),
+            Some("group/sub/project".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_or_unrecognized_url() {
+        assert_eq!(parse_project_path_from_remote_url(""), None);
+        assert_eq!(parse_project_path_from_remote_url("not-a-url"), None);
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -198,20 +198,10 @@ fn get_project_context_for_path(repo_path: &str) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let path = if url.starts_with("git@") {
-        url.split(':').nth(1).unwrap_or("").to_string()
-    } else if url.starts_with("http") {
-        let parts: Vec<&str> = url.split('/').collect();
-        if parts.len() >= 2 {
-            format!("{}/{}", parts[parts.len() - 2], parts[parts.len() - 1])
-        } else {
-            return None;
-        }
-    } else {
-        return None;
-    };
-    Some(path.trim_end_matches(".git").to_string())
+    let url = String::from_utf8_lossy(&output.stdout).to_string();
+    // Preserve any GitLab subgroups in the parsed project path
+    // (see `git_helpers::parse_project_path_from_remote_url`).
+    crate::git_helpers::parse_project_path_from_remote_url(&url)
 }
 
 pub fn is_git_repo(path: &str) -> bool {


### PR DESCRIPTION
## Summary

`get_project_context()` (and its duplicate `get_project_context_for_path()` in `utils/cache.rs`) truncates the project path derived from an HTTP(S) `origin` remote to only the **last two** `/`-separated segments. This silently drops any GitLab subgroups, so projects nested under one or more subgroups fail to resolve.

## The bug

Given a remote like:

```
https://gitlab.example.com/group/subgroup/project.git
```

glab-tui resolves the project as `subgroup/project` instead of `group/subgroup/project`, then passes that truncated path to `glab ... -R subgroup/project`. Since that project path doesn't exist on the GitLab instance, **every API call 404s** — even though `glab`/`gh` work perfectly fine when invoked directly with the correct full path.

This affects any self-hosted/enterprise GitLab instance that uses subgroups, which is a very common setup (e.g. `group/team/service` or deeper). The SSH shorthand branch (`git@host:group/subgroup/project.git`) was already unaffected since it just splits once on `:` and keeps everything after — this PR brings the HTTP(S)/SSH-URL parsing in line with that same "keep everything after the host" behavior.

### Repro

```
$ git remote get-url origin
https://gitlab.example.com/group/subgroup/project.git

$ glab-tui doctor
Repository context
-------------------
  Remote:  subgroup/project      # ← wrong, should be group/subgroup/project
  Backend: GitLab
```

## What changed

- Added `git_helpers::parse_project_path_from_remote_url()` — a single, well-tested helper that keeps the *entire* path after the host for `http(s)://` and `ssh://` remotes, and everything after the colon for `git@host:...` shorthand remotes.
- Replaced the duplicated truncation logic in `domain/client.rs::get_project_context()` and `utils/cache.rs::get_project_context_for_path()` with calls to the new shared helper, removing the duplication.
- Added 10 unit tests covering: simple two-segment paths, single and deeply nested subgroups, with/without `.git` suffix, custom ports, and both SSH shorthand and `ssh://` URL forms.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features` — no warnings
- `cargo test --bin glab-tui` — 61 passed (10 new + 51 existing, all green)
- `cargo test --test e2e -- --test-threads=1` — 71 passed, no regressions
- Manually verified against a real enterprise GitLab remote with a nested subgroup (`https://<host>/group/subgroup/project.git`): before the fix, `glab-tui doctor` showed `Remote: subgroup/project` and the TUI 404'd on launch; after the fix it correctly shows `Remote: group/subgroup/project` and all tabs load normally.

## Risk

Low — this is a pure bugfix isolated to remote-URL parsing, with no behavior change for the (already-working) simple `namespace/repo` case. All existing tests pass unmodified.