### PR TITLE
feat(config): add api_per_page to bound per-request response size

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -93,6 +93,7 @@ impl Backend for GhBackend {
         project: &str,
         show_closed: bool,
         page_size: usize,
+        _per_request: usize,
     ) -> Result<Vec<Issue>> {
         let state = if show_closed { "all" } else { "open" };
         let total = page_size * 10;
@@ -498,6 +499,7 @@ impl Backend for GhBackend {
         project: &str,
         show_closed: bool,
         page_size: usize,
+        _per_request: usize,
     ) -> Result<Vec<MergeRequest>> {
         let state = if show_closed { "all" } else { "open" };
         let total = page_size * 10;
@@ -1091,7 +1093,12 @@ impl Backend for GhBackend {
 
     // ── Pipelines ──
 
-    async fn list_pipelines(&self, project: &str, page_size: usize) -> Result<Vec<Pipeline>> {
+    async fn list_pipelines(
+        &self,
+        project: &str,
+        page_size: usize,
+        _per_request: usize,
+    ) -> Result<Vec<Pipeline>> {
         let total = page_size * 10;
         let raw = self
             .run_gh(

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -28,6 +28,11 @@ fn normalize_labels(s: &str) -> String {
     s.replace(", ", ",")
 }
 
+/// Number of `--per-page per_request` calls needed to cover a `page_size` item budget.
+fn page_count(page_size: usize, per_request: usize) -> usize {
+    page_size.div_ceil(per_request.max(1)).max(1)
+}
+
 pub struct GlabBackend {
     tx: Option<UnboundedSender<Event>>,
 }
@@ -97,11 +102,13 @@ impl Backend for GlabBackend {
         project: &str,
         show_closed: bool,
         page_size: usize,
+        per_request: usize,
     ) -> Result<Vec<Issue>> {
-        let pages = page_size.div_ceil(100).max(1);
+        let pages = page_count(page_size, per_request);
         let mut all: Vec<Issue> = Vec::new();
         for page in 1..=pages {
             let page_str = page.to_string();
+            let per_request_str = per_request.to_string();
             let raw = self
                 .run_glab(
                     &if show_closed {
@@ -116,7 +123,7 @@ impl Backend for GlabBackend {
                             "--page",
                             &page_str,
                             "--per-page",
-                            "100",
+                            &per_request_str,
                         ]
                     } else {
                         vec![
@@ -129,7 +136,7 @@ impl Backend for GlabBackend {
                             "--page",
                             &page_str,
                             "--per-page",
-                            "100",
+                            &per_request_str,
                         ]
                     },
                     "Fetching Issues",
@@ -196,7 +203,7 @@ impl Backend for GlabBackend {
                     due_date: i.due_date,
                 }
             }));
-            if len < 100 {
+            if len < per_request {
                 break;
             }
         }
@@ -527,11 +534,13 @@ impl Backend for GlabBackend {
         project: &str,
         show_closed: bool,
         page_size: usize,
+        per_request: usize,
     ) -> Result<Vec<MergeRequest>> {
-        let pages = page_size.div_ceil(100).max(1);
+        let pages = page_count(page_size, per_request);
         let mut all: Vec<MergeRequest> = Vec::new();
         for page in 1..=pages {
             let page_str = page.to_string();
+            let per_request_str = per_request.to_string();
             let raw = self
                 .run_glab(
                     &if show_closed {
@@ -546,7 +555,7 @@ impl Backend for GlabBackend {
                             "--page",
                             &page_str,
                             "--per-page",
-                            "100",
+                            &per_request_str,
                         ]
                     } else {
                         vec![
@@ -559,7 +568,7 @@ impl Backend for GlabBackend {
                             "--page",
                             &page_str,
                             "--per-page",
-                            "100",
+                            &per_request_str,
                         ]
                     },
                     "Fetching MRs",
@@ -658,7 +667,7 @@ impl Backend for GlabBackend {
                     }),
                 }
             }));
-            if len < 100 {
+            if len < per_request {
                 break;
             }
         }
@@ -1192,8 +1201,13 @@ impl Backend for GlabBackend {
 
     // ── Pipelines ──
 
-    async fn list_pipelines(&self, project: &str, page_size: usize) -> Result<Vec<Pipeline>> {
-        let pages = page_size.div_ceil(100).max(1);
+    async fn list_pipelines(
+        &self,
+        project: &str,
+        page_size: usize,
+        per_request: usize,
+    ) -> Result<Vec<Pipeline>> {
+        let pages = page_count(page_size, per_request);
         let mut all: Vec<Pipeline> = Vec::new();
         for page in 1..=pages {
             let raw = self
@@ -1208,7 +1222,7 @@ impl Backend for GlabBackend {
                         "--page",
                         &page.to_string(),
                         "--per-page",
-                        "100",
+                        &per_request.to_string(),
                     ],
                     "Fetching Pipelines",
                 )
@@ -1234,7 +1248,7 @@ impl Backend for GlabBackend {
                 head_sha: String::new(),
                 actor_login: String::new(),
             }));
-            if len < 100 {
+            if len < per_request {
                 break;
             }
         }
@@ -2252,5 +2266,20 @@ mod tests {
         assert_eq!(normalize_labels("bug, feature"), "bug,feature");
         assert_eq!(normalize_labels("bug,feature"), "bug,feature");
         assert_eq!(normalize_labels("bug"), "bug");
+    }
+
+    #[test]
+    fn test_page_count_arithmetic() {
+        // page_count() is what list_issues, list_mrs, and list_pipelines call to decide
+        // how many `--per-page per_request` requests to issue for a given total item
+        // budget. Exercising it directly (rather than re-deriving the formula inline)
+        // means a regression to the hard-coded `div_ceil(100)` this replaced would fail
+        // this test.
+        assert_eq!(page_count(100, 20), 5);
+        assert_eq!(page_count(100, 100), 1);
+        assert_eq!(page_count(250, 100), 3);
+        // per_request = 0 must not panic (div_ceil would); clamped to 1 item per
+        // request, so a 100-item budget needs 100 requests.
+        assert_eq!(page_count(100, 0), 100);
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -57,11 +57,14 @@ pub trait Backend: Send + Sync {
     fn set_tx(&mut self, tx: UnboundedSender<Event>);
 
     // ── Issues ──
+    /// `page_size` is the total item budget across all pages; `per_request` is how many
+    /// items each HTTP call asks for.
     async fn list_issues(
         &self,
         project: &str,
         show_closed: bool,
         page_size: usize,
+        per_request: usize,
     ) -> Result<Vec<Issue>>;
     async fn get_issue(&self, project: &str, iid: u64) -> Result<Issue>;
     async fn close_issue(&self, project: &str, iid: u64) -> Result<()>;
@@ -110,11 +113,14 @@ pub trait Backend: Send + Sync {
     ) -> Result<()>;
 
     // ── Merge Requests ──
+    /// `page_size` is the total item budget across all pages; `per_request` is how many
+    /// items each HTTP call asks for.
     async fn list_mrs(
         &self,
         project: &str,
         show_closed: bool,
         page_size: usize,
+        per_request: usize,
     ) -> Result<Vec<MergeRequest>>;
     async fn get_mr(&self, project: &str, iid: u64) -> Result<MergeRequest>;
     async fn get_mr_diff(&self, project: &str, iid: u64) -> Result<String>;
@@ -193,7 +199,14 @@ pub trait Backend: Send + Sync {
     async fn open_milestone_in_browser(&self, project: &str, id: &str) -> Result<()>;
 
     // ── Pipelines ──
-    async fn list_pipelines(&self, project: &str, page_size: usize) -> Result<Vec<Pipeline>>;
+    /// `page_size` is the total item budget across all pages; `per_request` is how many
+    /// items each HTTP call asks for.
+    async fn list_pipelines(
+        &self,
+        project: &str,
+        page_size: usize,
+        per_request: usize,
+    ) -> Result<Vec<Pipeline>>;
     async fn list_pipeline_jobs(
         &self,
         project: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1089,6 +1089,10 @@ fn def_page_size() -> usize {
     100
 }
 
+fn def_api_per_page() -> usize {
+    100
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct UiConfig {
@@ -1116,6 +1120,8 @@ pub struct Config {
     pub keybindings: KeybindingConfig,
     #[serde(default = "def_page_size")]
     pub page_size: usize,
+    #[serde(default = "def_api_per_page")]
+    pub api_per_page: usize,
     pub disabled_tabs: Option<Vec<String>>,
     pub ui: UiConfig,
     pub issues: PaneConfig,
@@ -1139,6 +1145,7 @@ impl Default for Config {
             theme: ThemeOverrides::default(),
             keybindings: KeybindingConfig::default(),
             page_size: def_page_size(),
+            api_per_page: def_api_per_page(),
             disabled_tabs: None,
             ui: UiConfig::default(),
             issues: PaneConfig::default(),
@@ -1162,6 +1169,11 @@ impl Config {
         let _ = std::fs::create_dir_all(&path);
         path.push("config.toml");
         path
+    }
+
+    /// Per-request page size, clamped to GitLab's accepted `per_page` range.
+    pub fn api_per_page_clamped(&self) -> usize {
+        self.api_per_page.clamp(1, 100)
     }
 
     fn generate_default_toml() -> String {
@@ -1653,6 +1665,46 @@ impl Config {
 pub fn reload_theme() {
     if let Ok(mut theme) = THEME.write() {
         *theme = Config::load().resolve_theme();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_per_page_clamped_bounds_to_gitlab_range() {
+        let mut cfg = Config::default();
+
+        cfg.api_per_page = 0;
+        assert_eq!(cfg.api_per_page_clamped(), 1);
+
+        cfg.api_per_page = 250;
+        assert_eq!(cfg.api_per_page_clamped(), 100);
+
+        cfg.api_per_page = 20;
+        assert_eq!(cfg.api_per_page_clamped(), 20);
+
+        cfg.api_per_page = 100;
+        assert_eq!(cfg.api_per_page_clamped(), 100);
+    }
+
+    #[test]
+    fn api_per_page_defaults_to_100() {
+        assert_eq!(Config::default().api_per_page, 100);
+    }
+
+    #[test]
+    fn config_toml_missing_api_per_page_deserializes_to_default() {
+        // Mirrors an old config.toml written before `api_per_page` existed --
+        // omitting the field must not fail to parse, and must fall back to 100.
+        let toml_str = r#"
+page_size = 250
+"#;
+        let cfg: Config =
+            toml::from_str(toml_str).expect("config.toml without api_per_page must still parse");
+        assert_eq!(cfg.api_per_page, 100);
+        assert_eq!(cfg.page_size, 250);
     }
 }
 

--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -6,6 +6,7 @@ pub struct GitlabClient {
     pub backend: Box<dyn Backend>,
     pub tx: Option<tokio::sync::mpsc::UnboundedSender<crate::event::Event>>,
     pub page_size: usize,
+    pub api_per_page: usize,
 }
 
 impl GitlabClient {
@@ -31,6 +32,7 @@ impl GitlabClient {
             backend,
             tx: None,
             page_size: 100,
+            api_per_page: 100,
         })
     }
 
@@ -556,6 +558,7 @@ impl Clone for GitlabClient {
             backend,
             tx: self.tx.clone(),
             page_size: self.page_size,
+            api_per_page: self.api_per_page,
         }
     }
 }

--- a/src/domain/issues.rs
+++ b/src/domain/issues.rs
@@ -43,7 +43,12 @@ pub async fn list_issues(
 ) -> Result<Vec<Issue>> {
     client
         .backend
-        .list_issues(project_path, show_closed, client.page_size)
+        .list_issues(
+            project_path,
+            show_closed,
+            client.page_size,
+            client.api_per_page,
+        )
         .await
 }
 

--- a/src/domain/mr.rs
+++ b/src/domain/mr.rs
@@ -123,7 +123,12 @@ pub async fn list_mrs(
 ) -> Result<Vec<MergeRequest>> {
     client
         .backend
-        .list_mrs(project_path, show_closed, client.page_size)
+        .list_mrs(
+            project_path,
+            show_closed,
+            client.page_size,
+            client.api_per_page,
+        )
         .await
 }
 

--- a/src/domain/pipelines.rs
+++ b/src/domain/pipelines.rs
@@ -147,7 +147,7 @@ pub fn process_pipeline_jobs(all_jobs: Vec<Job>) -> Vec<Job> {
 pub async fn list_pipelines(client: &GitlabClient, project_path: &str) -> Result<Vec<Pipeline>> {
     client
         .backend
-        .list_pipelines(project_path, client.page_size)
+        .list_pipelines(project_path, client.page_size, client.api_per_page)
         .await
 }
 

--- a/src/domain/workflow_inputs.rs
+++ b/src/domain/workflow_inputs.rs
@@ -95,23 +95,77 @@ pub fn parse_workflow_inputs(yaml_path: &str) -> Option<Vec<WorkflowInput>> {
 mod tests {
     use super::*;
 
+    /// A `workflow_dispatch` block with a single choice input, in the shape
+    /// GitHub emits. Kept inline so the parser's tests do not depend on which
+    /// workflow files happen to exist in this repository.
+    const CHOICE_WORKFLOW: &str = r#"
+name: Prepare Release
+on:
+  workflow_dispatch:
+    inputs:
+      version_increment:
+        description: "Version increment"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+"#;
+
+    fn write_workflow(contents: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("workflow.yml");
+        std::fs::write(&path, contents).unwrap();
+        let path_str = path.to_str().unwrap().to_string();
+        (dir, path_str)
+    }
+
     #[test]
-    fn test_parse_prepare_release_workflow() {
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let yaml_path = format!("{}/.github/workflows/prepare-release.yml", manifest_dir);
-        let inputs = parse_workflow_inputs(&yaml_path);
-        assert!(
-            inputs.is_some(),
-            "Failed to parse prepare-release.yml — inputs should not be None"
-        );
-        let inputs = inputs.unwrap();
-        assert_eq!(inputs.len(), 1, "Expected 1 input, got {}", inputs.len());
+    fn parses_a_choice_input_with_all_its_fields() {
+        let (_dir, path) = write_workflow(CHOICE_WORKFLOW);
+        let inputs = parse_workflow_inputs(&path).expect("workflow_dispatch inputs should parse");
+        assert_eq!(inputs.len(), 1, "expected 1 input, got {}", inputs.len());
 
         let version = &inputs[0];
         assert_eq!(version.name, "version_increment");
-        assert_eq!(version.required, true);
+        assert_eq!(version.description, "Version increment");
+        assert!(version.required);
         assert_eq!(version.default, Some("patch".to_string()));
         assert_eq!(version.input_type, WorkflowInputType::Choice);
         assert_eq!(version.options, vec!["patch", "minor", "major"]);
+    }
+
+    #[test]
+    fn untyped_input_defaults_to_string_and_is_optional() {
+        let (_dir, path) = write_workflow(
+            r#"
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build"
+"#,
+        );
+        let inputs = parse_workflow_inputs(&path).expect("inputs should parse");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].input_type, WorkflowInputType::String);
+        assert!(!inputs[0].required);
+        assert_eq!(inputs[0].default, None);
+        assert!(inputs[0].options.is_empty());
+    }
+
+    #[test]
+    fn workflow_without_dispatch_inputs_yields_none() {
+        let (_dir, path) = write_workflow("name: CI\non:\n  push:\n    branches: [main]\n");
+        assert!(parse_workflow_inputs(&path).is_none());
+    }
+
+    #[test]
+    fn missing_file_yields_none() {
+        let (dir, _) = write_workflow("");
+        let absent = dir.path().join("does-not-exist.yml");
+        assert!(parse_workflow_inputs(absent.to_str().unwrap()).is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -855,6 +855,7 @@ async fn main() -> Result<()> {
 
     if let Ok(mut client) = domain::client::GitlabClient::new().await {
         client.page_size = app.config.page_size;
+        client.api_per_page = app.config.api_per_page_clamped();
         client.tx = Some(events.sender());
         app.gitlab_client = Some(client.clone());
         let tx = events.sender();
@@ -2902,6 +2903,8 @@ async fn main() -> Result<()> {
                                                         domain::client::GitlabClient::new().await
                                                     {
                                                         client.page_size = app.config.page_size;
+                                                        client.api_per_page =
+                                                            app.config.api_per_page_clamped();
                                                         client.tx = Some(events.sender());
                                                         client.backend.set_tx(events.sender());
                                                         app.gitlab_client = Some(client.clone());


### PR DESCRIPTION
## Problem

Some GitLab instances — or a proxy in front of one — truncate large REST response bodies mid-stream. On the instance where this surfaced, fetching MRs failed roughly 4 times out of 5 with:

```
ERROR  Unexpected EOF.
```

That message is `glab` faithfully failing to parse JSON that arrived incomplete. Measured directly: the body should be 641,925 bytes; failing runs returned 466,152 bytes, cut mid-string. It reproduces through a bare `glab api` call, so the truncation is server-side — not a bug in glab-tui or in `glab`.

Failure probability tracks response size:

| Request | Body | Success rate |
|---|---|---|
| open MRs only, 100/page | 34 KB | 5/5 |
| all states, 20/page | 120 KB | 5/5 |
| all states, 50/page | 299 KB | 3/5 |
| all states, 100/page | 642 KB | 1/5 |

The three paged GitLab fetches hard-code `--per-page 100`, and `page_size` only controls *how many pages* are requested (`page_size.div_ceil(100)`), never how big each request is. So there is currently no setting that avoids asking for the largest possible response.

## Change

Adds `api_per_page` (default `100`, clamped to GitLab's accepted 1–100 range) controlling how many items each HTTP request asks for. `page_size` keeps its existing meaning as the total item budget.

With `page_size = 100, api_per_page = 20` the fetch makes 5 requests of ~120 KB instead of one of ~642 KB — the same 100 items, with each response staying under the truncation threshold. Verified against the affected instance: 5/5 pages succeed where the single large request failed 4/5.

Applied to the three GitLab methods that page in a loop: `list_issues`, `list_mrs`, `list_pipelines`. The GitHub backend uses `--limit <total>` rather than per-page paging and is untouched.

**Default behaviour is unchanged** — at the default of 100 this is still one request per page.

This also fixes the last-page check in those three methods, which compared the returned length against a hard-coded `100`. With a smaller `api_per_page` it would have stopped after the first page and silently returned a truncated list.

## Testing

- `cargo test --bin glab-tui` — 4 new tests: clamping bounds, the default, deserialising a config file that omits the key, and the page-count arithmetic
- `cargo test --test e2e` — passes
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean

> **Stacked on #271**, which repairs a test that fails on `main` today and would otherwise make this PR's CI red for unrelated reasons. That PR's single commit appears here until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)