### PR TITLE
feat: support transparent theme background via empty color string

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -272,6 +272,13 @@ pub enum SaveMenu {
 }
 
 pub(crate) fn hex_to_color(s: &str) -> Option<Color> {
+    let s = s.trim();
+    // An empty color string maps to Color::Reset, which lets the terminal's
+    // own (possibly transparent) background show through instead of painting
+    // an opaque color.
+    if s.is_empty() {
+        return Some(Color::Reset);
+    }
     let s = s.trim_start_matches('#');
     if s.len() == 6 {
         let r = u8::from_str_radix(&s[0..2], 16).ok()?;
@@ -285,6 +292,7 @@ pub(crate) fn hex_to_color(s: &str) -> Option<Color> {
 
 fn color_to_hex(c: Color) -> String {
     match c {
+        Color::Reset => String::new(),
         Color::Rgb(r, g, b) => format!("#{:02x}{:02x}{:02x}", r, g, b),
         _ => String::new(),
     }
@@ -1742,6 +1750,34 @@ pub fn set_theme_preset(name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_color_string_maps_to_reset() {
+        assert_eq!(hex_to_color(""), Some(Color::Reset));
+        assert_eq!(hex_to_color("   "), Some(Color::Reset));
+        assert_eq!(hex_to_color("\t\n"), Some(Color::Reset));
+    }
+
+    #[test]
+    fn reset_color_serializes_to_empty_string() {
+        assert_eq!(color_to_hex(Color::Reset), "");
+    }
+
+    #[test]
+    fn empty_color_round_trips_through_hex() {
+        let parsed = hex_to_color("").expect("empty string must parse");
+        assert_eq!(parsed, Color::Reset);
+        assert_eq!(color_to_hex(parsed), "");
+        assert_eq!(hex_to_color(&color_to_hex(parsed)), Some(Color::Reset));
+    }
+
+    #[test]
+    fn default_theme_uses_transparent_background() {
+        let theme = Theme::default();
+        assert_eq!(theme.bg, Color::Reset);
+        assert_eq!(theme.inactive_bg, Color::Reset);
+        assert_eq!(theme.diff_gutter_bg, Color::Reset);
+    }
 
     #[test]
     fn api_per_page_clamped_bounds_to_gitlab_range() {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -438,7 +438,7 @@ fn add_cmd(text: &mut Vec<Line<'static>>, key: &str, desc: &str) {
             padded_key,
             Style::default()
                 .bg(THEME.read().unwrap().border_focused)
-                .fg(THEME.read().unwrap().bg)
+                .fg(THEME.read().unwrap().highlight_bg)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -296,7 +296,7 @@ fn render_content_pane(
 
             let desc_lines = if is_desc_selected && menu.editing {
                 let cursor_style = Style::default()
-                    .fg(theme.bg)
+                    .fg(theme.highlight_bg)
                     .bg(theme.text_normal)
                     .add_modifier(Modifier::SLOW_BLINK);
                 let block_cursor_style = Style::default()
@@ -594,7 +594,7 @@ pub(crate) fn build_field_list_items(
                         Modifier::empty()
                     });
                 let cursor_style = Style::default()
-                    .fg(theme.bg)
+                    .fg(theme.highlight_bg)
                     .bg(theme.text_normal)
                     .add_modifier(Modifier::SLOW_BLINK);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -93,20 +93,20 @@ fn render_mode_indicator(f: &mut Frame, app: &App, area: Rect) {
         if menu.entity_kind.is_create() {
             // CREATE — distinct palette so the user knows they're filling
             // out a new entity, not editing an existing one.
-            (" CREATE ", theme.green, theme.bg)
+            (" CREATE ", theme.green, theme.highlight_bg)
         } else {
             // EDIT — reuse the GROUPED badge palette (blue).
-            (" EDIT ", theme.blue, theme.bg)
+            (" EDIT ", theme.blue, theme.highlight_bg)
         }
     } else if app.select_mode {
         // SELECT — distinct palette (purple) for yazi-style select mode.
-        (" SELECT ", theme.purple, theme.bg)
+        (" SELECT ", theme.purple, theme.highlight_bg)
     } else if app.details_zoomed {
         // PREVIEW — reuse the SEARCHING badge palette (yellow).
-        (" PREVIEW ", theme.yellow, theme.bg)
+        (" PREVIEW ", theme.yellow, theme.highlight_bg)
     } else {
         // NORMAL — reuse the GLAB-TUI header palette (border_focused).
-        (" NORMAL ", theme.border_focused, theme.bg)
+        (" NORMAL ", theme.border_focused, theme.highlight_bg)
     };
 
     let line = Line::from(vec![Span::styled(
@@ -272,7 +272,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             format!(" {} GLAB-TUI ", header_icon),
             Style::default()
                 .bg(THEME.read().unwrap().border_focused)
-                .fg(THEME.read().unwrap().bg)
+                .fg(THEME.read().unwrap().highlight_bg)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
@@ -291,7 +291,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             format!(" {} GROUPED: {} ", icons.label_filtered, group_col),
             Style::default()
                 .bg(THEME.read().unwrap().blue)
-                .fg(THEME.read().unwrap().bg)
+                .fg(THEME.read().unwrap().highlight_bg)
                 .add_modifier(Modifier::BOLD),
         ));
         if app.is_typing_search || !app.search_query.is_empty() {
@@ -303,7 +303,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             format!(" {} SEARCHING ", icons.label_searching),
             Style::default()
                 .bg(THEME.read().unwrap().yellow)
-                .fg(THEME.read().unwrap().bg)
+                .fg(THEME.read().unwrap().highlight_bg)
                 .add_modifier(Modifier::BOLD),
         ));
         title_spans.push(Span::styled(
@@ -315,7 +315,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             format!(" {} FILTERED ", icons.label_filtered),
             Style::default()
                 .bg(THEME.read().unwrap().yellow)
-                .fg(THEME.read().unwrap().bg)
+                .fg(THEME.read().unwrap().highlight_bg)
                 .add_modifier(Modifier::BOLD),
         ));
         title_spans.push(Span::styled(
@@ -430,7 +430,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                 ListItem::new(title).style(
                     Style::default()
                         .bg(THEME.read().unwrap().border_focused)
-                        .fg(THEME.read().unwrap().bg)
+                        .fg(THEME.read().unwrap().highlight_bg)
                         .add_modifier(Modifier::BOLD),
                 )
             } else {
@@ -701,7 +701,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                     format!(" {} SEARCHING ", &ICONS.read().unwrap().label_searching),
                     Style::default()
                         .bg(THEME.read().unwrap().yellow)
-                        .fg(THEME.read().unwrap().bg)
+                        .fg(THEME.read().unwrap().highlight_bg)
                         .add_modifier(Modifier::BOLD),
                 ));
                 title_spans.push(Span::styled(
@@ -722,7 +722,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                     format!(" {} FILTERED ", &ICONS.read().unwrap().label_filtered),
                     Style::default()
                         .bg(THEME.read().unwrap().yellow)
-                        .fg(THEME.read().unwrap().bg)
+                        .fg(THEME.read().unwrap().highlight_bg)
                         .add_modifier(Modifier::BOLD),
                 ));
                 title_spans.push(Span::styled(
@@ -887,7 +887,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                         if diff_view.focus_on_files {
                             Style::default()
                                 .bg(THEME.read().unwrap().highlight_bg)
-                                .fg(THEME.read().unwrap().bg)
+                                .fg(THEME.read().unwrap().highlight_bg)
                                 .add_modifier(Modifier::BOLD)
                         } else {
                             Style::default()

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -455,7 +455,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             }
             let style = if is_active {
                 Style::default()
-                    .fg(t.bg)
+                    .fg(t.highlight_bg)
                     .bg(t.border_focused)
                     .add_modifier(Modifier::BOLD)
             } else if checked {
@@ -495,7 +495,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             }
             let style = if is_active {
                 Style::default()
-                    .fg(t.bg)
+                    .fg(t.highlight_bg)
                     .bg(t.border_focused)
                     .add_modifier(Modifier::BOLD)
             } else if is_selected {
@@ -534,7 +534,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             }
             let style = if is_active {
                 Style::default()
-                    .fg(t.bg)
+                    .fg(t.highlight_bg)
                     .bg(t.border_focused)
                     .add_modifier(Modifier::BOLD)
             } else if is_selected {
@@ -557,12 +557,12 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
         };
         let page_size_style = if app.editing_page_size {
             Style::default()
-                .fg(t.bg)
+                .fg(t.highlight_bg)
                 .bg(t.green)
                 .add_modifier(Modifier::BOLD)
         } else if is_page_size_active {
             Style::default()
-                .fg(t.bg)
+                .fg(t.highlight_bg)
                 .bg(t.border_focused)
                 .add_modifier(Modifier::BOLD)
         } else {
@@ -601,7 +601,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
         let theme_value = format!("[ {} ]", current_theme_name);
         let theme_style = if is_theme_active {
             Style::default()
-                .fg(t.bg)
+                .fg(t.highlight_bg)
                 .bg(t.border_focused)
                 .add_modifier(Modifier::BOLD)
         } else {
@@ -642,7 +642,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
         let save_button_text = format!("{:pad$}{}", "", save_label, pad = save_left_pad);
         let save_button_style = if is_save_selected {
             Style::default()
-                .fg(t.bg)
+                .fg(t.highlight_bg)
                 .bg(t.border_focused)
                 .add_modifier(Modifier::BOLD)
         } else {
@@ -729,7 +729,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
                     };
                     let style = if is_active {
                         Style::default()
-                            .fg(THEME.read().unwrap().bg)
+                            .fg(THEME.read().unwrap().highlight_bg)
                             .bg(THEME.read().unwrap().border_focused)
                             .add_modifier(Modifier::BOLD)
                     } else {
@@ -1033,7 +1033,7 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
                 .highlight_style(
                     Style::default()
                         .bg(theme.border_focused)
-                        .fg(theme.bg)
+                        .fg(theme.highlight_bg)
                         .add_modifier(Modifier::BOLD),
                 );
 


### PR DESCRIPTION
Map an empty color string in theme TOML to `Color::Reset` so the terminal's own (possibly transparent) background shows through. The default theme's `bg`, `inactive_bg`, and `diff_gutter_bg` are now set to `""`.

- `src/config.rs`: `hex_to_color` returns `Color::Reset` for empty/whitespace input; `color_to_hex` returns `""` for `Color::Reset` (clean round-trip).
- `src/themes/default.toml`: `bg`, `inactive_bg`, and `diff_gutter_bg` set to `""`.

The root canvas at `src/ui/mod.rs:205` paints `bg(theme.bg)`, so an empty `bg` lets the terminal's transparent background show through. Build, clippy, and tests pass.