### PR TITLE
fix(diff): size the line-number column to the diff's widest number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+- **Wide line numbers no longer shift the diff gutter** — the line-number field was formatted with `{:>4}`, a minimum rather than a maximum, so a five-digit number took a fifth cell and pushed that row's separator and content one column right of its neighbours. Any diff touching a large file — a generated spec, a lockfile — was full of such rows, in both the unified and side-by-side layouts. The column is now as wide as the widest line number in the diff, and diffs under 10 000 lines look exactly as before (#368).
+
+---
+
 ## [0.8.4] - 2026-08-13
 
 ### Bug Fixes

--- a/src/app.rs
+++ b/src/app.rs
@@ -1001,6 +1001,32 @@ pub struct DiffView {
     pub search_cursor: usize,
     pub search_active: bool,
     pub file_tree_visible: bool,
+    /// Cells the line-number column needs, so the separator after it lands in
+    /// the same column on every row. Derived from the widest line number in the
+    /// diff, never below [`MIN_LINE_NUMBER_WIDTH`].
+    pub line_number_width: usize,
+}
+
+/// Narrowest line-number column, and what any diff under 10 000 lines gets —
+/// the width the gutter always had before it was computed at all.
+pub const MIN_LINE_NUMBER_WIDTH: usize = 4;
+
+/// Cells needed to print the widest line number in `lines` without pushing the
+/// separator that follows it out of column.
+///
+/// `{:>4}` is a *minimum* width, so a five-digit number silently took a fifth
+/// cell and shifted the separator and the whole content of that row one column
+/// right of its neighbours. Any diff touching a large file — a generated
+/// OpenAPI spec, a lockfile — is full of such rows.
+fn line_number_width(lines: &[DiffLine]) -> usize {
+    lines
+        .iter()
+        .flat_map(|line| [line.old_line_num, line.new_line_num])
+        .flatten()
+        .max()
+        .map_or(MIN_LINE_NUMBER_WIDTH, |widest| {
+            MIN_LINE_NUMBER_WIDTH.max(widest.to_string().len())
+        })
 }
 
 fn strip_ansi_escapes(input: &str) -> String {
@@ -1309,6 +1335,8 @@ impl DiffView {
         // Copy directory counts to flat dir nodes
         Self::copy_dir_counts_to_flat(&root_node, &mut visible_nodes);
 
+        let number_width = line_number_width(&all_lines);
+
         let mut view = Self {
             mr_iid,
             raw_diff,
@@ -1332,6 +1360,7 @@ impl DiffView {
             search_cursor: 0,
             search_active: false,
             file_tree_visible: true,
+            line_number_width: number_width,
         };
 
         view.update_active_lines();
@@ -5551,6 +5580,59 @@ new mode 100755
             .iter()
             .find(|l| l.content.starts_with("new mode "));
         assert_eq!(new_mode.unwrap().line_type, DiffLineType::Meta);
+    }
+
+    /// A one-hunk diff starting at `start_line`, so the line numbers it
+    /// produces have a chosen number of digits.
+    fn diff_starting_at(start_line: u32) -> String {
+        format!(
+            "diff --git a/spec.yml b/spec.yml\n--- a/spec.yml\n+++ b/spec.yml\n@@ -{s},3 +{s},4 @@\n context\n+added\n-removed\n",
+            s = start_line
+        )
+    }
+
+    #[test]
+    fn test_line_number_width_floors_at_the_narrow_gutter() {
+        // Anything that fits the old fixed field keeps the old look.
+        let view = DiffView::new(42, diff_starting_at(1));
+        assert_eq!(view.line_number_width, MIN_LINE_NUMBER_WIDTH);
+        let view = DiffView::new(42, diff_starting_at(9997));
+        assert_eq!(view.line_number_width, MIN_LINE_NUMBER_WIDTH);
+    }
+
+    #[test]
+    fn test_line_number_width_grows_for_a_wider_number() {
+        // The bug: `{:>4}` is a minimum, so a five-digit number took a fifth
+        // cell and shifted that row's separator and content one column right.
+        let view = DiffView::new(42, diff_starting_at(10_848));
+        assert_eq!(view.line_number_width, 5);
+
+        let view = DiffView::new(42, diff_starting_at(100_000));
+        assert_eq!(view.line_number_width, 6);
+    }
+
+    #[test]
+    fn test_line_number_width_is_taken_from_the_widest_line_in_the_diff() {
+        // A diff whose first hunk is narrow and whose last is not must use the
+        // wider gutter throughout, or the two hunks disagree on the column.
+        let diff = format!("{}{}", diff_starting_at(12), {
+            let mut second = diff_starting_at(15_610);
+            second.push('\n');
+            second
+        });
+        let view = DiffView::new(42, diff);
+        assert_eq!(view.line_number_width, 5);
+    }
+
+    #[test]
+    fn test_line_number_width_handles_a_diff_with_no_numbers() {
+        // Meta-only output (a rename with no hunks) has no line numbers at all.
+        let view = DiffView::new(
+            42,
+            "diff --git a/a.txt b/b.txt\nsimilarity index 100%\nrename from a.txt\nrename to b.txt\n"
+                .to_string(),
+        );
+        assert_eq!(view.line_number_width, MIN_LINE_NUMBER_WIDTH);
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -969,6 +969,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                         .zip(updated_diff_view.selection_end)
                         .map_or(false, |(s, e)| idx >= s && idx <= e);
 
+                    let num_width = updated_diff_view.line_number_width;
                     let gutter_bg = THEME.read().unwrap().diff_gutter_bg;
                     let marker_style = Style::default()
                         .fg(THEME.read().unwrap().yellow)
@@ -1008,7 +1009,10 @@ pub fn render(f: &mut Frame, app: &mut App) {
                                 },
                                 marker_style,
                             ),
-                            Span::styled(format!("{:>4} ", old_str), num_style),
+                            Span::styled(
+                                format!("{:>width$} ", old_str, width = num_width),
+                                num_style,
+                            ),
                             Span::styled("│ ", sep_style),
                         ]);
 
@@ -1150,7 +1154,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                                 },
                                 marker_style,
                             ),
-                            Span::styled("     ", num_style),
+                            Span::styled(" ".repeat(num_width + 1), num_style),
                             Span::styled("│ ", sep_style),
                             Span::styled(" ", Style::default().bg(actual_bg)),
                         ]);
@@ -1176,7 +1180,10 @@ pub fn render(f: &mut Frame, app: &mut App) {
                                 },
                                 marker_style,
                             ),
-                            Span::styled(format!("{:>4} ", new_str), num_style),
+                            Span::styled(
+                                format!("{:>width$} ", new_str, width = num_width),
+                                num_style,
+                            ),
                             Span::styled("│ ", sep_style),
                         ]);
 
@@ -1318,7 +1325,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                                 },
                                 marker_style,
                             ),
-                            Span::styled("     ", num_style),
+                            Span::styled(" ".repeat(num_width + 1), num_style),
                             Span::styled("│ ", sep_style),
                             Span::styled(" ", Style::default().bg(actual_bg)),
                         ]);
@@ -1521,6 +1528,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                         .map(|n| n.to_string())
                         .unwrap_or_else(|| " ".to_string());
 
+                    let num_width = updated_diff_view.line_number_width;
                     let gutter_bg = THEME.read().unwrap().diff_gutter_bg;
 
                     let marker_style = Style::default()
@@ -1547,8 +1555,14 @@ pub fn render(f: &mut Frame, app: &mut App) {
                             },
                             marker_style,
                         ),
-                        Span::styled(format!("{:>4} ", old_str), num_style),
-                        Span::styled(format!("{:>4} ", new_str), num_style),
+                        Span::styled(
+                            format!("{:>width$} ", old_str, width = num_width),
+                            num_style,
+                        ),
+                        Span::styled(
+                            format!("{:>width$} ", new_str, width = num_width),
+                            num_style,
+                        ),
                         Span::styled("│ ", sep_style),
                     ];
 


### PR DESCRIPTION
Closes #368

## Problem

The line-number field is formatted with `{:>4} `, and `{:>4}` is a **minimum** width rather than a maximum. A five-digit line number therefore takes a fifth cell, carrying the separator after it — and the whole content of that row — one column right of every neighbouring row:

```
   1150 │      - name: destinationType     <- separator here
  10848 │        - fireblocks              <- ...and one column right here
  15610 │          - funds_management
```

Any diff touching a large file is full of such rows: a generated spec, a lockfile, a long migration. Four sites carry the same format — two in side-by-side (left and right), two in unified (old and new) — and the unified layout can shift by two, since a row there has two number fields.

The empty-side branches in side-by-side pair that field with a hardcoded `"     "`, which bakes the same assumption in from the other direction.

## Approach

`DiffView` now carries `line_number_width`, computed once in `DiffView::new` from the widest line number in the diff and floored at the previous four cells — so any diff under 10 000 lines renders byte-identically to today. All four format sites read it, as do the two empty-side branches.

Width is taken across the whole diff rather than per file, so the gutter does not jump as you move between files in the tree.

## Testing

- `cargo test` — 240 unit (4 new) + 71 e2e, all passing
- `cargo clippy --all-targets` and `cargo fmt --check` clean

The new tests cover the floor (a 1-line and a 9 997-line diff both keep the four-cell gutter), the growth (10 848 → 5, 100 000 → 6), a diff whose first hunk is narrow and last is wide taking the wider gutter throughout, and a meta-only diff with no line numbers at all. I checked they fail when the width computation is stubbed back to the constant, so they catch the regression rather than merely restating the code.

## Note

This touches the same two empty-side branches as #367. They are independent fixes, so I have kept them as separate PRs — happy to rebase whichever lands second.
