### PR TITLE
fix(glab): merge MRs without prompting

### DIFF
--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -444,6 +444,33 @@ impl GlabBackend {
             format!("query={}", query),
         ]
     }
+
+    fn merge_args(
+        project: &str,
+        iid: u64,
+        squash: bool,
+        delete_branch: bool,
+        strategy: Option<&str>,
+    ) -> Vec<String> {
+        let mut args = vec![
+            "mr".into(),
+            "merge".into(),
+            iid.to_string(),
+            "-R".into(),
+            project.into(),
+        ];
+        if squash {
+            args.push("--squash".into());
+        }
+        if delete_branch {
+            args.push("--remove-source-branch".into());
+        }
+        if let Some(s) = strategy {
+            args.push(format!("--{}", s));
+        }
+        args.push("--yes".into());
+        args
+    }
 }
 
 #[async_trait]
@@ -1315,22 +1342,7 @@ impl Backend for GlabBackend {
         delete_branch: bool,
         strategy: Option<&str>,
     ) -> Result<()> {
-        let mut args: Vec<String> = vec![
-            "mr".into(),
-            "merge".into(),
-            iid.to_string(),
-            "-R".into(),
-            project.into(),
-        ];
-        if squash {
-            args.push("--squash".into());
-        }
-        if delete_branch {
-            args.push("--remove-source-branch".into());
-        }
-        if let Some(s) = strategy {
-            args.push(format!("--{}", s));
-        }
+        let args = Self::merge_args(project, iid, squash, delete_branch, strategy);
         let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
         self.run_glab(&args_refs, "MERGING MR").await?;
         Ok(())
@@ -2666,6 +2678,25 @@ impl Backend for GlabBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_args_skip_confirmation_prompt() {
+        let args = GlabBackend::merge_args("group/project", 42, true, true, None);
+
+        assert_eq!(
+            args,
+            vec![
+                "mr",
+                "merge",
+                "42",
+                "-R",
+                "group/project",
+                "--squash",
+                "--remove-source-branch",
+                "--yes",
+            ]
+        );
+    }
 
     // ── iid batching (GraphQL 100-node connection cap) ──
 

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -10,6 +10,46 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::ListState;
 use tokio::sync::mpsc::UnboundedSender;
 
+fn open_merge_selector(app: &mut App, mr_iid: u64, selected_count: usize) {
+    let is_github = app.is_github();
+    let all_items = if is_github {
+        vec![
+            "Squash".to_string(),
+            "Delete source branch".to_string(),
+            "Create merge commit".to_string(),
+            "Rebase and merge".to_string(),
+        ]
+    } else {
+        vec!["Squash".to_string(), "Delete source branch".to_string()]
+    };
+    let mut selected_items = std::collections::HashSet::new();
+    selected_items.insert("Squash".to_string());
+    selected_items.insert("Delete source branch".to_string());
+
+    app.selector = Some(crate::app::Selector {
+        title: if selected_count > 1 {
+            format!(" Merge {} MRs/PRs - Options ", selected_count)
+        } else {
+            format!(" Merge MR/PR #{} - Options ", mr_iid)
+        },
+        all_items,
+        selected_items,
+        cursor_idx: 0,
+        search_query: String::new(),
+        is_filtering: false,
+        is_loading: false,
+        entity_iid: if selected_count > 1 { 0 } else { mr_iid },
+        entity_type: if selected_count > 1 {
+            "bulk_merge_mrs".to_string()
+        } else {
+            "mr".to_string()
+        },
+        field_type: "merge_options".to_string(),
+        multi_select: true,
+        state: ListState::default(),
+    });
+}
+
 pub async fn handle_active_tab_key(
     app: &mut App,
     key_event: &KeyEvent,
@@ -444,6 +484,10 @@ pub async fn handle_active_tab_key(
                         });
                     }
                 }
+            } else if app.selected_mrs.len() > 1
+                && keybinding_matches(&app.config.keybindings.mrs.merge_mr, key_event)
+            {
+                open_merge_selector(app, 0, app.selected_mrs.len());
             } else if let Some(selected_idx) = app.mrs.state.selected() {
                 let filtered = app.filtered_mrs();
                 let mr_ref = filtered.get(selected_idx);
@@ -519,40 +563,7 @@ pub async fn handle_active_tab_key(
                             key_event,
                         ) =>
                         {
-                            let is_github = app
-                                .gitlab_client
-                                .as_ref()
-                                .map(|c| c.is_github)
-                                .unwrap_or(false);
-                            let all_items = if is_github {
-                                vec![
-                                    "Squash".to_string(),
-                                    "Delete source branch".to_string(),
-                                    "Create merge commit".to_string(),
-                                    "Rebase and merge".to_string(),
-                                ]
-                            } else {
-                                vec!["Squash".to_string(), "Delete source branch".to_string()]
-                            };
-                            app.selector = Some(crate::app::Selector {
-                                title: format!(" Merge MR/PR #{} - Options ", mr_iid),
-                                all_items,
-                                selected_items: {
-                                    let mut s = std::collections::HashSet::new();
-                                    s.insert("Squash".to_string());
-                                    s.insert("Delete source branch".to_string());
-                                    s
-                                },
-                                cursor_idx: 0,
-                                search_query: String::new(),
-                                is_filtering: false,
-                                is_loading: false,
-                                entity_iid: mr_iid,
-                                entity_type: "mr".to_string(),
-                                field_type: "merge_options".to_string(),
-                                multi_select: true,
-                                state: ListState::default(),
-                            });
+                            open_merge_selector(app, mr_iid, 1);
                         }
                         _ if keybinding_matches(
                             &app.config.keybindings.mrs.view_diff,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3398,7 +3398,16 @@ async fn main() -> Result<()> {
                                     }
 
                                     if field_type == "merge_options" {
-                                        let mr_iid = selector.entity_iid;
+                                        let is_bulk_merge =
+                                            selector.entity_type == "bulk_merge_mrs";
+                                        let merge_iids = if is_bulk_merge {
+                                            let mut iids: Vec<u64> =
+                                                app.selected_mrs.iter().copied().collect();
+                                            iids.sort_unstable();
+                                            iids
+                                        } else {
+                                            vec![selector.entity_iid]
+                                        };
                                         let mut squash = false;
                                         let mut delete_branch = false;
                                         let mut merge_strategy: Option<&str> = None;
@@ -3418,39 +3427,52 @@ async fn main() -> Result<()> {
                                             }
                                         }
                                         app.selector = None;
-                                        let client = app.gitlab_client.clone().unwrap();
+                                        let Some(client) = app.gitlab_client.clone() else {
+                                            app.error_message = Some(
+                                                "No backend is available for merging".to_string(),
+                                            );
+                                            continue;
+                                        };
                                         let project = app.project_context.clone();
                                         let tx = events.sender();
                                         let tab = app.active_tab;
                                         tokio::spawn(async move {
-                                            match client
-                                                .merge_mr(
-                                                    &project,
-                                                    mr_iid,
-                                                    squash,
-                                                    delete_branch,
-                                                    merge_strategy,
-                                                )
-                                                .await
-                                            {
-                                                Ok(_) => {
-                                                    let _ = tx
-                                                        .send(Event::CommandCompleted(tab, Ok(())));
-                                                }
-                                                Err(e) => {
-                                                    let _ = tx.send(Event::CommandCompleted(
-                                                        tab,
-                                                        Err(e.to_string()),
-                                                    ));
+                                            let mut failures = Vec::new();
+                                            for mr_iid in merge_iids {
+                                                if let Err(e) = client
+                                                    .merge_mr(
+                                                        &project,
+                                                        mr_iid,
+                                                        squash,
+                                                        delete_branch,
+                                                        merge_strategy,
+                                                    )
+                                                    .await
+                                                {
+                                                    failures.push(format!("#{}: {}", mr_iid, e));
                                                 }
                                             }
+                                            let result = if failures.is_empty() {
+                                                Ok(())
+                                            } else {
+                                                Err(format!(
+                                                    "Merge failures: {}",
+                                                    failures.join("; ")
+                                                ))
+                                            };
+                                            let _ = tx.send(Event::CommandCompleted(tab, result));
                                         });
-                                        if let Some(pos) =
-                                            app.mrs.items.iter().position(|m| m.iid == mr_iid)
-                                        {
-                                            app.mrs.items.remove(pos);
+                                        if is_bulk_merge {
+                                            app.selected_mrs.clear();
+                                        } else {
+                                            let mr_iid = selector.entity_iid;
+                                            if let Some(pos) =
+                                                app.mrs.items.iter().position(|m| m.iid == mr_iid)
+                                            {
+                                                app.mrs.items.remove(pos);
+                                            }
+                                            app.update_filter_selection();
                                         }
-                                        app.update_filter_selection();
                                         continue;
                                     }
 

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -673,7 +673,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             Shortcut {
                 category: "Merge Requests",
                 key: d(format!("{}", app.config.keybindings.mrs.select_mr)),
-                action: "Toggle MR/PR selection (bulk edit with e)",
+                action: "Toggle MR/PR selection (bulk edit/merge with e/m)",
             },
             Shortcut {
                 category: "Merge Requests",


### PR DESCRIPTION
Fixes #304

Support merging multiple selected MRs/PRs from the TUI. Press the configured selection key on each request, then press merge to choose squash/delete/strategy options; selected requests are merged sequentially with failures reported.

GitLab merges pass `--yes` so they do not wait for an unavailable interactive confirmation prompt. Failed requests remain in the table for retry.

Validation: cargo fmt, cargo test, cargo clippy --all-targets --all-features -- -D warnings, cargo check.