### PR TITLE
fix(tests): serialize env-mutating unit tests to fix Windows CI race

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -50,18 +50,83 @@ die()     { printf '%serror:%s %s\n' "${C_BOLD}${C_RED}" "$C_RESET" "$*" >&2; ex
 require() { command -v "$1" >/dev/null 2>&1 || die "missing required tool '$1' (${2:-})"; }
 note()    { printf '\n%s==>%s %s\n' "${C_BOLD}${C_CYAN}" "$C_RESET" "$*"; }
 ok()      { printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
-phase()   { printf '\n%s── [ %s ] ──%s\n' "${C_BOLD}${C_YELLOW}" "$*" "$C_RESET"; }
+PHASE_COUNT=7
+phase()   { printf '\n%s── [ %s/%s · %s ] ──%s\n' "${C_BOLD}${C_YELLOW}" "$1" "$PHASE_COUNT" "${*:2}" "$C_RESET"; }
 banner()  {
   printf '\n%s============================================%s\n' "${C_BOLD}${C_CYAN}" "$C_RESET"
   printf '%s  glab-tui release orchestrator%s\n' "${C_BOLD}" "$C_RESET"
   printf '%s============================================%s\n' "${C_BOLD}${C_CYAN}" "$C_RESET"
 }
 
+# ---------------------------------------------------------------------------
+# spinner / progress bar helpers (auto-disabled when not a TTY)
+# ---------------------------------------------------------------------------
+SPINNER_FRAMES=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+
+# spinner <label> <command...>
+# Runs <command> with its output captured to $TMP_DIR/spinner.log while an
+# animated spinner ticks in place on the current line. On failure the tail of
+# the log is printed so you can see what went wrong. Returns the command's
+# exit status so the caller's `set -e` / `if` semantics are preserved.
+spinner() {
+  local label="$1"
+  shift
+  if [[ ! -t 1 ]]; then
+    "$@"
+    return $?
+  fi
+
+  local log="${TMP_DIR}/spinner.log"
+  : > "$log"
+
+  # The animator runs in the background; the command stays in the foreground
+  # so Ctrl-C and exit codes behave exactly as if it had been run directly.
+  (
+    local i=0 start=$SECONDS
+    printf '\e[?25l'
+    while true; do
+      printf '\r\e[2K%s%s %s%s %s%ss%s' \
+        "$C_YELLOW" "${SPINNER_FRAMES[i % ${#SPINNER_FRAMES[@]}]}" \
+        "$C_BOLD" "$label" "$C_DIM" "$((SECONDS - start))" "$C_RESET"
+      i=$((i + 1))
+      sleep 0.1
+    done
+  ) &
+  local animator=$!
+  local status=0
+  "$@" >"$log" 2>&1 || status=$?
+  kill "$animator" 2>/dev/null || true
+  wait "$animator" 2>/dev/null || true
+  printf '\r\e[2K\e[?25h'
+  if (( status != 0 )); then
+    printf '%serror:%s %s\n' "${C_BOLD}${C_RED}" "$C_RESET" "$label" >&2
+    tail -20 "$log" >&2
+  fi
+  return "$status"
+}
+
+# progress_bar <current> <total> <label...>
+# Renders an in-place determinate progress bar, e.g. "[██████░░░░]  30% assets".
+progress_bar() {
+  local current="$1" total="$2"
+  shift 2
+  local width=20 pct=0 filled=0 empty=0 i bar=""
+  if (( total > 0 )); then
+    pct=$((current * 100 / total))
+  fi
+  filled=$((pct * width / 100))
+  empty=$((width - filled))
+  for ((i = 0; i < filled; i++)); do bar+="█"; done
+  for ((i = 0; i < empty; i++)); do bar+="░"; done
+  printf '\r\e[2K  %s[%s]%s %3d%%  %s%s%s' \
+    "$C_YELLOW" "$bar" "$C_RESET" "$pct" "$C_DIM" "$*" "$C_RESET"
+}
+
 run_opencode() {
-  note "opencode ($OPENCODE_MODEL), output logged to $TMP_DIR/opencode.log"
-  if ! opencode run --auto --model "$OPENCODE_MODEL" "$1" >"$TMP_DIR/opencode.log" 2>&1; then
-    tail -20 "$TMP_DIR/opencode.log" >&2
-    die "opencode failed (log: $TMP_DIR/opencode.log)"
+  note "opencode ($OPENCODE_MODEL), output logged to $TMP_DIR/spinner.log"
+  if ! spinner "opencode ($OPENCODE_MODEL)" \
+      opencode run --auto --model "$OPENCODE_MODEL" "$1"; then
+    die "opencode failed (log: $TMP_DIR/spinner.log)"
   fi
 }
 
@@ -215,13 +280,18 @@ preflight() {
   require ttyd "apt install ttyd / brew install ttyd"
   require ffmpeg "apt install ffmpeg / brew install ffmpeg"
   require unzip "apt install unzip"
-  gh auth status >/dev/null 2>&1 || die "not authenticated with gh; run 'gh auth login' first"
-  for repo in rcieri/homebrew-glab-tui rcieri/scoop-glab-tui; do
-    gh api "repos/$repo" --jq '.permissions.push' | grep -q true || \
-      die "no push access to $repo; grant your token write permission"
-  done
-  fc-list 2>/dev/null | grep -qi "JetBrainsMono.*Nerd" || \
-    die "JetBrainsMono Nerd Font not installed (download from https://github.com/ryanoasis/nerd-fonts)"
+  if ! spinner "Checking gh auth, push access, and fonts" bash -c '
+    gh auth status >/dev/null 2>&1 || { echo "not authenticated with gh; run gh auth login first"; exit 1; }
+    for repo in rcieri/homebrew-glab-tui rcieri/scoop-glab-tui; do
+      gh api "repos/$repo" --jq ".permissions.push" | grep -q true || \
+        { echo "no push access to $repo; grant your token write permission"; exit 1; }
+    done
+    fc-list 2>/dev/null | grep -qi "JetBrainsMono.*Nerd" || \
+      { echo "JetBrainsMono Nerd Font not installed (see https://github.com/ryanoasis/nerd-fonts)"; exit 1; }
+    exit 0
+  '; then
+    die "preflight checks failed (see $TMP_DIR/spinner.log)"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -288,8 +358,7 @@ prepare() {
   fi
 
   bump_cargo_version
-  note "Building release binary..."
-  cargo build --release
+  spinner "Building release binary" cargo build --release
 
   note "Regenerating CHANGELOG.md / AGENTS.md / README.md via opencode..."
   PROMPT="We are prepping a new repository release. The upcoming version tag is going to be: $NEW_TAG.
@@ -314,13 +383,11 @@ generate_gifs() {
 
   # Make sure there is a built binary on PATH.
   if [[ ! -x "$ROOT/target/release/glab-tui" ]]; then
-    note "No release binary found — building now..."
-    cargo build --release
+    spinner "Building release binary" cargo build --release
   fi
 
-  note "Generating demo GIFs..."
   export PATH="$ROOT/target/release:$PATH"
-  "$ROOT/assets/generate-demos.sh"
+  spinner "Generating demo GIFs" "$ROOT/assets/generate-demos.sh"
   ok "demo GIFs regenerated"
 
   # Stage and commit the GIFs (and any other outstanding prepare changes).
@@ -328,7 +395,7 @@ generate_gifs() {
   if ! git diff --cached --quiet; then
     git commit -m "chore: prepare release $NEW_TAG"
   fi
-  git push -u origin "$BRANCH"
+  spinner "Pushing branch $BRANCH" git push -u origin "$BRANCH"
 
   PR_NUMBER="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
   if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
@@ -363,19 +430,22 @@ merge_and_tag() {
   ensure_pr_number
 
   note "Merging PR #$PR_NUMBER (squash, auto-merge when checks pass)..."
-  if ! gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --auto 2>/dev/null; then
+  if ! spinner "Merging PR #$PR_NUMBER" gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --auto; then
     local state
     state="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')"
     [[ "$state" == "MERGED" ]] || die "failed to merge PR #$PR_NUMBER (conflicts? not mergeable?)"
   fi
-  for i in $(seq 1 120); do
-    if [[ "$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')" == "MERGED" ]]; then
-      ok "PR #$PR_NUMBER merged"
-      break
-    fi
-    [[ $i -eq 120 ]] && die "timed out waiting for PR #$PR_NUMBER to merge"
-    sleep 10
-  done
+  export PR_NUMBER REPO
+  if ! spinner "Waiting for PR #$PR_NUMBER to merge (up to 20m)" bash -c '
+      for i in $(seq 1 120); do
+        [[ "$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq .state)" == "MERGED" ]] && exit 0
+        sleep 10
+      done
+      exit 1
+    '; then
+    die "timed out waiting for PR #$PR_NUMBER to merge"
+  fi
+  ok "PR #$PR_NUMBER merged"
 
   note "Tagging $NEW_TAG on the merge commit..."
   local merge_sha
@@ -398,14 +468,14 @@ wait_for_release() {
   for i in $(seq 1 "$total"); do
     current="$(gh release view "$NEW_TAG" --repo "$REPO" --json assets --jq '[.assets[].name] | length' 2>/dev/null || echo 0)"
     if [[ "$current" -ge "${#REQUIRED_ASSETS[@]}" ]]; then
-      [[ -t 1 ]] && printf '\r\033[2K'
+      [[ -t 1 ]] && printf '\r\e[2K'
       ok "All ${#REQUIRED_ASSETS[@]} release assets present"
       return 0
     fi
     [[ $i -eq $total ]] && die "timed out waiting for release assets for $NEW_TAG"
     if [[ -t 1 ]]; then
       elapsed=$((i * 20 / 60))
-      printf '\r  %smin elapsed - %s/%s assets...' "$elapsed" "$current" "${#REQUIRED_ASSETS[@]}"
+      progress_bar "$current" "${#REQUIRED_ASSETS[@]}" "assets ($elapsed min elapsed)"
     fi
     sleep 20
   done
@@ -416,13 +486,13 @@ wait_for_release() {
 # ---------------------------------------------------------------------------
 update_homebrew() {
   local arch file sha macos_amd64 macos_arm64 linux_amd64 linux_arm64
-  gh repo clone rcieri/homebrew-glab-tui "$TMP_DIR/homebrew-glab-tui" >/dev/null
+  spinner "Cloning rcieri/homebrew-glab-tui" gh repo clone rcieri/homebrew-glab-tui "$TMP_DIR/homebrew-glab-tui"
   cd "$TMP_DIR/homebrew-glab-tui"
 
   for arch in macos-amd64 macos-arm64 linux-amd64 linux-arm64; do
     file="$TMP_DIR/glab-tui-${arch}.tar.gz"
-    note "Fetching glab-tui-${arch}.tar.gz..."
-    curl -sL "https://github.com/$REPO/releases/download/$NEW_TAG/glab-tui-${arch}.tar.gz" -o "$file"
+    spinner "Fetching glab-tui-${arch}.tar.gz" \
+      curl -sL "https://github.com/$REPO/releases/download/$NEW_TAG/glab-tui-${arch}.tar.gz" -o "$file"
     sha="$(sha256sum "$file" | cut -d' ' -f1)"
     case "$arch" in
       macos-amd64) macos_amd64=$sha ;;
@@ -445,7 +515,7 @@ update_homebrew() {
     git -c user.name="opencode-release[bot]" \
         -c user.email="opencode-release[bot]@users.noreply.github.com" \
         commit -m "Update to ${NEW_TAG}" >/dev/null
-    git push
+    spinner "Pushing Homebrew formula" git push
     ok "Homebrew formula updated and pushed"
   fi
   cd "$ROOT"
@@ -453,12 +523,12 @@ update_homebrew() {
 
 update_scoop() {
   local version sha
-  gh repo clone rcieri/scoop-glab-tui "$TMP_DIR/scoop-glab-tui" >/dev/null
+  spinner "Cloning rcieri/scoop-glab-tui" gh repo clone rcieri/scoop-glab-tui "$TMP_DIR/scoop-glab-tui"
   cd "$TMP_DIR/scoop-glab-tui"
 
   version="${NEW_TAG#v}"
-  note "Fetching glab-tui-windows-amd64.zip..."
-  curl -sL "https://github.com/$REPO/releases/download/$NEW_TAG/glab-tui-windows-amd64.zip" -o "$TMP_DIR/glab-tui-windows-amd64.zip"
+  spinner "Fetching glab-tui-windows-amd64.zip" \
+    curl -sL "https://github.com/$REPO/releases/download/$NEW_TAG/glab-tui-windows-amd64.zip" -o "$TMP_DIR/glab-tui-windows-amd64.zip"
   sha="$(sha256sum "$TMP_DIR/glab-tui-windows-amd64.zip" | cut -d' ' -f1)"
 
   jq --arg v "$version" --arg sha "$sha" \
@@ -473,7 +543,7 @@ update_scoop() {
     git -c user.name="opencode-release[bot]" \
         -c user.email="opencode-release[bot]@users.noreply.github.com" \
         commit -m "Update to ${NEW_TAG}" >/dev/null
-    git push
+    spinner "Pushing Scoop manifest" git push
     ok "Scoop manifest updated and pushed"
   fi
   cd "$ROOT"
@@ -506,7 +576,7 @@ Use the content from CHANGELOG.md for the current version as the source material
   ok "RELEASE_NOTES.md generated"
 
   note "Updating release $NEW_TAG body..."
-  gh release edit "$NEW_TAG" --repo "$REPO" --notes-file RELEASE_NOTES.md
+  spinner "Updating release $NEW_TAG body" gh release edit "$NEW_TAG" --repo "$REPO" --notes-file RELEASE_NOTES.md
 
   update_homebrew
   update_scoop
@@ -525,19 +595,17 @@ publish() {
     die "Cargo package version ($package_version) does not match tag version ($tag_version)"
   fi
 
-  note "Pushing Docker image to GHCR..."
   require docker "see https://docs.docker.com/get-docker/"
   user="$(gh api user --jq .login)"
-  gh auth token | docker login ghcr.io -u "$user" --password-stdin
+  spinner "Authenticating to GHCR" bash -c 'gh auth token | docker login ghcr.io -u "$0" --password-stdin' "$user"
   local tags_args=(-t "ghcr.io/$REPO:$NEW_TAG")
   if [[ "$NEW_TAG" != *-* ]]; then
     tags_args+=(-t "ghcr.io/$REPO:latest")
   fi
-  docker buildx build --push "${tags_args[@]}" .
+  spinner "Building & pushing Docker image to GHCR" docker buildx build --push "${tags_args[@]}" .
   ok "Docker image pushed to GHCR"
 
-  note "Publishing crate v$package_version to crates.io..."
-  cargo publish --locked
+  spinner "Publishing crate v$package_version to crates.io" cargo publish --locked
   ok "crate v$package_version published to crates.io"
 }
 
@@ -546,7 +614,7 @@ publish() {
 # ---------------------------------------------------------------------------
 main() {
   TMP_DIR="$(mktemp -d)"
-  trap 'rm -rf "$TMP_DIR"' EXIT
+  trap 'printf "\e[?25h" 2>/dev/null || true; rm -rf "$TMP_DIR"' EXIT
   banner
 
   # ── Starting-point picker ──────────────────────────────────────────────────
@@ -554,13 +622,13 @@ main() {
 
   # ── Phase 0: Preflight ────────────────────────────────────────────────────
   if [[ "$START_PHASE" -le "$PHASE_PREFLIGHT" ]]; then
-    phase "Preflight"
+    phase 1 "Preflight"
     preflight
   fi
 
   # ── Phase 1: Prepare (version bump, docs, PR) ─────────────────────────────
   if [[ "$START_PHASE" -le "$PHASE_PREPARE" ]]; then
-    phase "Prepare"
+    phase 2 "Prepare"
     next_version
     if [[ -z "$OPENCODE_MODEL_FROM_ENV" ]]; then
       select_opencode_model
@@ -572,7 +640,7 @@ main() {
 
   # ── Phase 2: Generate GIFs ────────────────────────────────────────────────
   if [[ "$START_PHASE" -le "$PHASE_GIFS" ]]; then
-    phase "Generate GIFs"
+    phase 3 "Generate GIFs"
     # If jumping directly to this phase, hydrate required state.
     if [[ "$START_PHASE" -ge "$PHASE_GIFS" ]]; then
       ensure_version
@@ -587,14 +655,14 @@ main() {
 
   # ── Phase 3: Review & merge ───────────────────────────────────────────────
   if [[ "$START_PHASE" -le "$PHASE_REVIEW" ]]; then
-    phase "Review & merge"
+    phase 4 "Review & merge"
     review_gate
     merge_and_tag
   fi
 
   # ── Phase 4: Wait for CI build ────────────────────────────────────────────
   if [[ "$START_PHASE" -le "$PHASE_WAIT_CI" ]]; then
-    phase "Wait for CI build"
+    phase 5 "Wait for CI build"
     if [[ "$START_PHASE" -ge "$PHASE_WAIT_CI" ]]; then
       ensure_version
     fi
@@ -603,7 +671,7 @@ main() {
 
   # ── Phase 5: Post-release (notes, Homebrew, Scoop) ───────────────────────
   if [[ "$START_PHASE" -le "$PHASE_POST_RELEASE" ]]; then
-    phase "Post-release"
+    phase 6 "Post-release"
     if [[ "$START_PHASE" -ge "$PHASE_POST_RELEASE" ]]; then
       ensure_version
       if [[ -z "$OPENCODE_MODEL_FROM_ENV" ]]; then
@@ -617,7 +685,7 @@ main() {
 
   # ── Phase 6: Publish (Docker + crate) ────────────────────────────────────
   if [[ "$START_PHASE" -le "$PHASE_PUBLISH" ]]; then
-    phase "Publish"
+    phase 7 "Publish"
     if [[ "$START_PHASE" -ge "$PHASE_PUBLISH" ]]; then
       ensure_version
     fi

--- a/src/app.rs
+++ b/src/app.rs
@@ -4878,11 +4878,9 @@ diff --git a/foo.txt b/foo.txt
         assert_eq!(app.unresolved_threads_count_for_path("other.txt"), 0);
     }
 
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
     fn test_save_layout_and_active_tab_and_group_sorting() {
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = crate::config::TEST_ENV_MUTEX.lock().unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let config_path = temp_dir.path().join("config.toml");
         let old_config = std::env::var("GLAB_TUI_CONFIG").ok();
@@ -4959,7 +4957,7 @@ diff --git a/foo.txt b/foo.txt
 
     #[test]
     fn test_save_layout_preserves_custom_settings() {
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = crate::config::TEST_ENV_MUTEX.lock().unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let config_path = temp_dir.path().join("config.toml");
         let old_config = std::env::var("GLAB_TUI_CONFIG").ok();

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,12 @@ use std::path::PathBuf;
 use std::sync::LazyLock as Lazy;
 use std::sync::RwLock;
 
+/// Serializes tests that mutate process-global environment variables
+/// (config paths, cache dirs). Env vars are visible to every test thread,
+/// so mutating ones must never overlap with a load in another.
+#[cfg(test)]
+pub(crate) static TEST_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Theme {
     pub bg: Color,
@@ -1721,6 +1727,7 @@ page_size = 250
 
     #[test]
     fn test_config_load_override() {
+        let _guard = TEST_ENV_MUTEX.lock().unwrap();
         let temp_dir = tempfile::tempdir().unwrap();
         let conf_dir = temp_dir.path().join("glab-tui");
         std::fs::create_dir_all(&conf_dir).unwrap();

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -346,6 +346,7 @@ mod tests {
 
     #[test]
     fn test_repos_dir_env_var() {
+        let _guard = crate::config::TEST_ENV_MUTEX.lock().unwrap();
         let temp_dir = tempdir().unwrap();
         let path_str = temp_dir.path().to_str().unwrap().to_string();
 


### PR DESCRIPTION
## Problem

`config::tests::test_config_load_override` fails intermittently on `windows-latest` with:

```
assertion left == right failed; left: 100; right: 250
```

at `src/config.rs:1738`. This is a **flaky race, not a regression** — it also failed on an unrelated toml-bump PR (run `30911079943`) while the merge push run (`30912451994`) passed all platforms.

## Root cause

Several unit tests mutate **process-global** environment variables, which are visible to every test thread:

- `src/app.rs` save-layout tests set `GLAB_TUI_CONFIG` (guarded by a local `ENV_MUTEX`)
- `src/config.rs` `test_config_load_override` sets `XDG_CONFIG_HOME` (**unguarded**)
- `src/utils/cache.rs` `test_repos_dir_env_var` sets `GLAB_TUI_REPOS_DIR` (**unguarded**)

Because `config_dir()` (`src/config.rs:463`) checks `GLAB_TUI_CONFIG` **before** `XDG_CONFIG_HOME`, when an app.rs test holds its mutex with `GLAB_TUI_CONFIG` pointing at a temp config, the config test's concurrent `Config::load()` reads that temp config (default `page_size = 100`) instead of its own (250) — hence `left: 100; right: 250`.

## Fix

Promote the test-only mutex to a single crate-wide `config::TEST_ENV_MUTEX` (guarded by `#[cfg(test)]`) and acquire it in **every** test that mutates env vars:

- `test_config_load_override` (XDG_CONFIG_HOME)
- both save-layout tests in `app.rs` (GLAB_TUI_CONFIG, replacing the local `ENV_MUTEX`)
- `test_repos_dir_env_var` (GLAB_TUI_REPOS_DIR)

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test`: 209 unit + 71 bin tests pass