### PR TITLE
fix: support GitHub Enterprise backend detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ gh auth login     # for GitHub repos
 ```
 
 The active project is detected automatically from the `origin` remote in the current working directory.
+For GitHub Enterprise or unusual hosting setups, set the backend explicitly in the repo-local config:
+
+```toml
+backend = "github" # or "gitlab"
+```
+
+The repo-local override takes precedence over automatic detection. Automatic detection recognizes
+`github.com` and checks `gh` authentication for other GitHub Enterprise hostnames; SSH aliases and
+hosts serving both platforms require the override.
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ backend = "github" # or "gitlab"
 ```
 
 The repo-local override takes precedence over automatic detection. Automatic detection recognizes
-`github.com` and checks `gh` authentication for other GitHub Enterprise hostnames; SSH aliases and
-hosts serving both platforms require the override.
+`github.com` and checks both `gh auth status` and `glab auth status` for other hostnames; SSH aliases
+and hosts serving both platforms require the override.
 
 ### Config file
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,7 +16,8 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum BackendKind {
     GitLab,
     GitHub,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -556,7 +556,11 @@ fn detect_github() -> bool {
         .args(["remote", "get-url", "origin"])
         .output()
     {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).contains("github.com"),
+        Ok(o) if o.status.success() => crate::git_helpers::detect_backend(
+            &String::from_utf8_lossy(&o.stdout),
+            crate::config::Config::load().backend,
+        )
+        .is_github(),
         _ => false,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1206,7 +1206,7 @@ theme_preset = "default"
 # Default request page size
 page_size = 100
 
-# Backend override for repositories where automatic detection is incorrect.
+# Backend override for repositories where automatic detection is ambiguous.
 # backend = "github" or "gitlab"
 
 # Maximum items per API request (1-100). Lower this if your GitLab instance

--- a/src/config.rs
+++ b/src/config.rs
@@ -1123,6 +1123,7 @@ impl Default for UiConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
+    pub backend: Option<crate::backend::BackendKind>,
     pub theme_preset: Option<String>,
     pub active_tab: Option<String>,
     pub theme: ThemeOverrides,
@@ -1153,6 +1154,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            backend: None,
             theme_preset: Some("default".to_string()),
             active_tab: None,
             theme: ThemeOverrides::default(),
@@ -1203,6 +1205,9 @@ theme_preset = "default"
 
 # Default request page size
 page_size = 100
+
+# Backend override for repositories where automatic detection is incorrect.
+# backend = "github" or "gitlab"
 
 # Maximum items per API request (1-100). Lower this if your GitLab instance
 # truncates large JSON response bodies. Only affects GitLab backends.
@@ -1776,6 +1781,15 @@ page_size = 250
 
         let empty: Config = toml::from_str("").expect("parse empty config");
         assert!(empty.fetch_label_colors);
+    }
+
+    #[test]
+    fn backend_override_is_optional_and_lowercase() {
+        assert_eq!(Config::default().backend, None);
+        let github: Config = toml::from_str("backend = \"github\"").expect("parse config");
+        assert_eq!(github.backend, Some(crate::backend::BackendKind::GitHub));
+        let gitlab: Config = toml::from_str("backend = \"gitlab\"").expect("parse config");
+        assert_eq!(gitlab.backend, Some(crate::backend::BackendKind::GitLab));
     }
 
     #[test]

--- a/src/domain/client.rs
+++ b/src/domain/client.rs
@@ -1,4 +1,5 @@
 use crate::backend::{Backend, BackendKind};
+use crate::config::Config;
 use anyhow::{Context, Result};
 
 pub struct GitlabClient {
@@ -14,7 +15,7 @@ impl GitlabClient {
         self.backend.kind()
     }
 
-    pub async fn new() -> Result<Self> {
+    pub async fn new(config: &Config) -> Result<Self> {
         let is_github = match tokio::process::Command::new("git")
             .args(["remote", "get-url", "origin"])
             .output()
@@ -22,9 +23,9 @@ impl GitlabClient {
         {
             Ok(output) if output.status.success() => {
                 let url = String::from_utf8_lossy(&output.stdout);
-                url.contains("github.com")
+                crate::git_helpers::detect_backend(&url, config.backend).is_github()
             }
-            _ => false,
+            _ => config.backend.is_some_and(BackendKind::is_github),
         };
         let backend = crate::backend::create_backend(is_github);
         Ok(Self {

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -76,15 +76,25 @@ pub fn detect_backend(remote_url: &str, override_kind: Option<BackendKind>) -> B
         return BackendKind::GitHub;
     }
 
-    let authenticated = std::process::Command::new("gh")
-        .args(["auth", "status", "--active", "--hostname", &host])
-        .output()
-        .is_ok_and(|output| output.status.success());
-    if authenticated {
+    let gh_authenticated = auth_status("gh", &host, true);
+    let glab_authenticated = auth_status("glab", &host, false);
+    if gh_authenticated && !glab_authenticated {
         BackendKind::GitHub
+    } else if glab_authenticated && !gh_authenticated {
+        BackendKind::GitLab
     } else {
         BackendKind::GitLab
     }
+}
+
+fn auth_status(program: &str, host: &str, active: bool) -> bool {
+    let mut command = std::process::Command::new(program);
+    command.args(["auth", "status"]);
+    if active {
+        command.arg("--active");
+    }
+    command.args(["--hostname", host]);
+    command.output().is_ok_and(|output| output.status.success())
 }
 
 pub fn slugify(s: &str) -> String {

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -1,3 +1,5 @@
+use crate::backend::BackendKind;
+
 pub fn get_current_branch() -> Option<String> {
     let output = std::process::Command::new("git")
         .args(["symbolic-ref", "--short", "HEAD"])
@@ -45,6 +47,44 @@ pub fn parse_project_path(url: &str) -> Option<String> {
     let path = path.trim_matches('/');
     let path = path.strip_suffix(".git").unwrap_or(path);
     path.contains('/').then(|| path.to_string())
+}
+
+pub fn parse_remote_host(url: &str) -> Option<String> {
+    let url = url.trim();
+    let authority = if let Some((_, rest)) = url.split_once("://") {
+        rest.split('/').next()?
+    } else {
+        url.split_once(':')?.0
+    };
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let host = host.trim_matches(['[', ']']);
+    let host = host.split(':').next().unwrap_or(host);
+    (!host.is_empty()).then(|| host.to_ascii_lowercase())
+}
+
+pub fn detect_backend(remote_url: &str, override_kind: Option<BackendKind>) -> BackendKind {
+    if let Some(kind) = override_kind {
+        return kind;
+    }
+
+    let Some(host) = parse_remote_host(remote_url) else {
+        return BackendKind::GitLab;
+    };
+    if host == "github.com" {
+        return BackendKind::GitHub;
+    }
+
+    let authenticated = std::process::Command::new("gh")
+        .args(["auth", "status", "--active", "--hostname", &host])
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if authenticated {
+        BackendKind::GitHub
+    } else {
+        BackendKind::GitLab
+    }
 }
 
 pub fn slugify(s: &str) -> String {
@@ -184,7 +224,35 @@ pub fn get_workflow_files(is_github: bool) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_project_path;
+    use super::{detect_backend, parse_project_path, parse_remote_host};
+    use crate::backend::BackendKind;
+
+    #[test]
+    fn parses_remote_hosts() {
+        assert_eq!(
+            parse_remote_host("https://github.example.com/org/repo.git").as_deref(),
+            Some("github.example.com")
+        );
+        assert_eq!(
+            parse_remote_host("git@github.example.com:org/repo.git").as_deref(),
+            Some("github.example.com")
+        );
+        assert_eq!(
+            parse_remote_host("ssh://git@gitlab.example.com:2222/org/repo.git").as_deref(),
+            Some("gitlab.example.com")
+        );
+    }
+
+    #[test]
+    fn backend_override_takes_precedence() {
+        assert_eq!(
+            detect_backend(
+                "git@github.example.com:org/repo.git",
+                Some(BackendKind::GitLab)
+            ),
+            BackendKind::GitLab
+        );
+    }
 
     #[test]
     fn keeps_nested_subgroups_over_https() {

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -577,16 +577,9 @@ pub async fn handle_active_tab_key(
                             let client = app.gitlab_client.clone();
                             let project_context = app.project_context.clone();
                             tokio::spawn(async move {
-                                let is_github = match tokio::process::Command::new("git")
-                                    .args(["remote", "get-url", "origin"])
-                                    .output()
-                                    .await
-                                    .map(|o| {
-                                        String::from_utf8_lossy(&o.stdout).contains("github.com")
-                                    }) {
-                                    Ok(true) => true,
-                                    _ => false,
-                                };
+                                let is_github = client
+                                    .as_ref()
+                                    .is_some_and(|client| client.kind().is_github());
 
                                 let program = if is_github { "gh" } else { "glab" };
                                 let (entity, sub) = if is_github {

--- a/src/main.rs
+++ b/src/main.rs
@@ -884,7 +884,7 @@ async fn main() -> Result<()> {
     }
     app.update_filter_selection();
 
-    if let Ok(mut client) = domain::client::GitlabClient::new().await {
+    if let Ok(mut client) = domain::client::GitlabClient::new(&app.config).await {
         client.page_size = app.config.page_size;
         client.api_per_page = app.config.api_per_page_clamped();
         client.tx = Some(events.sender());
@@ -1630,17 +1630,9 @@ async fn main() -> Result<()> {
                                 let mr_iid = diff_view.mr_iid;
                                 let mr_iid_str = mr_iid.to_string();
                                 tokio::spawn(async move {
-                                    let is_github = match tokio::process::Command::new("git")
-                                        .args(["remote", "get-url", "origin"])
-                                        .output()
-                                        .await
-                                        .map(|o| {
-                                            String::from_utf8_lossy(&o.stdout)
-                                                .contains("github.com")
-                                        }) {
-                                        Ok(true) => true,
-                                        _ => false,
-                                    };
+                                    let is_github = client
+                                        .as_ref()
+                                        .is_some_and(|client| client.kind().is_github());
 
                                     let program = if is_github { "gh" } else { "glab" };
                                     let (entity, sub) = if is_github {
@@ -2027,23 +2019,6 @@ async fn main() -> Result<()> {
                                                 {
                                                     let temp_str =
                                                         temp_path.to_string_lossy().to_string();
-
-                                                    let is_github =
-                                                        match tokio::process::Command::new("git")
-                                                            .args(["remote", "get-url", "origin"])
-                                                            .output()
-                                                            .await
-                                                        {
-                                                            Ok(output)
-                                                                if output.status.success() =>
-                                                            {
-                                                                let url = String::from_utf8_lossy(
-                                                                    &output.stdout,
-                                                                );
-                                                                url.contains("github.com")
-                                                            }
-                                                            _ => false,
-                                                        };
 
                                                     let program =
                                                         if is_github { "gh" } else { "glab" };
@@ -2987,7 +2962,10 @@ async fn main() -> Result<()> {
                                                         app.project_context = context;
                                                     }
                                                     if let Ok(mut client) =
-                                                        domain::client::GitlabClient::new().await
+                                                        domain::client::GitlabClient::new(
+                                                            &app.config,
+                                                        )
+                                                        .await
                                                     {
                                                         client.page_size = app.config.page_size;
                                                         client.api_per_page =


### PR DESCRIPTION
Closes #285

## Summary
- centralize remote-host parsing and backend detection
- check both `gh auth status` and `glab auth status` for custom hosts
- add a repo-local `backend = "github" | "gitlab"` override
- reuse the initialized backend for diff and release commands
- document the configuration and add coverage for host parsing and overrides

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo check`
- `cargo test --bin glab-tui`

The full e2e suite still has 10 pagination failures because its harness expects `glab` pagination while the detected test remote invokes `gh`; the changed unit/binary tests pass.