### PR TITLE
fix(ci): skip rust-cache on release tag builds (#260)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache dependencies
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}


### PR DESCRIPTION
Closes #260

Scopes the `Swatinem/rust-cache` step in `release.yml` off the release path by adding:

```yaml
if: ${{ !startsWith(github.ref, 'refs/tags/') }}
```

Since this workflow only triggers on `push: tags: ['v*']`, the cache step is now a no-op on every release build. This prevents a malicious PR branch from poisoning the shared cache that a later tag build would restore into the published binary or Docker image (option 2 from the issue).