### PR TITLE
fix(milestones): render correct milestone progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,8 @@ Every interaction with GitLab/GitHub goes through `glab` or `gh` CLI. This secti
 | List pipelines | `glab ci list --output json -R <repo> --page N --per-page <api_per_page>` | Loops up to `page_size/api_per_page` pages |
 | List runners | `glab runner list --output json -R <repo> --per-page <N>` | Single call |
 | List releases | `glab release list --output json -R <repo> --per-page <N>` | Single call |
-| List milestones | `glab milestone list --output json -R <repo> --per-page <N>` | Single call |
-| List milestone issues | `glab issue list --milestone <id> --all --output json -R <repo> --per-page <N>` | Single call |
+| List milestones | `glab milestone list --output json --project <repo> --per-page <N>` | Single call (`milestone list` requires `--project`/`--group`, not `-R`) |
+| List milestone issues | `glab issue list --milestone <title> --all --output json -R <repo> --per-page <N>` | Single call (`--milestone` filters by milestone **title**, not iid — resolved from the selected milestone at the call site) |
 | List todos | `glab todo list --output=json` | Single call |
 | List labels | `glab label list --output json -R <repo> --per-page <api_per_page>` | Single call (label colors feed the Labels column) |
 

--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -1806,6 +1806,7 @@ impl Backend for GhBackend {
         &self,
         project: &str,
         milestone_iid: u64,
+        _milestone_title: &str,
         page_size: usize,
     ) -> Result<Vec<Issue>> {
         let total = page_size * 10;

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -1994,7 +1994,7 @@ impl Backend for GlabBackend {
                     "list",
                     "--output",
                     "json",
-                    "-R",
+                    "--project",
                     project,
                     "--per-page",
                     &page_size.to_string(),
@@ -2038,15 +2038,20 @@ impl Backend for GlabBackend {
         &self,
         project: &str,
         milestone_iid: u64,
+        milestone_title: &str,
         page_size: usize,
     ) -> Result<Vec<Issue>> {
+        // `glab issue list --milestone` filters by milestone **title**, not
+        // iid/id — passing the iid silently returns an empty list, which made
+        // milestone progress render as 0%. The title is resolved at the call
+        // site and passed through the domain layer.
         let raw = self
             .run_glab(
                 &[
                     "issue",
                     "list",
                     "--milestone",
-                    &milestone_iid.to_string(),
+                    milestone_title,
                     "--all",
                     "--output",
                     "json",

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -272,6 +272,7 @@ pub trait Backend: Send + Sync {
         &self,
         project: &str,
         milestone_iid: u64,
+        milestone_title: &str,
         page_size: usize,
     ) -> Result<Vec<Issue>>;
     async fn create_milestone(

--- a/src/domain/milestones.rs
+++ b/src/domain/milestones.rs
@@ -31,10 +31,16 @@ pub async fn list_milestone_issues(
     client: &GitlabClient,
     project_path: &str,
     milestone_iid: u64,
+    milestone_title: &str,
 ) -> Result<Vec<Issue>> {
     client
         .backend
-        .list_milestone_issues(project_path, milestone_iid, client.page_size)
+        .list_milestone_issues(
+            project_path,
+            milestone_iid,
+            milestone_title,
+            client.page_size,
+        )
         .await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1021,29 +1021,54 @@ async fn main() -> Result<()> {
         if app.active_tab == app::Tab::Milestones {
             if let Some(client) = &app.gitlab_client {
                 if let Some(idx) = app.milestones.state.selected() {
-                    let milestone_iid = app.filtered_milestones().get(idx).map(|m| m.iid);
-                    if let Some(iid) = milestone_iid {
-                        if app.selected_milestone_iid != Some(iid) {
-                            app.selected_milestone_iid = Some(iid);
-                            // Use cached data if available; only fetch if not yet cached
-                            if let Some(cached) = app.milestone_issues_cache.get(&iid) {
+                    let milestone = app
+                        .filtered_milestones()
+                        .get(idx)
+                        .map(|m| (m.iid, m.title.clone()));
+                    if let Some((milestone_iid, milestone_title)) = milestone {
+                        if app.selected_milestone_iid != Some(milestone_iid) {
+                            app.selected_milestone_iid = Some(milestone_iid);
+                            // Use cached data if available; only fetch if not yet cached.
+                            // An empty cached list is NOT treated as data: it is what a
+                            // failed/buggy fetch (e.g. `--milestone <iid>` matching nothing)
+                            // leaves behind, and trusting it would freeze progress at 0%.
+                            let cached = app
+                                .milestone_issues_cache
+                                .get(&milestone_iid)
+                                .filter(|c| !c.is_empty());
+                            if let Some(cached) = cached {
                                 app.selected_milestone_issues = Some(cached.clone());
                             } else {
                                 app.selected_milestone_issues = None;
                                 let client_clone = client.clone();
                                 let project_context = app.project_context.clone();
+                                // `glab issue list --milestone` filters by milestone
+                                // title, not iid — passing the title here is required
+                                // for the glab backend to return any issues.
                                 let tx = events.sender();
                                 tokio::spawn(async move {
-                                    if let Ok(issues) = domain::milestones::list_milestone_issues(
+                                    match domain::milestones::list_milestone_issues(
                                         &client_clone,
                                         &project_context,
-                                        iid,
+                                        milestone_iid,
+                                        &milestone_title,
                                     )
                                     .await
                                     {
-                                        let _ = tx.send(Event::MilestoneIssuesFetched(iid, issues));
-                                    } else {
-                                        let _ = tx.send(Event::MilestoneIssuesFetched(iid, vec![]));
+                                        Ok(issues) => {
+                                            let _ = tx.send(Event::MilestoneIssuesFetched(
+                                                milestone_iid,
+                                                issues,
+                                            ));
+                                        }
+                                        Err(e) => {
+                                            // Don't silently substitute an empty list: that
+                                            // renders as 0% progress with no explanation.
+                                            let _ = tx.send(Event::FetchFailed(
+                                                app::Tab::Milestones,
+                                                format!("Failed to fetch milestone issues: {e}"),
+                                            ));
+                                        }
                                     }
                                 });
                             }
@@ -1254,7 +1279,15 @@ async fn main() -> Result<()> {
                 Event::MilestoneIssuesFetched(iid, issues) => {
                     let mut fallback_success = false;
                     if issues.is_empty() {
-                        if let Some(cached) = app.project_cache.milestone_issues.get(&iid) {
+                        // Only fall back to a cached list that actually has data;
+                        // a cached empty list is indistinguishable from a failed
+                        // fetch and must not mask a real 0% progress display.
+                        if let Some(cached) = app
+                            .project_cache
+                            .milestone_issues
+                            .get(&iid)
+                            .filter(|c| !c.is_empty())
+                        {
                             app.milestone_issues_cache.insert(iid, cached.clone());
                             if app.selected_milestone_iid == Some(iid) {
                                 app.selected_milestone_issues = Some(cached.clone());


### PR DESCRIPTION
Fixes #302

## Problem

The **Milestones** tab rendered `0%` / `0 Closed / 0 Open` for milestones that actually contain issues, because:

1. `glab milestone list` was invoked with `-R <repo>`, which is silently ignored — the flag must be `--project`/`--group`, so the Milestones tab listed nothing.
2. `glab issue list --milestone <iid>` filters by milestone **title**, not iid. Passing the iid returned an empty list (exit code 0), which was cached as `milestone_issues: {"1": []}` and froze the progress column at 0%.

## Changes

- **`src/backend/glab.rs`** — `list_milestones` uses `--project <repo>`; `list_milestone_issues` passes the milestone **title** to `--milestone` instead of the iid.
- **`src/backend/mod.rs` / `src/backend/gh.rs` / `src/domain/milestones.rs` / `src/main.rs`** — the milestone title is resolved from the selected milestone and threaded through the `Backend` trait (`list_milestone_issues` gains a `milestone_title` parameter). The GitHub backend keeps the numeric milestone, which `gh issue list --milestone` accepts unambiguously.
- **`src/main.rs`** — a cached **empty** milestone-issue list is no longer treated as data (stale `[]` entries can't block a re-fetch), and milestone-issues fetch failures now surface via `FetchFailed` instead of silently substituting an empty list.

## Verification

- Against a real GitLab repo: `glab issue list --milestone 1` → `[]`; `glab issue list --milestone "0.0.1"` → 38 issues (27 closed). After the fix the progress column shows ~71%.
- `cargo check`, `cargo fmt`, `cargo clippy -- -D warnings` clean; full test suite 280/280 passes.
