### PR TITLE
fix(logs): render job traces as UTF-8 and strip GitLab timestamp prefix

### DIFF
--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -155,7 +155,8 @@ pub fn parse_ansi_trace(trace: &str, theme: &crate::config::Theme) -> Vec<Line<'
     trace
         .lines()
         .map(|raw_line| {
-            let (prefix, content) = split_gh_prefix(raw_line);
+            let (gl_ts, line) = strip_gl_ts(raw_line);
+            let (prefix, content) = split_gh_prefix(line);
 
             let content_spans = if content.contains('\x1b') {
                 parse_ansi_line(content, theme)
@@ -163,16 +164,23 @@ pub fn parse_ansi_trace(trace: &str, theme: &crate::config::Theme) -> Vec<Line<'
                 format_plain_line(content, theme)
             };
 
+            let mut spans: Vec<Span<'static>> = Vec::new();
+            if let Some(ts) = gl_ts {
+                spans.push(Span::styled(
+                    format!("{} ", ts),
+                    Style::default()
+                        .fg(theme.text_muted)
+                        .add_modifier(Modifier::ITALIC),
+                ));
+            }
             if let Some(p) = prefix {
-                let mut spans = vec![Span::styled(
+                spans.push(Span::styled(
                     p.to_string(),
                     Style::default().fg(theme.text_muted),
-                )];
-                spans.extend(content_spans);
-                Line::from(spans)
-            } else {
-                Line::from(content_spans)
+                ));
             }
+            spans.extend(content_spans);
+            Line::from(spans)
         })
         .collect()
 }
@@ -386,6 +394,32 @@ fn format_plain_line(line: &str, theme: &crate::config::Theme) -> Vec<Span<'stat
     }
     spans.push(Span::styled(body.to_string(), body_style));
     spans
+}
+
+/// Strips a GitLab Runner timestamped-log prefix (`FF_TIMESTAMPS`), which
+/// prepends every line with an ISO 8601 timestamp, a space, and a 4-character
+/// metadata field: two hex flag digits, a stream indicator (`O` stdout, `E`
+/// stderr) and an append flag (`+` when the line continues the previous one, a
+/// space otherwise) — e.g. `2024-05-14T11:19:20.000000Z 00O+`.
+///
+/// Returns `(Some(timestamp), content)`, dropping the metadata field the same
+/// way GitLab's own log viewer does, or `(None, original)` when the prefix is
+/// absent — which leaves GitHub Actions timestamps to `strip_gh_ts`.
+fn strip_gl_ts(line: &str) -> (Option<&str>, &str) {
+    let (Some(ts), rest) = strip_gh_ts(line) else {
+        return (None, line);
+    };
+    let meta = rest.as_bytes();
+    if meta.len() >= 5
+        && meta[0] == b' '
+        && meta[1].is_ascii_hexdigit()
+        && meta[2].is_ascii_hexdigit()
+        && (meta[3] == b'O' || meta[3] == b'E')
+        && (meta[4] == b' ' || meta[4] == b'+')
+    {
+        return (Some(ts), &rest[5..]);
+    }
+    (None, line)
 }
 
 /// Strips a GitHub Actions timestamp (`YYYY-MM-DDTHH:MM:SS.fffffffZ`) from
@@ -665,5 +699,44 @@ mod tests {
         let spans = parse_ansi_line("\u{1b}[32m✓\u{1b}[0m tests passed — é 日本", &theme);
         let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(text, "✓ tests passed — é 日本");
+    }
+
+    #[test]
+    fn test_strip_gl_ts_drops_metadata_field() {
+        assert_eq!(
+            strip_gl_ts("2024-05-14T11:19:20.000000Z 00O Preparing docker"),
+            (Some("2024-05-14T11:19:20.000000Z"), "Preparing docker")
+        );
+        assert_eq!(
+            strip_gl_ts("2024-05-14T11:19:20.000000Z 01E error: boom"),
+            (Some("2024-05-14T11:19:20.000000Z"), "error: boom")
+        );
+        // `+` marks a line continuing the previous one
+        assert_eq!(
+            strip_gl_ts("2024-05-14T11:19:20.000000Z 00O+environment..."),
+            (Some("2024-05-14T11:19:20.000000Z"), "environment...")
+        );
+    }
+
+    #[test]
+    fn test_strip_gl_ts_leaves_other_lines_untouched() {
+        // GitHub Actions: same timestamp shape, no GitLab metadata field
+        let gh = "2024-05-14T11:19:20.0000000Z Run actions/checkout@v4";
+        assert_eq!(strip_gl_ts(gh), (None, gh));
+        let plain = "$ cargo test";
+        assert_eq!(strip_gl_ts(plain), (None, plain));
+    }
+
+    #[test]
+    fn test_parse_ansi_trace_strips_gitlab_prefix() {
+        let theme = crate::config::Theme::default();
+        let trace =
+            "2026-08-18T16:54:49.475670Z 01O \u{1b}[32m✓\u{1b}[0m src/foo.test.ts (19 tests)";
+        let lines = parse_ansi_trace(trace, &theme);
+        let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(
+            text,
+            "2026-08-18T16:54:49.475670Z ✓ src/foo.test.ts (19 tests)"
+        );
     }
 }

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -132,20 +132,20 @@ pub fn parse_mr_title_prefix(title: &str) -> (String, String) {
 
 pub fn strip_ansi_escapes(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
-    let mut bytes = s.bytes();
-    while let Some(b) = bytes.next() {
-        if b == 0x1b {
-            if let Some(next_b) = bytes.next() {
-                if next_b == b'[' {
-                    while let Some(next_c) = bytes.next() {
-                        if (0x40..=0x7e).contains(&next_c) {
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            if let Some(next_c) = chars.next() {
+                if next_c == '[' {
+                    for seq_c in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&seq_c) {
                             break;
                         }
                     }
                 }
             }
         } else {
-            result.push(b as char);
+            result.push(c);
         }
     }
     result
@@ -193,12 +193,12 @@ fn parse_ansi_line(line: &str, theme: &crate::config::Theme) -> Vec<Span<'static
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut current_style = Style::default().fg(theme.text_normal);
     let mut current_text = String::new();
-    let bytes: Vec<u8> = line.bytes().collect();
+    let chars: Vec<char> = line.chars().collect();
     let mut i = 0;
 
-    while i < bytes.len() {
-        let b = bytes[i];
-        if b == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+    while i < chars.len() {
+        let ch = chars[i];
+        if ch == '\u{1b}' && i + 1 < chars.len() && chars[i + 1] == '[' {
             if !current_text.is_empty() {
                 spans.push(Span::styled(
                     std::mem::take(&mut current_text),
@@ -209,13 +209,13 @@ fn parse_ansi_line(line: &str, theme: &crate::config::Theme) -> Vec<Span<'static
             let mut params = Vec::new();
             let mut num_buf = String::new();
             loop {
-                if i >= bytes.len() {
+                if i >= chars.len() {
                     break;
                 }
-                let c = bytes[i];
+                let c = chars[i];
                 i += 1;
-                if (0x40..=0x7e).contains(&c) {
-                    if c == b'm' {
+                if ('\u{40}'..='\u{7e}').contains(&c) {
+                    if c == 'm' {
                         if !num_buf.is_empty() {
                             params.push(num_buf);
                         }
@@ -224,23 +224,23 @@ fn parse_ansi_line(line: &str, theme: &crate::config::Theme) -> Vec<Span<'static
                     break;
                 }
                 match c {
-                    b';' => {
+                    ';' => {
                         if !num_buf.is_empty() {
                             params.push(std::mem::take(&mut num_buf));
                         } else {
                             params.push("0".to_string());
                         }
                     }
-                    b'0'..=b'9' => {
-                        num_buf.push(c as char);
+                    '0'..='9' => {
+                        num_buf.push(c);
                     }
                     _ => {
-                        num_buf.push(c as char);
+                        num_buf.push(c);
                     }
                 }
             }
         } else {
-            current_text.push(b as char);
+            current_text.push(ch);
             i += 1;
         }
     }
@@ -651,5 +651,19 @@ mod tests {
             strip_ansi_escapes(input),
             "[SUCCESS] Job finished successfully"
         );
+    }
+
+    #[test]
+    fn test_strip_ansi_escapes_preserves_non_ascii() {
+        let input = "\u{1b}[32m✓\u{1b}[0m src/lib.rs — 3 tests ✔";
+        assert_eq!(strip_ansi_escapes(input), "✓ src/lib.rs — 3 tests ✔");
+    }
+
+    #[test]
+    fn test_parse_ansi_line_preserves_non_ascii() {
+        let theme = crate::config::Theme::default();
+        let spans = parse_ansi_line("\u{1b}[32m✓\u{1b}[0m tests passed — é 日本", &theme);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "✓ tests passed — é 日本");
     }
 }


### PR DESCRIPTION
## What

Two independent bugs in the job-log viewer, both visible in a single GitLab pipeline log. One commit each.

### 1. Non-ASCII characters are mangled (`✓` → `â`)

`parse_ansi_line` and `strip_ansi_escapes` walk the line as bytes and rebuild the text with `b as char`. In Rust `u8 as char` maps a byte to the code point with the same numeric value — that is latin-1 — so every UTF-8 multi-byte sequence is split into one visible garbage character plus invisible C1 controls.

`✓` (U+2713 = `E2 9C 93`) becomes `â` + U+009C + U+0093. The new test, run against `main`:

```
left:  "â\u{9c}\u{93} src/lib.rs â\u{80}\u{94} 3 tests â\u{9c}\u{94}"
right: "✓ src/lib.rs — 3 tests ✔"
```

Both functions take a `&str`, which is already valid UTF-8 by construction, so the corruption is introduced by the re-encoding rather than by the data. It affects any job log containing check marks, box drawing, em dashes or emoji — vitest/jest/pytest reporters, cargo, docker pull progress, and so on.

Fix: iterate `chars()` instead of `bytes()`. The ANSI scanning logic is untouched: escape sequences are pure ASCII, and in UTF-8 every byte of a multi-byte sequence has the high bit set, so it can never collide with `ESC`, `[`, a digit, or the `0x40..=0x7e` final byte.

### 2. GitLab's `FF_TIMESTAMPS` prefix is rendered as log content

With timestamps enabled on the runner (GitLab Runner 17.0+), every line arrives as:

```
2026-08-18T16:54:49.475670Z 01O ✓ src/foo.test.ts (19 tests)
```

an ISO 8601 timestamp, a space, then a 4-character metadata field: two hex flag digits, a stream indicator (`O` stdout / `E` stderr) and an append flag (`+` when the line continues the previous one, space otherwise). See [Job logs](https://docs.gitlab.com/ci/jobs/job_logs/).

`strip_gh_ts` already recognises that timestamp shape, but it is only reachable from `format_plain_line`, so today:

- lines containing ANSI never reach it and show the raw timestamp at full contrast;
- the `01O` / `01E` field is not handled at all and shows up on every line;
- `classify_line` receives `01E error: …` instead of `error: …`, so severity colouring never matches on these logs.

Fix: a `strip_gl_ts` helper applied in `parse_ansi_trace`, before the ANSI/plain split. The timestamp is kept and styled muted + italic, matching how the GitHub Actions timestamp is already rendered; the metadata field is dropped, as GitLab's own log viewer does. Lines without the metadata field return `(None, line)`, so GitHub Actions logs keep their current code path unchanged.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --bin glab-tui` (241 passed), `cargo test --test e2e -- --test-threads=1` (71 passed).

Five new unit tests in `src/utils/format.rs`. The two UTF-8 ones fail on `main` with the mojibake quoted above.
