### PR TITLE
fix(help): clarify quit and overlay hints

### DIFF
--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -615,8 +615,13 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             },
             Shortcut {
                 category: "Global & Nav",
-                key: d(format!("q / {} / Esc", app.config.keybindings.global.quit)),
-                action: "Quit / Close overlay",
+                key: d(app.config.keybindings.global.quit.clone()),
+                action: "Quit program",
+            },
+            Shortcut {
+                category: "Global & Nav",
+                key: s("Esc"),
+                action: "Close active overlay",
             },
             Shortcut {
                 category: "Global & Nav",


### PR DESCRIPTION
Clarify the keyboard-shortcuts help overlay:

- The configured quit binding is shown as `Quit program`.
- `Esc` is shown as `Close active overlay`.
- `Ctrl+C` remains an explicit quit shortcut.

This avoids conflating quit and overlay-dismiss behavior in a single hint.