### PR TITLE
fix(help): keep quit key in shortcut search

### DIFF
--- a/src/handlers/overlays.rs
+++ b/src/handlers/overlays.rs
@@ -473,3 +473,25 @@ pub fn handle_date_picker(
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::handle_help_overlay;
+    use crate::app::App;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    #[test]
+    fn help_search_consumes_q_instead_of_closing_or_quitting() {
+        let mut app = App::default();
+        app.show_help = true;
+
+        let handled = handle_help_overlay(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        );
+
+        assert!(handled);
+        assert_eq!(app.help_search_query, "q");
+        assert!(app.show_help);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1713,6 +1713,7 @@ async fn main() -> Result<()> {
                         && app.text_input.is_none()
                         && app.edit_menu.is_none()
                         && app.selector.is_none()
+                        && !app.show_help
                         && !app.focus_column_checklist
                     {
                         app.quit();


### PR DESCRIPTION
Fixes #299

Prevent the global quit binding from running while the keyboard-shortcuts help overlay is open, allowing characters such as `q` to be entered in the filter. Add a regression test for help-search input handling.

Validation: targeted help-overlay test, cargo fmt, cargo clippy --all-targets --all-features -- -D warnings, cargo check.