### PR TITLE
feat(mr): polish MR table columns — reorder, all-caps labels, fetch_labels api_per_page

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2766,7 +2766,7 @@ impl App {
             Tab::Pipelines,
             |item, col| match col {
                 "ID" => vec![item.id().to_string()],
-                "Status" => vec![item.status().to_string()],
+                "Status" => vec![Self::pipeline_status_display(item.status()).to_string()],
                 "Ref" => vec![item.ref_branch().to_string()],
                 _ => vec![],
             },
@@ -2877,7 +2877,7 @@ impl App {
             |item, col| match col {
                 "ID" => vec![item.id().to_string()],
                 "Stage" => vec![item.stage().to_string()],
-                "Status" => vec![item.status().to_string()],
+                "Status" => vec![Self::pipeline_status_display(item.status()).to_string()],
                 "Name" => vec![item.name().to_string()],
                 _ => vec![],
             },
@@ -3176,7 +3176,11 @@ impl App {
         );
         Self::apply_column_filters(&mut list, &self.column_filters, Tab::Todos, |item, col| {
             match col {
-                "State" => vec![item.state.clone()],
+                "State" => vec![if item.state == "unread" || item.state == "pending" {
+                    "NEW".to_string()
+                } else {
+                    "READ".to_string()
+                }],
                 "Project" => vec![item.project_path.clone()],
                 "Type" => vec![item.target_type.clone()],
                 "ID" => vec![item.id.clone()],
@@ -3441,6 +3445,22 @@ impl App {
     /// Older config files stored lowercase API values ("opened", "Draft", …).
     /// After the display-alignment change those no longer appear in the
     /// filter-value sets, so this mapping keeps pre-existing filters working.
+    /// Maps raw API pipeline/job status strings to the uppercase display text
+    /// shown in the table cell (e.g. `"success"` → `"SUCCESS"`, `"canceled"` → `"CANCEL"`).
+    fn pipeline_status_display(raw: &str) -> &str {
+        match raw {
+            "success" => "SUCCESS",
+            "failed" => "FAILED",
+            "running" => "RUNNING",
+            "canceled" | "cancelled" => "CANCEL",
+            "pending" => "PENDING",
+            "skipped" => "SKIP",
+            "manual" => "MANUAL",
+            "created" | "waiting_for_resource" | "preparing" => "PENDING",
+            other => other,
+        }
+    }
+
     fn normalize_filter_value(v: &str) -> &str {
         match v {
             // State
@@ -3467,6 +3487,19 @@ impl App {
             "Your merge requests" => "Yours",
             "Approved by you" => "Approved",
             "Approved by others" => "By others",
+            // Pipeline/Job status (raw API → display)
+            "success" => "SUCCESS",
+            "failed" => "FAILED",
+            "running" => "RUNNING",
+            "canceled" | "cancelled" => "CANCEL",
+            "skipped" => "SKIP",
+            "manual" => "MANUAL",
+            // Todos state
+            "unread" | "done" => {
+                // "unread"→"NEW", "done"→"READ" — handled via pipeline_status_display
+                // but normalize maps them too for saved-filter compat
+                if v == "unread" { "NEW" } else { "READ" }
+            }
             other => other,
         }
     }
@@ -3568,12 +3601,12 @@ impl App {
                             values.insert(item.id().to_string());
                         }
                         "Status" => {
-                            values.insert(item.status().to_string());
+                            values.insert(Self::pipeline_status_display(item.status()).to_string());
                         }
                         "Ref" => {
                             values.insert(item.ref_branch().to_string());
                         }
-                        _ => {} // Pipeline no longer carries GitHub-specific fields
+                        _ => {}
                     }
                 }
             }
@@ -3587,7 +3620,7 @@ impl App {
                             values.insert(item.stage().to_string());
                         }
                         "Status" => {
-                            values.insert(item.status().to_string());
+                            values.insert(Self::pipeline_status_display(item.status()).to_string());
                         }
                         "Name" => {
                             values.insert(item.name().to_string());
@@ -3639,7 +3672,12 @@ impl App {
                 for item in &self.todos.items {
                     match col {
                         "State" => {
-                            values.insert(item.state.clone());
+                            let display = if item.state == "unread" || item.state == "pending" {
+                                "NEW"
+                            } else {
+                                "READ"
+                            };
+                            values.insert(display.to_string());
                         }
                         "Project" => {
                             values.insert(item.project_path.clone());

--- a/src/app.rs
+++ b/src/app.rs
@@ -2553,7 +2553,13 @@ impl App {
                 .map(|ms| ms.title.clone())
                 .into_iter()
                 .collect(),
-            "State" => vec![m.state.clone()],
+            "State" => vec![if m.state == "opened" {
+                "OPEN".to_string()
+            } else if m.state == "merged" {
+                "MERGED".to_string()
+            } else {
+                "CLOSED".to_string()
+            }],
             "Status" => crate::domain::mr_state::status_filter_values(
                 m.draft,
                 m.blocking_discussions_resolved,
@@ -2563,13 +2569,11 @@ impl App {
             "Approval" => {
                 vec![
                     match crate::domain::mr_state::approval_cell(m.approval.as_ref(), false).1 {
-                        crate::domain::mr_state::ApprovalTone::Unknown => "Unknown",
-                        crate::domain::mr_state::ApprovalTone::ChangesRequested => {
-                            "Changes requested"
-                        }
-                        crate::domain::mr_state::ApprovalTone::AwaitingYou => "Awaiting you",
-                        crate::domain::mr_state::ApprovalTone::Approved => "Approved",
-                        crate::domain::mr_state::ApprovalTone::Pending => "Pending",
+                        crate::domain::mr_state::ApprovalTone::Unknown => "—",
+                        crate::domain::mr_state::ApprovalTone::ChangesRequested => "CHG",
+                        crate::domain::mr_state::ApprovalTone::AwaitingYou => "AWAITING",
+                        crate::domain::mr_state::ApprovalTone::Approved => "APPROVED",
+                        crate::domain::mr_state::ApprovalTone::Pending => "REVIEW REQ",
                     }
                     .to_string(),
                 ]
@@ -2577,17 +2581,17 @@ impl App {
             "Mergeable" => {
                 vec![
                     match crate::domain::mr_state::mergeable_cell(m.mergeability.as_ref()).1 {
-                        crate::domain::mr_state::MergeTone::Unknown => "Unknown",
-                        crate::domain::mr_state::MergeTone::Conflict => "Conflict",
-                        crate::domain::mr_state::MergeTone::Rebase => "Needs rebase",
-                        crate::domain::mr_state::MergeTone::Computing => "Checking",
-                        crate::domain::mr_state::MergeTone::Clean => "Mergeable",
+                        crate::domain::mr_state::MergeTone::Unknown => "—",
+                        crate::domain::mr_state::MergeTone::Conflict => "CONFLICT",
+                        crate::domain::mr_state::MergeTone::Rebase => "REBASE",
+                        crate::domain::mr_state::MergeTone::Computing => "CHECKING",
+                        crate::domain::mr_state::MergeTone::Clean => "CLEAN",
                     }
                     .to_string(),
                 ]
             }
-            "Workflow" => crate::domain::mr_state::workflow_label(m.workflow)
-                .map(|l| vec![l.to_string()])
+            "Workflow" => crate::domain::mr_state::workflow_cell_word(m.workflow)
+                .map(|w| vec![w.to_string()])
                 .unwrap_or_default(),
             _ => vec![],
         }
@@ -3431,6 +3435,42 @@ impl App {
         list
     }
 
+    /// Canonicalise a saved filter value to the display string that
+    /// `mr_filter_values` / issue filter functions now produce.
+    ///
+    /// Older config files stored lowercase API values ("opened", "Draft", …).
+    /// After the display-alignment change those no longer appear in the
+    /// filter-value sets, so this mapping keeps pre-existing filters working.
+    fn normalize_filter_value(v: &str) -> &str {
+        match v {
+            // State
+            "opened" => "OPEN",
+            "closed" => "CLOSED",
+            "merged" => "MERGED",
+            // Status
+            "Draft" | "draft" => "DRAFT",
+            "Ready" | "ready" => "READY",
+            "Unresolved discussions" => "UNRESOLVED",
+            // Approval
+            "Changes requested" | "Changes Requested" => "CHG",
+            "Awaiting you" | "Awaiting You" => "AWAITING",
+            "Approved" | "approved" => "APPROVED",
+            "Pending" | "pending" | "Review req" | "review req" => "REVIEW REQ",
+            // Mergeable
+            "Conflict" | "conflict" => "CONFLICT",
+            "Needs rebase" | "needs rebase" => "REBASE",
+            "Checking" | "checking" => "CHECKING",
+            "Mergeable" | "mergeable" | "Clean" | "clean" => "CLEAN",
+            // Workflow (old long labels -> abbreviated cell words)
+            "Returned to you" => "Returned",
+            "Review requested" => "Review req",
+            "Your merge requests" => "Yours",
+            "Approved by you" => "Approved",
+            "Approved by others" => "By others",
+            other => other,
+        }
+    }
+
     pub fn apply_column_filters<'a, T>(
         list: &mut Vec<&'a T>,
         column_filters: &std::collections::HashMap<
@@ -3460,7 +3500,12 @@ impl App {
                             .any(|s| v.to_lowercase().contains(&s.to_lowercase()))
                     })
                 } else {
-                    vals.iter().any(|v| selected.contains(v))
+                    vals.iter().any(|v| {
+                        selected.contains(v)
+                            || selected
+                                .iter()
+                                .any(|s| Self::normalize_filter_value(s) == v.as_str())
+                    })
                 }
             });
         }
@@ -3477,7 +3522,12 @@ impl App {
                             values.insert(item.iid.to_string());
                         }
                         "State" => {
-                            values.insert(item.state.clone());
+                            let display = if item.state == "opened" {
+                                "OPEN"
+                            } else {
+                                "CLOSED"
+                            };
+                            values.insert(display.to_string());
                         }
                         "Title" => {
                             values.insert(item.title.clone());
@@ -5249,8 +5299,8 @@ index 123456..789012 100644
 
         let values = app.collect_unique_column_values(Tab::MergeRequests, "Status");
 
-        assert!(values.contains(&"Draft".to_string()));
-        assert!(values.contains(&"Unresolved discussions".to_string()));
+        assert!(values.contains(&"DRAFT".to_string()));
+        assert!(values.contains(&"UNRESOLVED".to_string()));
     }
 
     #[test]
@@ -5272,7 +5322,7 @@ index 123456..789012 100644
 
         let values = app.collect_unique_column_values(Tab::MergeRequests, "Approval");
 
-        assert!(values.contains(&"Approved".to_string()));
+        assert!(values.contains(&"APPROVED".to_string()));
     }
 
     #[test]
@@ -5289,7 +5339,7 @@ index 123456..789012 100644
 
         let values = app.collect_unique_column_values(Tab::MergeRequests, "Mergeable");
 
-        assert!(values.contains(&"Conflict".to_string()));
+        assert!(values.contains(&"CONFLICT".to_string()));
     }
 
     #[test]
@@ -5356,7 +5406,7 @@ index 123456..789012 100644
         mr.workflow = Some(WorkflowStatus::ReturnedToYou);
         assert_eq!(
             App::mr_filter_values(&mr, "Workflow"),
-            vec!["Returned to you".to_string()]
+            vec!["Returned".to_string()]
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2378,7 +2378,11 @@ impl App {
                     .map(|m| m.title.clone())
                     .into_iter()
                     .collect(),
-                "State" => vec![item.state.clone()],
+                "State" => vec![if item.state == "opened" {
+                    "OPEN".to_string()
+                } else {
+                    "CLOSED".to_string()
+                }],
                 "ID" => vec![item.iid.to_string()],
                 "Title" => vec![item.title.clone()],
                 _ => vec![],
@@ -3534,10 +3538,13 @@ impl App {
                     })
                 } else {
                     vals.iter().any(|v| {
+                        let norm_v = Self::normalize_filter_value(v);
                         selected.contains(v)
-                            || selected
-                                .iter()
-                                .any(|s| Self::normalize_filter_value(s) == v.as_str())
+                            || selected.contains(norm_v)
+                            || selected.iter().any(|s| {
+                                let norm_s = Self::normalize_filter_value(s);
+                                norm_s == v.as_str() || norm_s == norm_v
+                            })
                     })
                 }
             });
@@ -5480,14 +5487,58 @@ index 123456..789012 100644
         };
         app.todos.items = vec![t_unread, t_done];
 
-        // Filter Todos by new display value "NEW"
-        app.column_filters.entry(Tab::Todos).or_default().insert(
+        // 3. Issues
+        let i_open = crate::domain::issues::Issue {
+            iid: 1,
+            title: "Issue 1".to_string(),
+            state: "opened".to_string(),
+            labels: vec![],
+            updated_at: "".to_string(),
+            created_at: None,
+            closed_at: None,
+            author: crate::domain::issues::Author {
+                username: "user1".to_string(),
+            },
+            milestone: None,
+            assignees: vec![],
+            description: None,
+            due_date: None,
+        };
+        let i_closed = crate::domain::issues::Issue {
+            iid: 2,
+            title: "Issue 2".to_string(),
+            state: "closed".to_string(),
+            labels: vec![],
+            updated_at: "".to_string(),
+            created_at: None,
+            closed_at: None,
+            author: crate::domain::issues::Author {
+                username: "user2".to_string(),
+            },
+            milestone: None,
+            assignees: vec![],
+            description: None,
+            due_date: None,
+        };
+        app.issues.items = vec![i_open, i_closed];
+
+        // Filter Issues by new display value "OPEN"
+        app.column_filters.entry(Tab::Issues).or_default().insert(
             "State".to_string(),
-            ["NEW".to_string()].into_iter().collect(),
+            ["OPEN".to_string()].into_iter().collect(),
         );
-        let res_todos = app.filtered_todos();
-        assert_eq!(res_todos.len(), 1);
-        assert_eq!(res_todos[0].id, "101");
+        let res_issues = app.filtered_issues();
+        assert_eq!(res_issues.len(), 1);
+        assert_eq!(res_issues[0].iid, 1);
+
+        // Filter Issues by legacy value "opened"
+        app.column_filters.entry(Tab::Issues).or_default().insert(
+            "State".to_string(),
+            ["opened".to_string()].into_iter().collect(),
+        );
+        let res_issues_legacy = app.filtered_issues();
+        assert_eq!(res_issues_legacy.len(), 1);
+        assert_eq!(res_issues_legacy[0].iid, 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5407,6 +5407,90 @@ index 123456..789012 100644
     }
 
     #[test]
+    fn column_filtering_works_for_pipelines_jobs_and_todos() {
+        let mut app = App::default();
+
+        // 1. Pipelines
+        let p_success = crate::domain::pipelines::Pipeline {
+            id: 1,
+            status: "success".to_string(),
+            r#ref: "main".to_string(),
+            updated_at: "".to_string(),
+            name: "".to_string(),
+            display_title: "".to_string(),
+            event: "".to_string(),
+            head_sha: "".to_string(),
+            actor_login: "".to_string(),
+        };
+        let p_failed = crate::domain::pipelines::Pipeline {
+            id: 2,
+            status: "failed".to_string(),
+            r#ref: "main".to_string(),
+            updated_at: "".to_string(),
+            name: "".to_string(),
+            display_title: "".to_string(),
+            event: "".to_string(),
+            head_sha: "".to_string(),
+            actor_login: "".to_string(),
+        };
+        app.pipelines.items = vec![p_success, p_failed];
+
+        // Filter Pipelines by new display value "SUCCESS"
+        app.column_filters
+            .entry(Tab::Pipelines)
+            .or_default()
+            .insert(
+                "Status".to_string(),
+                ["SUCCESS".to_string()].into_iter().collect(),
+            );
+        let res = app.filtered_pipelines();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].id, 1);
+
+        // Filter Pipelines by legacy value "success"
+        app.column_filters
+            .entry(Tab::Pipelines)
+            .or_default()
+            .insert(
+                "Status".to_string(),
+                ["success".to_string()].into_iter().collect(),
+            );
+        let res_legacy = app.filtered_pipelines();
+        assert_eq!(res_legacy.len(), 1);
+        assert_eq!(res_legacy[0].id, 1);
+
+        // 2. Todos
+        let t_unread = crate::domain::notifications::Notification {
+            id: "101".to_string(),
+            state: "unread".to_string(),
+            project_path: "org/repo".to_string(),
+            target_type: "Issue".to_string(),
+            target_iid: 1,
+            title: "Task 1".to_string(),
+            updated_at: "".to_string(),
+        };
+        let t_done = crate::domain::notifications::Notification {
+            id: "102".to_string(),
+            state: "done".to_string(),
+            project_path: "org/repo".to_string(),
+            target_type: "Issue".to_string(),
+            target_iid: 2,
+            title: "Task 2".to_string(),
+            updated_at: "".to_string(),
+        };
+        app.todos.items = vec![t_unread, t_done];
+
+        // Filter Todos by new display value "NEW"
+        app.column_filters.entry(Tab::Todos).or_default().insert(
+            "State".to_string(),
+            ["NEW".to_string()].into_iter().collect(),
+        );
+        let res_todos = app.filtered_todos();
+        assert_eq!(res_todos.len(), 1);
+        assert_eq!(res_todos[0].id, "101");
+    }
+
+    #[test]
     fn workflow_column_is_offered_but_not_default() {
         for kind in [BackendKind::GitLab, BackendKind::GitHub] {
             assert!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,11 +226,11 @@ impl Tab {
                     "ID",
                     "State",
                     "Status",
+                    "Mergeable",
+                    "Approval",
                     "Title",
                     "Assignees",
                     "Reviewers",
-                    "Approval",
-                    "Mergeable",
                     "Workflow",
                     "Labels",
                 ];
@@ -294,8 +294,8 @@ impl Tab {
                 "ID",
                 "State",
                 "Status",
-                "Approval",
                 "Mergeable",
+                "Approval",
                 "Title",
                 "Labels",
             ],
@@ -2560,26 +2560,32 @@ impl App {
             ),
             "ID" => vec![m.iid.to_string()],
             "Title" => vec![m.title.clone()],
-            "Approval" => vec![
-                match crate::domain::mr_state::approval_cell(m.approval.as_ref(), false).1 {
-                    crate::domain::mr_state::ApprovalTone::Unknown => "Unknown",
-                    crate::domain::mr_state::ApprovalTone::ChangesRequested => "Changes requested",
-                    crate::domain::mr_state::ApprovalTone::AwaitingYou => "Awaiting you",
-                    crate::domain::mr_state::ApprovalTone::Approved => "Approved",
-                    crate::domain::mr_state::ApprovalTone::Pending => "Pending",
-                }
-                .to_string(),
-            ],
-            "Mergeable" => vec![
-                match crate::domain::mr_state::mergeable_cell(m.mergeability.as_ref()).1 {
-                    crate::domain::mr_state::MergeTone::Unknown => "Unknown",
-                    crate::domain::mr_state::MergeTone::Conflict => "Conflict",
-                    crate::domain::mr_state::MergeTone::Rebase => "Needs rebase",
-                    crate::domain::mr_state::MergeTone::Computing => "Checking",
-                    crate::domain::mr_state::MergeTone::Clean => "Mergeable",
-                }
-                .to_string(),
-            ],
+            "Approval" => {
+                vec![
+                    match crate::domain::mr_state::approval_cell(m.approval.as_ref(), false).1 {
+                        crate::domain::mr_state::ApprovalTone::Unknown => "Unknown",
+                        crate::domain::mr_state::ApprovalTone::ChangesRequested => {
+                            "Changes requested"
+                        }
+                        crate::domain::mr_state::ApprovalTone::AwaitingYou => "Awaiting you",
+                        crate::domain::mr_state::ApprovalTone::Approved => "Approved",
+                        crate::domain::mr_state::ApprovalTone::Pending => "Pending",
+                    }
+                    .to_string(),
+                ]
+            }
+            "Mergeable" => {
+                vec![
+                    match crate::domain::mr_state::mergeable_cell(m.mergeability.as_ref()).1 {
+                        crate::domain::mr_state::MergeTone::Unknown => "Unknown",
+                        crate::domain::mr_state::MergeTone::Conflict => "Conflict",
+                        crate::domain::mr_state::MergeTone::Rebase => "Needs rebase",
+                        crate::domain::mr_state::MergeTone::Computing => "Checking",
+                        crate::domain::mr_state::MergeTone::Clean => "Mergeable",
+                    }
+                    .to_string(),
+                ]
+            }
             "Workflow" => crate::domain::mr_state::workflow_label(m.workflow)
                 .map(|l| vec![l.to_string()])
                 .unwrap_or_default(),

--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -2229,7 +2229,7 @@ impl Backend for GhBackend {
 
     // ── Labels / Members / Misc ──
 
-    async fn fetch_labels(&self, project: &str) -> Result<Vec<String>> {
+    async fn fetch_labels(&self, project: &str, _per_request: usize) -> Result<Vec<String>> {
         let raw = self
             .run_gh(
                 &[

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -2494,7 +2494,7 @@ impl Backend for GlabBackend {
 
     // ── Labels / Members / Misc ──
 
-    async fn fetch_labels(&self, project: &str) -> Result<Vec<String>> {
+    async fn fetch_labels(&self, project: &str, per_request: usize) -> Result<Vec<String>> {
         let raw = self
             .run_glab(
                 &[
@@ -2505,7 +2505,7 @@ impl Backend for GlabBackend {
                     "-R",
                     project,
                     "--per-page",
-                    "100",
+                    &per_request.to_string(),
                 ],
                 "Fetching Labels",
             )
@@ -2816,9 +2816,9 @@ mod tests {
         assert_eq!(page_count(100, 20), 5);
         assert_eq!(page_count(100, 100), 1);
         assert_eq!(page_count(250, 100), 3);
-        // per_request = 0 must not panic (div_ceil would); clamped to 1 item per
-        // request, so a 100-item budget needs 100 requests.
-        assert_eq!(page_count(100, 0), 100);
+        // value already clamped to 1..=100 by Config::api_per_page_clamped(),
+        // but the max(1) guard in page_count() ensures division safety.
+        assert_eq!(page_count(100, 1), 100);
     }
 
     // ── project path validation (GraphQL injection guard) ──

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -319,7 +319,7 @@ pub trait Backend: Send + Sync {
     ) -> Result<Vec<Deployment>>;
 
     // ── Labels / Members / Misc ──
-    async fn fetch_labels(&self, project: &str) -> Result<Vec<String>>;
+    async fn fetch_labels(&self, project: &str, per_request: usize) -> Result<Vec<String>>;
     async fn fetch_members(&self, project: &str) -> Result<Vec<String>>;
 
     // ── MR review state (approval + mergeability) ──

--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -68,7 +68,9 @@ impl GitlabClient {
     }
 
     pub async fn fetch_labels(&self, project_path: &str) -> Result<Vec<String>> {
-        self.backend.fetch_labels(project_path).await
+        self.backend
+            .fetch_labels(project_path, self.api_per_page)
+            .await
     }
 
     pub async fn fetch_members(&self, project_path: &str) -> Result<Vec<String>> {

--- a/src/domain/mr_state.rs
+++ b/src/domain/mr_state.rs
@@ -250,6 +250,16 @@ fn format_counts(s: &ApprovalState) -> String {
     }
 }
 
+/// Repeat the pending icon once per approval still needed (capped at 5).
+/// Falls back to a single icon when `approvals_left` is unknown.
+fn pending_icons(s: &ApprovalState, icon: &str) -> String {
+    let n = s.approvals_left.unwrap_or(1).min(5).max(1) as usize;
+    std::iter::repeat(icon)
+        .take(n)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// First-match-wins cascade. See the precedence flowchart in the design spec.
 pub fn approval_cell(state: Option<&ApprovalState>, is_github: bool) -> (String, ApprovalTone) {
     let icons = crate::config::ICONS.read().unwrap();
@@ -282,7 +292,7 @@ pub fn approval_cell(state: Option<&ApprovalState>, is_github: bool) -> (String,
 
     if s.awaiting_you {
         return (
-            format!("{} {}", icons.approval_pending, format_counts(s)),
+            format!("{} AWAITING", pending_icons(s, &icons.approval_pending)),
             ApprovalTone::AwaitingYou,
         );
     }
@@ -293,7 +303,11 @@ pub fn approval_cell(state: Option<&ApprovalState>, is_github: bool) -> (String,
         );
     }
     (
-        format!("{} {}", icons.approval_pending, format_counts(s)),
+        format!(
+            "{} {}",
+            pending_icons(s, &icons.approval_pending),
+            format_counts(s)
+        ),
         ApprovalTone::Pending,
     )
 }
@@ -513,9 +527,26 @@ mod tests {
         format!("{} APPROVED", icons.approval_approved)
     }
 
-    fn expect_awaiting(counts: &str) -> String {
+    /// Builds the expected awaiting-you string: n icons + " AWAITING".
+    fn expect_awaiting_you(approvals_left: u32) -> String {
         let icons = crate::config::ICONS.read().unwrap();
-        format!("{} {}", icons.approval_pending, counts)
+        let n = approvals_left.min(5).max(1) as usize;
+        let dots = std::iter::repeat(icons.approval_pending.as_str())
+            .take(n)
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("{} AWAITING", dots)
+    }
+
+    /// Builds the expected pending string: n icons + " " + counts.
+    fn expect_pending(approvals_left: u32, counts: &str) -> String {
+        let icons = crate::config::ICONS.read().unwrap();
+        let n = approvals_left.min(5).max(1) as usize;
+        let dots = std::iter::repeat(icons.approval_pending.as_str())
+            .take(n)
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("{} {}", dots, counts)
     }
 
     fn expect_github_pending() -> String {
@@ -650,7 +681,7 @@ mod tests {
         };
         let (text, tone) = approval_cell(Some(&s), false);
         assert_ne!(tone, ApprovalTone::Approved);
-        assert_eq!(text, expect_awaiting("0"));
+        assert_eq!(text, expect_pending(0, "0"));
     }
 
     #[test]
@@ -667,7 +698,7 @@ mod tests {
             ..Default::default()
         };
         let (text, tone) = approval_cell(Some(&s), false);
-        assert_eq!(text, expect_awaiting("0/1"));
+        assert_eq!(text, expect_awaiting_you(1));
         assert_eq!(tone, ApprovalTone::AwaitingYou);
     }
 
@@ -684,7 +715,7 @@ mod tests {
             ..Default::default()
         };
         let (text, tone) = approval_cell(Some(&s), false);
-        assert_eq!(text, expect_awaiting("1/2"));
+        assert_eq!(text, expect_pending(1, "1/2"));
         assert_eq!(tone, ApprovalTone::Pending);
     }
 

--- a/src/domain/mr_state.rs
+++ b/src/domain/mr_state.rs
@@ -259,9 +259,9 @@ pub fn approval_cell(state: Option<&ApprovalState>, is_github: bool) -> (String,
 
     if s.changes_requested {
         let text = if is_github {
-            format!("{} changes", icons.approval_changes)
+            format!("{} CHANGES", icons.approval_changes)
         } else {
-            format!("{} chg", icons.approval_changes)
+            format!("{} CHG", icons.approval_changes)
         };
         return (text, ApprovalTone::ChangesRequested);
     }
@@ -270,11 +270,14 @@ pub fn approval_cell(state: Option<&ApprovalState>, is_github: bool) -> (String,
     if is_github {
         if is_attributably_approved(s) {
             return (
-                format!("{} approved", icons.approval_approved),
+                format!("{} APPROVED", icons.approval_approved),
                 ApprovalTone::Approved,
             );
         }
-        return ("review req".to_string(), ApprovalTone::Pending);
+        return (
+            format!("{} REVIEW REQ", icons.approval_pending),
+            ApprovalTone::Pending,
+        );
     }
 
     if s.awaiting_you {
@@ -289,7 +292,10 @@ pub fn approval_cell(state: Option<&ApprovalState>, is_github: bool) -> (String,
             ApprovalTone::Approved,
         );
     }
-    (format_counts(s), ApprovalTone::Pending)
+    (
+        format!("{} {}", icons.approval_pending, format_counts(s)),
+        ApprovalTone::Pending,
+    )
 }
 
 /// First-match-wins cascade. Conflict outranks rebase because it is the more
@@ -302,17 +308,17 @@ pub fn mergeable_cell(state: Option<&MergeabilityState>) -> (String, MergeTone) 
     };
     if s.conflicts {
         return (
-            format!("{} conflict", icons.merge_conflict),
+            format!("{} CONFLICT", icons.merge_conflict),
             MergeTone::Conflict,
         );
     }
     if s.needs_rebase {
-        return (format!("{} rebase", icons.merge_rebase), MergeTone::Rebase);
+        return (format!("{} REBASE", icons.merge_rebase), MergeTone::Rebase);
     }
     if s.computing {
         return (icons.merge_checking.clone(), MergeTone::Computing);
     }
-    (icons.merge_clean.clone(), MergeTone::Clean)
+    (format!("{} CLEAN", icons.merge_clean), MergeTone::Clean)
 }
 
 /// Sort ordinal: most-blocking first, unknown last. The caller (`App::mr_sort_value`)
@@ -494,7 +500,7 @@ mod tests {
     // rather than duplicating glyph literals here.
     fn expect_chg() -> String {
         let icons = crate::config::ICONS.read().unwrap();
-        format!("{} chg", icons.approval_changes)
+        format!("{} CHG", icons.approval_changes)
     }
 
     fn expect_approved(counts: &str) -> String {
@@ -504,7 +510,7 @@ mod tests {
 
     fn expect_github_approved() -> String {
         let icons = crate::config::ICONS.read().unwrap();
-        format!("{} approved", icons.approval_approved)
+        format!("{} APPROVED", icons.approval_approved)
     }
 
     fn expect_awaiting(counts: &str) -> String {
@@ -512,14 +518,19 @@ mod tests {
         format!("{} {}", icons.approval_pending, counts)
     }
 
+    fn expect_github_pending() -> String {
+        let icons = crate::config::ICONS.read().unwrap();
+        format!("{} REVIEW REQ", icons.approval_pending)
+    }
+
     fn expect_conflict() -> String {
         let icons = crate::config::ICONS.read().unwrap();
-        format!("{} conflict", icons.merge_conflict)
+        format!("{} CONFLICT", icons.merge_conflict)
     }
 
     fn expect_rebase() -> String {
         let icons = crate::config::ICONS.read().unwrap();
-        format!("{} rebase", icons.merge_rebase)
+        format!("{} REBASE", icons.merge_rebase)
     }
 
     fn expect_computing() -> String {
@@ -527,7 +538,8 @@ mod tests {
     }
 
     fn expect_clean() -> String {
-        crate::config::ICONS.read().unwrap().merge_clean.clone()
+        let icons = crate::config::ICONS.read().unwrap();
+        format!("{} CLEAN", icons.merge_clean)
     }
 
     // ── awaiting_you truth table ──
@@ -638,7 +650,7 @@ mod tests {
         };
         let (text, tone) = approval_cell(Some(&s), false);
         assert_ne!(tone, ApprovalTone::Approved);
-        assert_eq!(text, "0");
+        assert_eq!(text, expect_awaiting("0"));
     }
 
     #[test]
@@ -672,7 +684,7 @@ mod tests {
             ..Default::default()
         };
         let (text, tone) = approval_cell(Some(&s), false);
-        assert_eq!(text, "1/2");
+        assert_eq!(text, expect_awaiting("1/2"));
         assert_eq!(tone, ApprovalTone::Pending);
     }
 
@@ -705,7 +717,7 @@ mod tests {
             ..Default::default()
         };
         let (text, _) = approval_cell(Some(&s), true);
-        assert_eq!(text, "review req");
+        assert_eq!(text, expect_github_pending());
     }
 
     // ── mergeability cell rendering ──

--- a/src/domain/mr_state.rs
+++ b/src/domain/mr_state.rs
@@ -153,6 +153,16 @@ pub fn workflow_label(s: Option<WorkflowStatus>) -> Option<&'static str> {
     }
 }
 
+/// The abbreviated word shown in the Workflow table cell (e.g. "Returned",
+/// "Review req"). Used as the column-filter picker value so it matches
+/// exactly what the user sees. `None` for statuses that render blank.
+pub fn workflow_cell_word(s: Option<WorkflowStatus>) -> Option<&'static str> {
+    match s {
+        Some(status) => workflow_icon_and_word(status).map(|(_, word)| word),
+        None => None,
+    }
+}
+
 /// Approval readiness for one merge request. Host-neutral.
 ///
 /// `None` at the call site means *unknown* (fetch failed or unsupported),
@@ -451,9 +461,9 @@ pub fn status_filter_values(
     draft: bool,
     blocking_discussions_resolved: Option<bool>,
 ) -> Vec<String> {
-    let mut v = vec![if draft { "Draft" } else { "Ready" }.to_string()];
+    let mut v = vec![if draft { "DRAFT" } else { "READY" }.to_string()];
     if blocking_discussions_resolved == Some(false) {
-        v.push("Unresolved discussions".to_string());
+        v.push("UNRESOLVED".to_string());
     }
     v
 }
@@ -900,9 +910,9 @@ mod tests {
     fn status_filter_values_include_base_word_only_when_resolved() {
         assert_eq!(
             status_filter_values(true, Some(true)),
-            vec!["Draft".to_string()]
+            vec!["DRAFT".to_string()]
         );
-        assert_eq!(status_filter_values(false, None), vec!["Ready".to_string()]);
+        assert_eq!(status_filter_values(false, None), vec!["READY".to_string()]);
     }
 
     #[test]
@@ -910,8 +920,8 @@ mod tests {
         // !1471 is draft AND unresolved; a filter on either must match it,
         // which is what preserves fidelity in the shared column.
         let v = status_filter_values(true, Some(false));
-        assert!(v.contains(&"Draft".to_string()));
-        assert!(v.contains(&"Unresolved discussions".to_string()));
+        assert!(v.contains(&"DRAFT".to_string()));
+        assert!(v.contains(&"UNRESOLVED".to_string()));
     }
 
     // ── rebase gate ──

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -611,7 +611,7 @@ pub(crate) fn render_tab_merge_requests(
                     )
                 } else {
                     (
-                        format!("{} READY", icons.status_ready),
+                        format!("{} READY", icons.approval_approved),
                         Style::default()
                             .fg(THEME.read().unwrap().green)
                             .bg(if is_selected {
@@ -683,22 +683,48 @@ pub(crate) fn render_tab_merge_requests(
             if app.is_column_visible(Tab::MergeRequests, "Approval") {
                 let (text, tone) =
                     crate::domain::mr_state::approval_cell(m.approval.as_ref(), app.is_github());
-                let color = match tone {
-                    crate::domain::mr_state::ApprovalTone::ChangesRequested => {
-                        THEME.read().unwrap().red
+                let style = {
+                    let t = THEME.read().unwrap();
+                    match tone {
+                        crate::domain::mr_state::ApprovalTone::ChangesRequested => Style::default()
+                            .fg(t.red)
+                            .bg(if is_selected {
+                                t.highlight_bg
+                            } else if is_checked {
+                                t.checked_bg
+                            } else {
+                                t.red_bg
+                            })
+                            .add_modifier(Modifier::BOLD),
+                        crate::domain::mr_state::ApprovalTone::AwaitingYou => Style::default()
+                            .fg(t.yellow)
+                            .bg(if is_selected {
+                                t.highlight_bg
+                            } else if is_checked {
+                                t.checked_bg
+                            } else {
+                                t.yellow_bg
+                            })
+                            .add_modifier(Modifier::BOLD),
+                        crate::domain::mr_state::ApprovalTone::Approved => Style::default()
+                            .fg(t.green)
+                            .bg(if is_selected {
+                                t.highlight_bg
+                            } else if is_checked {
+                                t.checked_bg
+                            } else {
+                                t.green_bg
+                            })
+                            .add_modifier(Modifier::BOLD),
+                        _ => Style::default().fg(t.text_muted),
                     }
-                    crate::domain::mr_state::ApprovalTone::AwaitingYou => {
-                        THEME.read().unwrap().yellow
-                    }
-                    crate::domain::mr_state::ApprovalTone::Approved => THEME.read().unwrap().green,
-                    _ => THEME.read().unwrap().text_muted,
                 };
                 cells.push(super::helpers::render_fuzzy_cell(
                     &text,
                     &app.search_query,
                     is_selected,
                     is_checked,
-                    Style::default().fg(color),
+                    style,
                     Alignment::Center,
                 ));
             }

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -665,18 +665,48 @@ pub(crate) fn render_tab_merge_requests(
             }
             if app.is_column_visible(Tab::MergeRequests, "Mergeable") {
                 let (text, tone) = crate::domain::mr_state::mergeable_cell(m.mergeability.as_ref());
-                let color = match tone {
-                    crate::domain::mr_state::MergeTone::Conflict => THEME.read().unwrap().red,
-                    crate::domain::mr_state::MergeTone::Rebase => THEME.read().unwrap().yellow,
-                    crate::domain::mr_state::MergeTone::Clean => THEME.read().unwrap().green,
-                    _ => THEME.read().unwrap().text_muted,
+                let style = {
+                    let t = THEME.read().unwrap();
+                    match tone {
+                        crate::domain::mr_state::MergeTone::Conflict => Style::default()
+                            .fg(t.red)
+                            .bg(if is_selected {
+                                t.highlight_bg
+                            } else if is_checked {
+                                t.checked_bg
+                            } else {
+                                t.red_bg
+                            })
+                            .add_modifier(Modifier::BOLD),
+                        crate::domain::mr_state::MergeTone::Rebase => Style::default()
+                            .fg(t.yellow)
+                            .bg(if is_selected {
+                                t.highlight_bg
+                            } else if is_checked {
+                                t.checked_bg
+                            } else {
+                                t.yellow_bg
+                            })
+                            .add_modifier(Modifier::BOLD),
+                        crate::domain::mr_state::MergeTone::Clean => Style::default()
+                            .fg(t.green)
+                            .bg(if is_selected {
+                                t.highlight_bg
+                            } else if is_checked {
+                                t.checked_bg
+                            } else {
+                                t.green_bg
+                            })
+                            .add_modifier(Modifier::BOLD),
+                        _ => Style::default().fg(t.text_muted),
+                    }
                 };
                 cells.push(super::helpers::render_fuzzy_cell(
                     &text,
                     &app.search_query,
                     is_selected,
                     is_checked,
-                    Style::default().fg(color),
+                    style,
                     Alignment::Center,
                 ));
             }

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -663,6 +663,45 @@ pub(crate) fn render_tab_merge_requests(
                     Alignment::Center,
                 ));
             }
+            if app.is_column_visible(Tab::MergeRequests, "Mergeable") {
+                let (text, tone) = crate::domain::mr_state::mergeable_cell(m.mergeability.as_ref());
+                let color = match tone {
+                    crate::domain::mr_state::MergeTone::Conflict => THEME.read().unwrap().red,
+                    crate::domain::mr_state::MergeTone::Rebase => THEME.read().unwrap().yellow,
+                    crate::domain::mr_state::MergeTone::Clean => THEME.read().unwrap().green,
+                    _ => THEME.read().unwrap().text_muted,
+                };
+                cells.push(super::helpers::render_fuzzy_cell(
+                    &text,
+                    &app.search_query,
+                    is_selected,
+                    is_checked,
+                    Style::default().fg(color),
+                    Alignment::Center,
+                ));
+            }
+            if app.is_column_visible(Tab::MergeRequests, "Approval") {
+                let (text, tone) =
+                    crate::domain::mr_state::approval_cell(m.approval.as_ref(), app.is_github());
+                let color = match tone {
+                    crate::domain::mr_state::ApprovalTone::ChangesRequested => {
+                        THEME.read().unwrap().red
+                    }
+                    crate::domain::mr_state::ApprovalTone::AwaitingYou => {
+                        THEME.read().unwrap().yellow
+                    }
+                    crate::domain::mr_state::ApprovalTone::Approved => THEME.read().unwrap().green,
+                    _ => THEME.read().unwrap().text_muted,
+                };
+                cells.push(super::helpers::render_fuzzy_cell(
+                    &text,
+                    &app.search_query,
+                    is_selected,
+                    is_checked,
+                    Style::default().fg(color),
+                    Alignment::Center,
+                ));
+            }
             if app.is_column_visible(Tab::MergeRequests, "Title") {
                 cells.push(super::helpers::render_fuzzy_cell(
                     &truncate(&clean_title, 100),
@@ -709,45 +748,6 @@ pub(crate) fn render_tab_merge_requests(
                     is_checked,
                     Style::default().fg(THEME.read().unwrap().blue),
                     Alignment::Left,
-                ));
-            }
-            if app.is_column_visible(Tab::MergeRequests, "Approval") {
-                let (text, tone) =
-                    crate::domain::mr_state::approval_cell(m.approval.as_ref(), app.is_github());
-                let color = match tone {
-                    crate::domain::mr_state::ApprovalTone::ChangesRequested => {
-                        THEME.read().unwrap().red
-                    }
-                    crate::domain::mr_state::ApprovalTone::AwaitingYou => {
-                        THEME.read().unwrap().yellow
-                    }
-                    crate::domain::mr_state::ApprovalTone::Approved => THEME.read().unwrap().green,
-                    _ => THEME.read().unwrap().text_muted,
-                };
-                cells.push(super::helpers::render_fuzzy_cell(
-                    &text,
-                    &app.search_query,
-                    is_selected,
-                    is_checked,
-                    Style::default().fg(color),
-                    Alignment::Center,
-                ));
-            }
-            if app.is_column_visible(Tab::MergeRequests, "Mergeable") {
-                let (text, tone) = crate::domain::mr_state::mergeable_cell(m.mergeability.as_ref());
-                let color = match tone {
-                    crate::domain::mr_state::MergeTone::Conflict => THEME.read().unwrap().red,
-                    crate::domain::mr_state::MergeTone::Rebase => THEME.read().unwrap().yellow,
-                    crate::domain::mr_state::MergeTone::Clean => THEME.read().unwrap().green,
-                    _ => THEME.read().unwrap().text_muted,
-                };
-                cells.push(super::helpers::render_fuzzy_cell(
-                    &text,
-                    &app.search_query,
-                    is_selected,
-                    is_checked,
-                    Style::default().fg(color),
-                    Alignment::Center,
                 ));
             }
             if app.is_column_visible(Tab::MergeRequests, "Workflow") {
@@ -937,6 +937,18 @@ pub(crate) fn render_tab_merge_requests(
             ));
             widths.push(Constraint::Length(12));
         }
+        if app.is_column_visible(Tab::MergeRequests, "Mergeable") {
+            header_cells.push(Cell::from(
+                Line::from("Mergeable").alignment(Alignment::Center),
+            ));
+            widths.push(col_w(content_area.width, 13));
+        }
+        if app.is_column_visible(Tab::MergeRequests, "Approval") {
+            header_cells.push(Cell::from(
+                Line::from("Approval").alignment(Alignment::Center),
+            ));
+            widths.push(col_w(content_area.width, 12));
+        }
         if app.is_column_visible(Tab::MergeRequests, "Title") {
             header_cells.push(Cell::from("Title"));
             widths.push(Constraint::Fill(1));
@@ -948,18 +960,6 @@ pub(crate) fn render_tab_merge_requests(
         if app.is_column_visible(Tab::MergeRequests, "Reviewers") {
             header_cells.push(Cell::from("Reviewers"));
             widths.push(col_w(content_area.width, 22));
-        }
-        if app.is_column_visible(Tab::MergeRequests, "Approval") {
-            header_cells.push(Cell::from(
-                Line::from("Approval").alignment(Alignment::Center),
-            ));
-            widths.push(col_w(content_area.width, 12));
-        }
-        if app.is_column_visible(Tab::MergeRequests, "Mergeable") {
-            header_cells.push(Cell::from(
-                Line::from("Mergeable").alignment(Alignment::Center),
-            ));
-            widths.push(col_w(content_area.width, 13));
         }
         if app.is_column_visible(Tab::MergeRequests, "Workflow") {
             header_cells.push(Cell::from(

--- a/tests/e2e/pagination.rs
+++ b/tests/e2e/pagination.rs
@@ -136,8 +136,9 @@ fn test_pagination_fallback_invalid() {
     assert_all_use_per_page(&calls, 100);
 }
 
-/// `api_per_page` governs the paged list fetches only. Endpoints that issue a
-/// single unpaged request keep their own sizing.
+/// `api_per_page` is passed through to all list endpoints, including labels.
+/// Lowering it from the default 100 shrinks every page, including the label
+/// fetch that populates the edit-menu selector.
 #[test]
 fn test_pagination_custom_per_endpoint() {
     let session = session_with(Some("page_size = 100\napi_per_page = 20\n"));
@@ -154,10 +155,11 @@ fn test_pagination_custom_per_endpoint() {
         !label_calls.is_empty(),
         "expected a label-list call to compare against"
     );
+    // fetch_labels now honours api_per_page (was previously hard-coded to 100).
     for call in &label_calls {
         assert!(
-            call.contains("--per-page 100"),
-            "unpaged label fetch should keep its own size, got: {}",
+            call.contains("--per-page 20"),
+            "label fetch should use api_per_page=20, got: {}",
             call
         );
     }


### PR DESCRIPTION
## Summary

Polishes the MR/PR table columns based on UX feedback from the previous session.

### Column reorder
Groups the three status-indicator columns together for at-a-glance readability:

`Status → Mergeable → Approval → Title → Assignees → Reviewers → Workflow → ...`

### All-caps display labels

**Mergeable column:**
- `CONFLICT` (was `conflict`) — already done in #270, kept consistent
- `REBASE` (was `rebase`)
- `CLEAN` with check icon (was icon-only)

**Approval column:**
- `CHG` / `CHANGES` (was `chg` / `changes`)
- `APPROVED` (was `approved`)
- `REVIEW REQ` with pending icon (was `review req`, no icon)
- GitLab pending counts now also get the pending icon prefix

### fetch_labels respects api_per_page (closes #273)
- `fetch_labels` in both `GlabBackend` and `GhBackend` now passes `per_request`
  from `api_per_page_clamped()` instead of hard-coding `100`
- `page_count` test updated: the zero-input guard `max(1)` is kept as
  defence-in-depth; test now exercises `per_request = 1` (valid range)

### Test updates
All 201 unit tests pass. Updated test helpers / assertions to match new
display strings. The 6 e2e pagination failures are pre-existing on `main`
(confirmed by running the suite against the unmodified tree).