### PR TITLE
fix(diff): expand tabs so tab-indented files keep their indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 - **Wide line numbers no longer shift the diff gutter** — the line-number field was formatted with `{:>4}`, a minimum rather than a maximum, so a five-digit number took a fifth cell and pushed that row's separator and content one column right of its neighbours. Any diff touching a large file — a generated spec, a lockfile — was full of such rows, in both the unified and side-by-side layouts. The column is now as wide as the widest line number in the diff, and diffs under 10 000 lines look exactly as before (#368).
+- **Tab-indented files keep their indentation in the diff view** — a tab reached the rendered buffer as-is and occupied a single cell there, so Go, Makefiles and other tab-indented sources displayed flush-left with their structure gone. Tabs are now expanded to spaces at tab stops as the diff is parsed, which is the one point every consumer derives from — the stored line content, the syntect highlighting computed from it, the search's match indices and the side-by-side pairs all stay in agreement about where a character sits (#364).
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@
 use crate::backend::BackendKind;
 use crate::config::{Config, THEME, Theme};
 use crate::domain::workflow_inputs::WorkflowInput;
+use crate::utils::format::expand_tabs;
 use crate::utils::ui::StatefulTable;
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
@@ -1029,6 +1030,29 @@ fn line_number_width(lines: &[DiffLine]) -> usize {
         })
 }
 
+/// Columns per tab in the diff view. A literal tab occupies a single cell in
+/// the rendered buffer, so a tab-indented file (Go, Makefiles) would otherwise
+/// display with no indentation at all.
+const DIFF_TAB_WIDTH: usize = 4;
+
+/// Expands the tabs in one diff line, keeping its `+`/`-`/space marker.
+///
+/// The marker is part of the diff, not of the source line, so tab stops are
+/// measured from the character after it. Counting the marker as column 0 would
+/// make a single leading tab three spaces wide instead of four, and shift every
+/// alignment tab on the line with it.
+fn expand_diff_line_tabs(line: &str) -> String {
+    match line.chars().next() {
+        Some(marker @ ('+' | '-' | ' ')) => {
+            let mut out = String::with_capacity(line.len());
+            out.push(marker);
+            out.push_str(&expand_tabs(&line[1..], DIFF_TAB_WIDTH));
+            out
+        }
+        _ => expand_tabs(line, DIFF_TAB_WIDTH),
+    }
+}
+
 fn strip_ansi_escapes(input: &str) -> String {
     let mut result = String::new();
     let mut in_escape = false;
@@ -1055,7 +1079,16 @@ fn strip_ansi_escapes(input: &str) -> String {
 impl DiffView {
     #[allow(clippy::too_many_lines)]
     pub fn new(mr_iid: u64, raw_diff: String) -> Self {
-        let cleaned_diff = strip_ansi_escapes(&raw_diff);
+        // Expand tabs once, here: everything downstream — the stored line
+        // content, the syntect highlighting computed from it, the search's
+        // fuzzy match indices, the side-by-side pairs — is derived from these
+        // strings, so expanding at the single point where they are produced
+        // keeps all of them agreeing on where a character sits.
+        let cleaned_diff = strip_ansi_escapes(&raw_diff)
+            .lines()
+            .map(expand_diff_line_tabs)
+            .collect::<Vec<_>>()
+            .join("\n");
         let mut all_lines = Vec::new();
         let mut current_file = String::new();
         let mut old_line_num = None;
@@ -5633,6 +5666,90 @@ new mode 100755
                 .to_string(),
         );
         assert_eq!(view.line_number_width, MIN_LINE_NUMBER_WIDTH);
+    }
+
+    /// A diff of a tab-indented file, as `gofmt` would produce it.
+    fn tab_indented_diff() -> String {
+        [
+            "diff --git a/handler.go b/handler.go",
+            "index 1111111..2222222 100644",
+            "--- a/handler.go",
+            "+++ b/handler.go",
+            "@@ -1,6 +1,7 @@",
+            " func handle() error {",
+            " \tif err := check(); err != nil {",
+            "+\t\treturn fmt.Errorf(\"check: %w\", err)",
+            "-\t\treturn err",
+            " \t}",
+            " }",
+        ]
+        .join("\n")
+    }
+
+    #[test]
+    fn test_diff_view_expands_tabs_so_indentation_survives() {
+        let view = DiffView::new(42, tab_indented_diff());
+
+        let content: Vec<&str> = view
+            .all_lines
+            .iter()
+            .map(|l| l.content.as_str())
+            .filter(|c| c.contains("return") || c.contains("if err"))
+            .collect();
+
+        assert_eq!(
+            content,
+            vec![
+                " \u{20}\u{20}\u{20}\u{20}if err := check(); err != nil {",
+                "+        return fmt.Errorf(\"check: %w\", err)",
+                "-        return err",
+            ],
+            "tabs must reach the rendered content as spaces, or the file displays flush-left"
+        );
+        assert!(
+            !view.all_lines.iter().any(|l| l.content.contains('\t')),
+            "no tab may survive into a rendered line"
+        );
+    }
+
+    #[test]
+    fn test_diff_view_keeps_the_marker_out_of_the_tab_stops() {
+        let view = DiffView::new(42, tab_indented_diff());
+        let added = view
+            .all_lines
+            .iter()
+            .find(|l| l.line_type == DiffLineType::Addition)
+            .expect("an addition");
+
+        // One marker, then a full tab stop per tab — not three spaces because
+        // the marker ate a column.
+        assert!(added.content.starts_with('+'));
+        assert_eq!(
+            added.content[1..].len() - added.content[1..].trim_start().len(),
+            8,
+            "two tabs of source indent must survive as two full stops"
+        );
+    }
+
+    #[test]
+    fn test_diff_view_expands_tabs_in_the_highlighted_spans_too() {
+        // A highlighted line renders from its spans, not from `content`, so a
+        // tab surviving there would leave syntax-highlighted code sitting at a
+        // different indent from everything else.
+        let view = DiffView::new(42, tab_indented_diff());
+        let mut highlighted_lines = 0;
+        for line in &view.all_lines {
+            if let Some(ref spans) = line.syntax_highlighted {
+                highlighted_lines += 1;
+                let text: String = spans.iter().map(|(_, t)| t.as_str()).collect();
+                assert!(!text.contains('\t'), "a span kept its tab: {text:?}");
+            }
+        }
+        assert!(
+            highlighted_lines > 0,
+            "fixture produced no highlighted lines, so this proves nothing"
+        );
+    }
     }
 
     #[test]

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -2,6 +2,33 @@ use chrono::{DateTime, Utc};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+/// Replaces tab characters with spaces, advancing to the next `tab_width`
+/// column each time.
+///
+/// Tab stops rather than a fixed number of spaces per tab, because a tab in the
+/// middle of a line is an alignment request, not an indent: `gofmt` lines up
+/// consecutive struct fields and their tags that way, and expanding each tab to
+/// the same width would leave those columns ragged.
+pub fn expand_tabs(text: &str, tab_width: usize) -> String {
+    if !text.contains('\t') {
+        return text.to_string();
+    }
+    let tab_width = tab_width.max(1);
+    let mut out = String::with_capacity(text.len() + tab_width);
+    let mut column = 0usize;
+    for ch in text.chars() {
+        if ch == '\t' {
+            let pad = tab_width - (column % tab_width);
+            out.push_str(&" ".repeat(pad));
+            column += pad;
+        } else {
+            out.push(ch);
+            column += 1;
+        }
+    }
+    out
+}
+
 pub fn truncate(s: &str, max_chars: usize) -> String {
     match s.char_indices().nth(max_chars) {
         None => String::from(s),
@@ -597,6 +624,43 @@ fn classify_line(line: &str, lower: &str, theme: &crate::config::Theme) -> Style
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_expand_tabs_indentation() {
+        assert_eq!(expand_tabs("no tabs here", 4), "no tabs here");
+        assert_eq!(expand_tabs("\tone", 4), "    one");
+        assert_eq!(expand_tabs("\t\ttwo", 4), "        two");
+        assert_eq!(expand_tabs("\tone", 8), "        one");
+        assert_eq!(expand_tabs("", 4), "");
+    }
+
+    #[test]
+    fn test_expand_tabs_advances_to_the_next_stop() {
+        // Not a fixed width per tab: the pad is whatever reaches the next stop.
+        assert_eq!(expand_tabs("ab\tc", 4), "ab  c");
+        assert_eq!(expand_tabs("abc\td", 4), "abc d");
+        assert_eq!(expand_tabs("abcd\te", 4), "abcd    e");
+    }
+
+    #[test]
+    fn test_expand_tabs_keeps_a_column_grid() {
+        // Two lines whose text lands in the same stop keep the same column
+        // after a tab, which a fixed number of spaces per tab would not give.
+        let a = expand_tabs("ab\tX", 4);
+        let b = expand_tabs("abc\tX", 4);
+        assert_eq!(a.find('X'), b.find('X'));
+    }
+
+    #[test]
+    fn test_expand_tabs_treats_zero_width_as_one() {
+        // A misconfigured width must not divide by zero or eat the tab.
+        assert_eq!(expand_tabs("\tx", 0), " x");
+    }
+
+    #[test]
+    fn test_expand_tabs_leaves_multibyte_text_intact() {
+        assert_eq!(expand_tabs("\tπλ→", 4), "    πλ→");
+    }
 
     #[test]
     fn test_format_ref() {


### PR DESCRIPTION
Closes #364

## Problem

A tab reached the rendered buffer as a tab, where it occupies a single cell, so any tab-indented file displayed in the diff view with its indentation gone — every level of nesting reading as top-level, in the view whose whole purpose is reading code.

Go is the common case, since `gofmt` always indents with tabs. Makefiles and plenty of C and shell code are the same. It stays invisible in this repo's own diffs because `rustfmt` indents with spaces.

Before, for a tab-indented Go file:

```
 func Load(path string) (*Config, error) {
 f, err := os.Open(path)
+if err != nil {
+return nil, err
+}
 defer f.Close()
 }
```

After:

```
 func Load(path string) (*Config, error) {
     f, err := os.Open(path)
+    if err != nil {
+        return nil, err
+    }
     defer f.Close()
 }
```

## Approach

`expand_tabs(text, tab_width)` in `utils/format.rs` pads to the next tab stop rather than emitting a fixed number of spaces per tab — how a terminal, a pager and an editor all render tabs.

Two things worth reviewing:

- **Where it happens.** Once, as the diff is parsed, because that is the single point everything else derives from: the stored line content, the syntect highlighting computed from the same string, the search's fuzzy match indices, and the side-by-side pairs. Expanding in the renderer instead would leave those disagreeing about which column a character occupies — highlighted code sitting at a different indent from unhighlighted code, and search matches landing off by the number of tabs before them.
- **The marker column is excluded from the tab stops.** The leading `+`, `-` or space belongs to the diff, not to the source line, so counting it as column 0 would make a single leading tab three spaces wide instead of four, and shift every alignment tab on the line along with it.

`DIFF_TAB_WIDTH` is a constant set to 4. Happy to make it a `config.toml` key if you would rather it were configurable — it is a one-line change plus the plumbing, and I left it out to keep this reviewable.

## Testing

- `cargo test` — 244 unit (9 new) + 71 e2e, all passing
- `cargo clippy --all-targets` and `cargo fmt --check` clean
- Also exercised against a real Go merge request in the TUI, before and after, including a build of `aa82b40` to confirm the behaviour predates this branch

The new tests cover tab-stop advancement (not fixed-width padding), the zero-width guard, multibyte text, the marker staying out of the stops, and that no tab survives into either the stored content or the syntax-highlighted spans — the spans matter separately, because a highlighted line renders from those rather than from `content`.

No recording attached: the tab-indented repository I verified against is private.

## Note on scope

One thing I deliberately did **not** change: `expand_tabs` counts characters, not display columns, so a CJK or emoji character before a tab still counts as one column. Getting that exactly right needs `unicode-width`, which is not a dependency here, and the existing diff and file-tree layout code already counts the same way — so this stays consistent with its surroundings rather than half-fixing a wider issue.
