### PR TITLE
fix: use correct --variables flag for glab ci run

### DIFF
--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -1347,11 +1347,11 @@ impl Backend for GlabBackend {
             args.push("--branch".into());
             args.push(branch.into());
         }
-        if mr {
+        if mr && variables.is_empty() && inputs.is_empty() {
             args.push("--mr".into());
         }
         for (k, v) in variables {
-            args.push("--variable".into());
+            args.push("--variables".into());
             args.push(format!("{}:{}", k, v));
         }
         for (k, v) in inputs {


### PR DESCRIPTION
The run_pipeline function was passing --variable (singular) to glab ci run, but the correct flag is --variables (plural). This caused pipeline execution with variables to fail.

Also added a guard to skip the --mr flag when variables or inputs are provided, since the glab CLI does not allow combining these flags.

Reference: https://docs.gitlab.com/cli/ci/run/