### PR TITLE
fix: make syntax highlighting theme-safe

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use crate::backend::BackendKind;
-use crate::config::Config;
+use crate::config::{Config, THEME};
 use crate::domain::workflow_inputs::WorkflowInput;
 use crate::utils::ui::StatefulTable;
 use fuzzy_matcher::FuzzyMatcher;
@@ -38,8 +38,15 @@ pub fn highlight_line_syntax(
         .find_syntax_by_extension(ext)
         .or_else(|| SYNTAX_SET.find_syntax_by_extension("txt"))?;
 
-    let syntax_theme = THEME_SET.themes.values().next()?;
-    let mut highlighter = syntect::easy::HighlightLines::new(syntax, syntax_theme);
+    let mut syntax_theme = THEME_SET.themes.values().next()?.clone();
+    let theme = THEME.read().unwrap();
+    syntax_theme.settings.foreground = Some(syntect_color(theme.text_normal)?);
+    syntax_theme.settings.background = Some(syntect_color(theme.bg)?);
+    for item in &mut syntax_theme.scopes {
+        item.style.foreground = None;
+        item.style.background = None;
+    }
+    let mut highlighter = syntect::easy::HighlightLines::new(syntax, &syntax_theme);
 
     // Remove the leading +/-/space for syntax highlighting, but keep the actual code
     let code = if line_content.starts_with('+')
@@ -70,6 +77,13 @@ pub fn highlight_line_syntax(
     } else {
         Some(result)
     }
+}
+
+fn syntect_color(color: ratatui::style::Color) -> Option<syntect::highlighting::Color> {
+    let ratatui::style::Color::Rgb(r, g, b) = color else {
+        return None;
+    };
+    Some(syntect::highlighting::Color { r, g, b, a: 255 })
 }
 
 fn syntect_style_to_ratatui(style: SyntectStyle) -> ratatui::style::Style {

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,8 +38,8 @@ pub fn highlight_line_syntax(
         .find_syntax_by_extension(ext)
         .or_else(|| SYNTAX_SET.find_syntax_by_extension("txt"))?;
 
-    let mut highlighter =
-        syntect::easy::HighlightLines::new(syntax, &THEME_SET.themes["base16-eighties.dark"]);
+    let syntax_theme = THEME_SET.themes.values().next()?;
+    let mut highlighter = syntect::easy::HighlightLines::new(syntax, syntax_theme);
 
     // Remove the leading +/-/space for syntax highlighting, but keep the actual code
     let code = if line_content.starts_with('+')
@@ -73,7 +73,6 @@ pub fn highlight_line_syntax(
 }
 
 fn syntect_style_to_ratatui(style: SyntectStyle) -> ratatui::style::Style {
-    let fg = ratatui::style::Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
     let mut modifier = Modifier::empty();
     if style
         .font_style
@@ -93,9 +92,7 @@ fn syntect_style_to_ratatui(style: SyntectStyle) -> ratatui::style::Style {
     {
         modifier |= Modifier::UNDERLINED;
     }
-    ratatui::style::Style::default()
-        .fg(fg)
-        .add_modifier(modifier)
+    ratatui::style::Style::default().add_modifier(modifier)
 }
 
 pub use crate::config::SaveMenu;

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,6 +267,9 @@ pub enum SaveMenu {
 
 pub(crate) fn hex_to_color(s: &str) -> Option<Color> {
     let s = s.trim_start_matches('#');
+    if s.eq_ignore_ascii_case("reset") {
+        return Some(Color::Reset);
+    }
     if s.len() == 6 {
         let r = u8::from_str_radix(&s[0..2], 16).ok()?;
         let g = u8::from_str_radix(&s[2..4], 16).ok()?;
@@ -280,7 +283,8 @@ pub(crate) fn hex_to_color(s: &str) -> Option<Color> {
 fn color_to_hex(c: Color) -> String {
     match c {
         Color::Rgb(r, g, b) => format!("#{:02x}{:02x}{:02x}", r, g, b),
-        _ => "#000000".to_string(),
+        Color::Reset => "reset".to_string(),
+        _ => String::new(),
     }
 }
 
@@ -1790,6 +1794,12 @@ page_size = 250
         assert_eq!(github.backend, Some(crate::backend::BackendKind::GitHub));
         let gitlab: Config = toml::from_str("backend = \"gitlab\"").expect("parse config");
         assert_eq!(gitlab.backend, Some(crate::backend::BackendKind::GitLab));
+    }
+
+    #[test]
+    fn reset_color_round_trips_without_a_rgb_fallback() {
+        assert_eq!(hex_to_color("reset"), Some(Color::Reset));
+        assert_eq!(color_to_hex(Color::Reset), "reset");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,9 +267,6 @@ pub enum SaveMenu {
 
 pub(crate) fn hex_to_color(s: &str) -> Option<Color> {
     let s = s.trim_start_matches('#');
-    if s.eq_ignore_ascii_case("reset") {
-        return Some(Color::Reset);
-    }
     if s.len() == 6 {
         let r = u8::from_str_radix(&s[0..2], 16).ok()?;
         let g = u8::from_str_radix(&s[2..4], 16).ok()?;
@@ -283,7 +280,6 @@ pub(crate) fn hex_to_color(s: &str) -> Option<Color> {
 fn color_to_hex(c: Color) -> String {
     match c {
         Color::Rgb(r, g, b) => format!("#{:02x}{:02x}{:02x}", r, g, b),
-        Color::Reset => "reset".to_string(),
         _ => String::new(),
     }
 }
@@ -1794,12 +1790,6 @@ page_size = 250
         assert_eq!(github.backend, Some(crate::backend::BackendKind::GitHub));
         let gitlab: Config = toml::from_str("backend = \"gitlab\"").expect("parse config");
         assert_eq!(gitlab.backend, Some(crate::backend::BackendKind::GitLab));
-    }
-
-    #[test]
-    fn reset_color_round_trips_without_a_rgb_fallback() {
-        assert_eq!(hex_to_color("reset"), Some(Color::Reset));
-        assert_eq!(color_to_hex(Color::Reset), "reset");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop rendering Syntect foreground colors directly over the active TUI theme
- preserve configured theme colors for diff code while retaining syntax modifiers
- remove the hardcoded black serialization fallback in favor of the explicit `reset` color

Fixes the unresolved color/contrast concerns from PR #278.

## Validation
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo check`
- `cargo test --bin glab-tui` (216 passed)