### PR TITLE
docs(backend): document _per_request in GhBackend and add api_per_page to generated TOML

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -88,6 +88,9 @@ impl Backend for GhBackend {
 
     // ── Issues ──
 
+    /// `_per_request` is unused in the GitHub backend (as with all `Backend`
+    /// methods that take it) — `gh` uses `--limit` for the total item count,
+    /// not per-page pagination. Only GitLab backends paginate per-request.
     async fn list_issues(
         &self,
         project: &str,
@@ -494,6 +497,8 @@ impl Backend for GhBackend {
 
     // ── Merge Requests ──
 
+    /// `_per_request` is unused in the GitHub backend — `gh` uses `--limit`
+    /// for the total item count, not per-page pagination.
     async fn list_mrs(
         &self,
         project: &str,
@@ -1093,6 +1098,8 @@ impl Backend for GhBackend {
 
     // ── Pipelines ──
 
+    /// `_per_request` is unused in the GitHub backend — `gh run list` uses
+    /// `--limit` for the total item count, not per-page pagination.
     async fn list_pipelines(
         &self,
         project: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1189,6 +1189,10 @@ theme_preset = "default"
 # Default request page size
 page_size = 100
 
+# Maximum items per API request (1-100). Lower this if your GitLab instance
+# truncates large JSON response bodies. Only affects GitLab backends.
+# api_per_page = 100
+
 # Per-color overrides (takes precedence over theme_preset).
 # Uncomment the [theme] line and any colors you want to override.
 # [theme]


### PR DESCRIPTION
## Changes

- Adds doc comments to `_per_request` parameters in `GhBackend` methods (`list_issues`, `list_mrs`, `list_pipelines`) explaining they are unused because `gh` uses `--limit` for totals, not per-page pagination
- Adds commented `api_per_page = 100` to `generate_default_toml()` so users discover the setting

Follow-up to #269.