### PR TITLE
feat: expand help overlay size and make accessible from all views

### DIFF
--- a/src/handlers/overlays.rs
+++ b/src/handlers/overlays.rs
@@ -487,18 +487,33 @@ fn run_submit_action(
 }
 
 pub fn handle_help_keybinding(app: &mut App, key_event: &KeyEvent) -> bool {
-    if keybinding_matches(&app.config.keybindings.global.help, key_event)
-        && app.text_input.is_none()
-        && app.edit_menu.is_none()
-        && app.selector.is_none()
-        && !app.show_help
-        && !app.focus_column_checklist
-    {
-        app.show_help = true;
-        app.help_search_query.clear();
-        return true;
+    if app.show_help {
+        return false;
     }
-    false
+
+    let is_f1 = key_event.code == KeyCode::F(1);
+    let is_help_key = is_f1 || keybinding_matches(&app.config.keybindings.global.help, key_event);
+
+    if !is_help_key {
+        return false;
+    }
+
+    // When the user is actively typing raw text into a text field, allow F1 to open help,
+    // but keep regular character keys (like '?') so they can be typed into the field.
+    let is_typing_text = app.text_input.is_some()
+        || app.is_typing_search
+        || app.job_trace_searching
+        || app.edit_menu.as_ref().map_or(false, |m| m.editing)
+        || app.diff_view.as_ref().map_or(false, |d| d.search_active)
+        || app.selector.as_ref().map_or(false, |s| s.is_filtering);
+
+    if is_typing_text && !is_f1 {
+        return false;
+    }
+
+    app.show_help = true;
+    app.help_search_query.clear();
+    true
 }
 
 pub fn handle_help_overlay(app: &mut App, key_event: &KeyEvent) -> bool {
@@ -680,8 +695,8 @@ pub fn handle_date_picker(
 
 #[cfg(test)]
 mod tests {
-    use super::handle_help_overlay;
-    use crate::app::App;
+    use super::{handle_help_keybinding, handle_help_overlay};
+    use crate::app::{App, DiffView, EditEntityKind, EditMenu, Selector};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     #[test]
@@ -697,5 +712,138 @@ mod tests {
         assert!(handled);
         assert_eq!(app.help_search_query, "q");
         assert!(app.show_help);
+    }
+
+    #[test]
+    fn help_keybinding_accessible_in_all_views() {
+        let mut app = App::default();
+
+        // 1. Normal view with '?' and F1
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+
+        // 2. Edit menu (Inspector / Form) - not actively editing text
+        app.edit_menu = Some(EditMenu {
+            entity_iid: 1,
+            entity_kind: EditEntityKind::EditIssue,
+            title: "Edit Issue".to_string(),
+            fields: vec![],
+            selected_idx: 0,
+            editing: false,
+            cursor_pos: 0,
+            state: ratatui::widgets::ListState::default(),
+            desc_scroll: 0,
+            workflow_inputs: vec![],
+        });
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+
+        // Edit menu - actively editing text: '?' types into field, but F1 opens help
+        if let Some(ref mut menu) = app.edit_menu {
+            menu.editing = true;
+        }
+        assert!(!handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(!app.show_help);
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+        app.edit_menu = None;
+
+        // 3. Diff View - not searching
+        app.diff_view = Some(DiffView::new(
+            1,
+            "diff --git a/a b/b\n--- a/a\n+++ b/b\n@@ -1 +1 @@\n-old\n+new\n".to_string(),
+        ));
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+
+        // Diff View - searching: '?' types into search, F1 opens help
+        if let Some(ref mut diff_view) = app.diff_view {
+            diff_view.search_active = true;
+        }
+        assert!(!handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(!app.show_help);
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+        app.diff_view = None;
+
+        // 4. Selector overlay
+        app.selector = Some(Selector {
+            title: "Select Label".to_string(),
+            all_items: vec!["bug".to_string()],
+            selected_items: std::collections::HashSet::new(),
+            cursor_idx: 0,
+            search_query: String::new(),
+            is_filtering: false,
+            is_loading: false,
+            entity_iid: 1,
+            entity_type: "issue".to_string(),
+            field_type: "labels".to_string(),
+            multi_select: true,
+            state: ratatui::widgets::ListState::default(),
+        });
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+        app.selector = None;
+
+        // 5. Column checklist
+        app.focus_column_checklist = true;
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+        app.focus_column_checklist = false;
+
+        // 6. Date picker
+        app.date_picker = Some(crate::app::DatePicker::new(
+            "Select Date".to_string(),
+            "2026-08-23",
+            crate::app::DatePickerAction::EditNewField { field_idx: 0 },
+        ));
+        assert!(handle_help_keybinding(
+            &mut app,
+            &KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        ));
+        assert!(app.show_help);
+        app.show_help = false;
+        app.date_picker = None;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1526,9 +1526,9 @@ async fn main() -> Result<()> {
                         continue;
                     }
 
-                    if handle_submit_dialog(&mut app, &key_event, events.sender())
+                    if handle_help_overlay(&mut app, &key_event)
                         || handle_help_keybinding(&mut app, &key_event)
-                        || handle_help_overlay(&mut app, &key_event)
+                        || handle_submit_dialog(&mut app, &key_event, events.sender())
                         || handle_switch_repo(&mut app, &key_event)
                         || handle_refresh(&mut app, &key_event, &mut last_refresh, events.sender())
                         || handle_date_picker(&mut app, &key_event, &mut terminal, events.sender())

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -739,17 +739,6 @@ pub fn render(f: &mut Frame, app: &mut App) {
 
             let inner_area = outer_block.inner(area);
 
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(
-                    [
-                        Constraint::Min(0),    // Main content split
-                        Constraint::Length(1), // Help / controls footer
-                    ]
-                    .as_ref(),
-                )
-                .split(inner_area);
-
             let main_chunks = {
                 let file_tree_constraint = if diff_view.file_tree_visible {
                     Constraint::Percentage(25)
@@ -759,7 +748,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
                 Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints([file_tree_constraint, Constraint::Percentage(100)].as_ref())
-                    .split(chunks[0])
+                    .split(inner_area)
             };
 
             // 1. Render Files list on the left (only if visible)
@@ -1907,17 +1896,11 @@ pub fn render(f: &mut Frame, app: &mut App) {
                 }
             }
 
-            let footer_p = Paragraph::new(" Esc/q: Exit • d: Toggle Diff Layout • Enter/Space: Select File / Toggle Zoom • h/l: Collapse/Expand Dir • j/k/↑/↓: Navigate • J/K: Scroll 10 • [/]: Prev/Next Hunk • z/Z: Collapse/Expand All • m: Mark Reviewed • M: Hide Reviewed • v: Select Lines • c: Comment • e: Suggest Code • a: Comment Actions • r: Submit Review • / or f: Search • Ctrl+n/Ctrl+N: Next/Prev Match ")
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(THEME.read().unwrap().text_muted).add_modifier(Modifier::ITALIC))
-            .wrap(ratatui::widgets::Wrap { trim: true });
-
             clear_area(f, area);
             f.render_widget(outer_block, area);
             if file_tree_visible {
                 f.render_widget(files_list, main_chunks[0]);
             }
-            f.render_widget(footer_p, chunks[1]);
 
             if updated_diff_view.side_by_side {
                 let diff_inner = diff_block.inner(main_chunks[1]);

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -399,783 +399,6 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
         f.render_widget(table, chunks[1]);
     }
 
-    if app.show_help {
-        struct Shortcut {
-            category: &'static str,
-            key: std::borrow::Cow<'static, str>,
-            action: &'static str,
-        }
-
-        let s = |k: &'static str| std::borrow::Cow::Borrowed(k);
-        let d = |k: String| std::borrow::Cow::Owned(k);
-
-        let shortcuts: Vec<Shortcut> = vec![
-            // ── Global & Nav ──
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{} / →", app.config.keybindings.global.next_tab)),
-                action: "Next tab",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{} / ←", app.config.keybindings.global.prev_tab)),
-                action: "Previous tab",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{}", app.config.keybindings.global.configure)),
-                action: "Toggle columns config popup (filter / group / sort)",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: s("j / k / ↓ / ↑"),
-                action: "Select item / Scroll page",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!(
-                    "{} / {}",
-                    app.config.keybindings.global.scroll_down,
-                    app.config.keybindings.global.scroll_up
-                )),
-                action: "Scroll description / trace / notes",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{} / f", app.config.keybindings.global.search)),
-                action: "Open fuzzy search / filter bar",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!(
-                    "F5 / Ctrl+R / {}",
-                    app.config.keybindings.global.refresh
-                )),
-                action: "Refresh active tab data",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: s("Ctrl+S"),
-                action: "Switch repository",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{}", app.config.keybindings.global.global_search)),
-                action: "Global search across all tabs",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: s("u"),
-                action: "Check for updates",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{} / F1", app.config.keybindings.global.help)),
-                action: "Show this help modal",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(format!("{}", app.config.keybindings.global.save_view)),
-                action: "Save view layout to config",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: d(app.config.keybindings.global.quit.clone()),
-                action: "Quit program",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: s("Esc"),
-                action: "Close active overlay",
-            },
-            Shortcut {
-                category: "Global & Nav",
-                key: s("Ctrl+C"),
-                action: "Quit program",
-            },
-            // ── Issues ──
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.create_issue)),
-                action: "Create new Issue",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.select_issue)),
-                action: "Toggle issue selection (bulk edit with e)",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.issues.selection_toggle
-                )),
-                action: "Toggle select mode (paint selection while navigating)",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.edit_entity)),
-                action: "Open parameter edit menu",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.close_entity)),
-                action: "Close selected Issue",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.reopen_entity)),
-                action: "Reopen selected Issue",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.delete_entity)),
-                action: "Delete selected Issue",
-            },
-            Shortcut {
-                category: "Issues",
-                key: s("o"),
-                action: "Open selected Issue in browser",
-            },
-            Shortcut {
-                category: "Issues",
-                key: d(format!("{}", app.config.keybindings.issues.create_mr)),
-                action: "Create Merge Request from selected Issue",
-            },
-            // ── Merge Requests ──
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.create_mr)),
-                action: "Create new Merge Request",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.select_mr)),
-                action: "Toggle MR/PR selection (bulk edit/merge with e/m)",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.selection_toggle)),
-                action: "Toggle select mode (paint selection while navigating)",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.edit_entity)),
-                action: "Open parameter edit menu",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.approve_mr)),
-                action: "Approve selected MR",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.revoke_mr)),
-                action: "Revoke your approval (GitLab only)",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.rebase_mr)),
-                action: "Rebase source branch onto target",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.merge_mr)),
-                action: "Merge selected MR (configure squash/delete)",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.toggle_draft)),
-                action: "Toggle Draft / Ready status",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.view_diff)),
-                action: "View Merge Request diff changes",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.mrs.view_related_pipelines
-                )),
-                action: "View related pipelines for selected MR",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.close_entity)),
-                action: "Close selected MR",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.reopen_entity)),
-                action: "Reopen selected MR",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: d(format!("{}", app.config.keybindings.mrs.delete_entity)),
-                action: "Delete selected MR",
-            },
-            Shortcut {
-                category: "Merge Requests",
-                key: s("o"),
-                action: "Open selected MR in browser",
-            },
-            // ── Pipelines ──
-            Shortcut {
-                category: "Pipelines",
-                key: s("Enter"),
-                action: "View pipeline jobs list",
-            },
-            Shortcut {
-                category: "Pipelines",
-                key: s("n"),
-                action: "Create pipeline with interactive form",
-            },
-            Shortcut {
-                category: "Pipelines",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.pipelines.trigger_pipeline
-                )),
-                action: "Trigger new pipeline from MR",
-            },
-            Shortcut {
-                category: "Pipelines",
-                key: d(format!("{}", app.config.keybindings.pipelines.retry)),
-                action: "Retry selected pipeline(s)",
-            },
-            Shortcut {
-                category: "Pipelines",
-                key: d(format!("{}", app.config.keybindings.pipelines.cancel)),
-                action: "Cancel pipeline execution",
-            },
-            Shortcut {
-                category: "Pipelines",
-                key: s("Space"),
-                action: "Check / uncheck pipeline for bulk retry",
-            },
-            Shortcut {
-                category: "Pipelines",
-                key: s("o"),
-                action: "Open pipeline in browser",
-            },
-            // ── Jobs ──
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.view_trace)),
-                action: "View job trace (toggle zoom)",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: s("Esc / Backspc"),
-                action: "Go back to Pipelines list",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.enter_pipeline)),
-                action: "Switch to pipeline selector",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.retry)),
-                action: "Retry selected job(s)",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.start_job)),
-                action: "Start manual job (GitLab only)",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.cancel)),
-                action: "Cancel selected job(s)",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.select_job)),
-                action: "Check / uncheck job for bulk retry/cancel",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.select_stage)),
-                action: "Select all jobs in stage",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.download_artifact)),
-                action: "Download job artifact",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.view_trace_editor)),
-                action: "Open job trace in external $EDITOR",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.open_in_browser)),
-                action: "Open selected job in browser",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: d(format!("{}", app.config.keybindings.jobs.toggle_trace_wrap)),
-                action: "Toggle trace word wrap / clipped view",
-            },
-            Shortcut {
-                category: "Jobs",
-                key: s("m"),
-                action: "Collapse / expand matrix jobs",
-            },
-            // ── Milestones ──
-            Shortcut {
-                category: "Milestones",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.milestones.create_milestone
-                )),
-                action: "Create new milestone",
-            },
-            Shortcut {
-                category: "Milestones",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.milestones.edit_milestone
-                )),
-                action: "Edit selected milestone",
-            },
-            Shortcut {
-                category: "Milestones",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.milestones.close_milestone
-                )),
-                action: "Close selected milestone",
-            },
-            Shortcut {
-                category: "Milestones",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.milestones.reopen_milestone
-                )),
-                action: "Reopen selected milestone",
-            },
-            Shortcut {
-                category: "Milestones",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.milestones.delete_milestone
-                )),
-                action: "Delete selected milestone",
-            },
-            Shortcut {
-                category: "Milestones",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.milestones.open_in_browser
-                )),
-                action: "Open milestone in browser",
-            },
-            // ── Runners ──
-            Shortcut {
-                category: "Runners",
-                key: d(format!(
-                    "{} / {}",
-                    app.config.keybindings.runners.pause, app.config.keybindings.runners.resume,
-                )),
-                action: "Pause / Resume runner",
-            },
-            Shortcut {
-                category: "Runners",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.runners.edit_description
-                )),
-                action: "Edit runner description text",
-            },
-            // ── Releases ──
-            Shortcut {
-                category: "Releases",
-                key: s("Enter"),
-                action: "View release notes (toggle zoom)",
-            },
-            Shortcut {
-                category: "Releases",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.releases.create_release
-                )),
-                action: "Create new release tag & changelog",
-            },
-            Shortcut {
-                category: "Releases",
-                key: d(format!("{}", app.config.keybindings.releases.edit_release)),
-                action: "Edit selected release",
-            },
-            Shortcut {
-                category: "Releases",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.releases.delete_release
-                )),
-                action: "Delete selected release",
-            },
-            Shortcut {
-                category: "Releases",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.releases.open_in_browser
-                )),
-                action: "Open release in browser",
-            },
-            // ── TODOs ──
-            Shortcut {
-                category: "TODOs",
-                key: d(format!("{}", app.config.keybindings.todos.mark_as_read)),
-                action: "Open todo target & mark read",
-            },
-            Shortcut {
-                category: "TODOs",
-                key: d(format!("{}", app.config.keybindings.todos.open_in_browser)),
-                action: "Open todo in browser",
-            },
-            // ── Terminal ──
-            Shortcut {
-                category: "Terminal",
-                key: s("j / k / ↑ / ↓"),
-                action: "Scroll terminal log",
-            },
-            Shortcut {
-                category: "Terminal",
-                key: d(format!("{}", app.config.keybindings.terminal.toggle_wrap)),
-                action: "Toggle terminal line wrapping",
-            },
-            // ── Branches ──
-            Shortcut {
-                category: "Branches",
-                key: d(format!("{}", app.config.keybindings.branches.create_branch)),
-                action: "Create new branch",
-            },
-            Shortcut {
-                category: "Branches",
-                key: d(format!("{}", app.config.keybindings.branches.delete_branch)),
-                action: "Delete selected branch",
-            },
-            // ── Environments ──
-            Shortcut {
-                category: "Environments",
-                key: d(format!(
-                    "{}",
-                    app.config.keybindings.environments.view_deployments
-                )),
-                action: "View deployments list for environment",
-            },
-            // ── Diff View ──
-            Shortcut {
-                category: "Diff View",
-                key: s("q / Esc"),
-                action: "Exit Diff View",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("Tab"),
-                action: "Toggle Focus (Files / Diff)",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("h / l / Left / Right"),
-                action: "Switch Panel Focus",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("j / k / ↓ / ↑"),
-                action: "Navigate files or diff lines",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("J / K"),
-                action: "Page down / Page up",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("[ / ]"),
-                action: "Previous / Next Hunk",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("c"),
-                action: "Add Comment on Line",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("r"),
-                action: "Submit Review (approve/changes/comment)",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("d"),
-                action: "Toggle unified / side-by-side layout",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("v / V"),
-                action: "Start / Stop line selection for comment",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("a"),
-                action: "Interact with comments on current line",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("C"),
-                action: "Add comment via external $EDITOR",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("e"),
-                action: "Add code suggestion via $EDITOR",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("/ f"),
-                action: "Search within diff",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("Ctrl+n / Ctrl+N"),
-                action: "Search next / previous match",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("z / Z"),
-                action: "Collapse / Expand all files",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("m"),
-                action: "Mark / unmark file (or directory) as reviewed",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("M"),
-                action: "Hide / show reviewed files in the tree",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("Enter / Space"),
-                action: "Expand file tree / Toggle zoom",
-            },
-            Shortcut {
-                category: "Diff View",
-                key: s("? / F1"),
-                action: "Show this help modal",
-            },
-        ];
-
-        let active_categories: &[&str] = if app.diff_view.is_some() {
-            &["Diff View"]
-        } else {
-            match app.active_tab {
-                Tab::Issues => &["Global & Nav", "Issues"],
-                Tab::MergeRequests => &["Global & Nav", "Merge Requests"],
-                Tab::Pipelines => &["Global & Nav", "Pipelines"],
-                Tab::Jobs => &["Global & Nav", "Jobs"],
-                Tab::Milestones => &["Global & Nav", "Milestones"],
-                Tab::Runners => &["Global & Nav", "Runners"],
-                Tab::Releases => &["Global & Nav", "Releases"],
-                Tab::Todos => &["Global & Nav", "TODOs"],
-                Tab::Branches => &["Global & Nav", "Branches"],
-                Tab::Environments => &["Global & Nav", "Environments"],
-                Tab::Terminal => &["Global & Nav", "Terminal"],
-            }
-        };
-
-        let filtered_shortcuts: Vec<&Shortcut> = shortcuts
-            .iter()
-            .filter(|s| active_categories.contains(&s.category))
-            .collect();
-
-        let block = Block::default()
-            .title(format!(" {} Keyboard Shortcuts ", icons.label_keyboard))
-            .title_style(
-                Style::default()
-                    .fg(THEME.read().unwrap().header_fg)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(THEME.read().unwrap().border_focused))
-            .border_type(BorderType::Double)
-            .style(Style::default().bg(THEME.read().unwrap().bg));
-
-        let area = centered_rect_fixed(90, 40, size);
-        app.overlay_stack
-            .push((crate::app::OverlayKind::Help, area));
-
-        let help_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints(
-                [
-                    Constraint::Length(3), // Search / Filter
-                    Constraint::Min(0),    // Table
-                ]
-                .as_ref(),
-            )
-            .split(area);
-
-        // Action column width: inner table width minus the two fixed columns
-        // (16 + 18) and the inter-column spacing (2 gaps of 2).
-        let action_width = help_chunks[1].width.saturating_sub(16 + 18 + 4).max(8);
-
-        let border_color = if app.help_search_query.is_empty() {
-            THEME.read().unwrap().border
-        } else {
-            THEME.read().unwrap().border_focused
-        };
-        let search_block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(border_color))
-            .title(" Filter Shortcuts ")
-            .title_style(
-                Style::default()
-                    .fg(THEME.read().unwrap().text_muted)
-                    .add_modifier(Modifier::BOLD),
-            );
-
-        let search_text = if app.help_search_query.is_empty() {
-            "Type to search commands...▋".to_string()
-        } else {
-            format!("{}▋", app.help_search_query)
-        };
-
-        let search_style = if app.help_search_query.is_empty() {
-            Style::default()
-                .fg(THEME.read().unwrap().text_muted)
-                .add_modifier(Modifier::ITALIC)
-        } else {
-            Style::default().fg(THEME.read().unwrap().text_normal)
-        };
-
-        let search_p = Paragraph::new(search_text)
-            .style(search_style)
-            .block(search_block)
-            .wrap(ratatui::widgets::Wrap { trim: true });
-
-        let rows: Vec<Row> =
-            if app.help_search_query.is_empty() {
-                let mut result_rows = Vec::new();
-                let mut last_category = "";
-                for s in &filtered_shortcuts {
-                    if s.category != last_category {
-                        if !last_category.is_empty() {
-                            result_rows.push(Row::new(vec![
-                                Cell::from(""),
-                                Cell::from(""),
-                                Cell::from(""),
-                            ])); // spacer
-                        }
-                        let (action_text, action_lines) = wrap_cell_text(s.action, action_width);
-                        result_rows.push(
-                            Row::new(vec![
-                                Cell::from(Span::styled(
-                                    s.category,
-                                    Style::default()
-                                        .fg(THEME.read().unwrap().purple)
-                                        .add_modifier(Modifier::BOLD),
-                                )),
-                                Cell::from(Span::styled(
-                                    s.key.clone(),
-                                    Style::default()
-                                        .fg(THEME.read().unwrap().text_normal)
-                                        .add_modifier(Modifier::BOLD),
-                                )),
-                                Cell::from(action_text.patch_style(
-                                    Style::default().fg(THEME.read().unwrap().text_normal),
-                                )),
-                            ])
-                            .height(action_lines),
-                        );
-                        last_category = s.category;
-                    } else {
-                        let (action_text, action_lines) = wrap_cell_text(s.action, action_width);
-                        result_rows.push(
-                            Row::new(vec![
-                                Cell::from(""),
-                                Cell::from(Span::styled(
-                                    s.key.clone(),
-                                    Style::default()
-                                        .fg(THEME.read().unwrap().text_normal)
-                                        .add_modifier(Modifier::BOLD),
-                                )),
-                                Cell::from(action_text.patch_style(
-                                    Style::default().fg(THEME.read().unwrap().text_normal),
-                                )),
-                            ])
-                            .height(action_lines),
-                        );
-                    }
-                }
-                result_rows
-            } else {
-                let query = app.help_search_query.to_lowercase();
-                filtered_shortcuts
-                    .iter()
-                    .filter(|s| {
-                        s.category.to_lowercase().contains(&query)
-                            || s.key.to_lowercase().contains(&query)
-                            || s.action.to_lowercase().contains(&query)
-                    })
-                    .map(|s| {
-                        let (action_text, action_lines) = wrap_cell_text(s.action, action_width);
-                        Row::new(vec![
-                            Cell::from(Span::styled(
-                                s.category,
-                                Style::default()
-                                    .fg(THEME.read().unwrap().purple)
-                                    .add_modifier(Modifier::BOLD),
-                            )),
-                            Cell::from(Span::styled(
-                                s.key.clone(),
-                                Style::default()
-                                    .fg(THEME.read().unwrap().text_normal)
-                                    .add_modifier(Modifier::BOLD),
-                            )),
-                            Cell::from(action_text.patch_style(
-                                Style::default().fg(THEME.read().unwrap().text_normal),
-                            )),
-                        ])
-                        .height(action_lines)
-                    })
-                    .collect()
-            };
-
-        let widths = [
-            Constraint::Length(16),
-            Constraint::Length(18),
-            Constraint::Min(0),
-        ];
-
-        let header_style = Style::default()
-            .fg(THEME.read().unwrap().header_fg)
-            .add_modifier(Modifier::BOLD);
-        let table = Table::new(rows, widths)
-            .header(
-                Row::new(vec![
-                    Cell::from(Span::styled("Category", header_style)),
-                    Cell::from(Span::styled("Key", header_style)),
-                    Cell::from(Span::styled("Action", header_style)),
-                ])
-                .height(1),
-            )
-            .block(block)
-            .row_highlight_style(Style::default())
-            .column_spacing(2);
-
-        clear_area(f, area);
-        f.render_widget(search_p, help_chunks[0]);
-        f.render_widget(table, help_chunks[1]);
-    }
-
     if app.focus_column_checklist && app.selector.is_none() {
         let tab = app.active_tab;
         let kind = app.kind();
@@ -1914,6 +1137,919 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
             halves[0],
         );
     }
+
+    render_help(f, app, size);
+}
+
+pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
+    if !app.show_help {
+        return;
+    }
+
+    let icons = ICONS.read().unwrap();
+
+    struct Shortcut {
+        category: &'static str,
+        key: std::borrow::Cow<'static, str>,
+        action: &'static str,
+    }
+
+    let s = |k: &'static str| std::borrow::Cow::Borrowed(k);
+    let d = |k: String| std::borrow::Cow::Owned(k);
+
+    let shortcuts: Vec<Shortcut> = vec![
+        // ── Global & Nav ──
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{} / →", app.config.keybindings.global.next_tab)),
+            action: "Next tab",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{} / ←", app.config.keybindings.global.prev_tab)),
+            action: "Previous tab",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{}", app.config.keybindings.global.configure)),
+            action: "Toggle columns config popup (filter / group / sort)",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: s("j / k / ↓ / ↑"),
+            action: "Select item / Scroll page",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!(
+                "{} / {}",
+                app.config.keybindings.global.scroll_down, app.config.keybindings.global.scroll_up
+            )),
+            action: "Scroll description / trace / notes",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{} / f", app.config.keybindings.global.search)),
+            action: "Open fuzzy search / filter bar",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!(
+                "F5 / Ctrl+R / {}",
+                app.config.keybindings.global.refresh
+            )),
+            action: "Refresh active tab data",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: s("Ctrl+S"),
+            action: "Switch repository",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{}", app.config.keybindings.global.global_search)),
+            action: "Global search across all tabs",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: s("u"),
+            action: "Check for updates",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{} / F1", app.config.keybindings.global.help)),
+            action: "Show this help modal",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!("{}", app.config.keybindings.global.save_view)),
+            action: "Save view layout to config",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(app.config.keybindings.global.quit.clone()),
+            action: "Quit program",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: s("Esc"),
+            action: "Close active overlay",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: s("Ctrl+C"),
+            action: "Quit program",
+        },
+        // ── Issues ──
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.create_issue)),
+            action: "Create new Issue",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.select_issue)),
+            action: "Toggle issue selection (bulk edit with e)",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.issues.selection_toggle
+            )),
+            action: "Toggle select mode (paint selection while navigating)",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.edit_entity)),
+            action: "Open parameter edit menu",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.close_entity)),
+            action: "Close selected Issue",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.reopen_entity)),
+            action: "Reopen selected Issue",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.delete_entity)),
+            action: "Delete selected Issue",
+        },
+        Shortcut {
+            category: "Issues",
+            key: s("o"),
+            action: "Open selected Issue in browser",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(format!("{}", app.config.keybindings.issues.create_mr)),
+            action: "Create Merge Request from selected Issue",
+        },
+        // ── Merge Requests ──
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.create_mr)),
+            action: "Create new Merge Request",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.select_mr)),
+            action: "Toggle MR/PR selection (bulk edit/merge with e/m)",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.selection_toggle)),
+            action: "Toggle select mode (paint selection while navigating)",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.edit_entity)),
+            action: "Open parameter edit menu",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.approve_mr)),
+            action: "Approve selected MR",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.revoke_mr)),
+            action: "Revoke your approval (GitLab only)",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.rebase_mr)),
+            action: "Rebase source branch onto target",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.merge_mr)),
+            action: "Merge selected MR (configure squash/delete)",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.toggle_draft)),
+            action: "Toggle Draft / Ready status",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.view_diff)),
+            action: "View Merge Request diff changes",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.mrs.view_related_pipelines
+            )),
+            action: "View related pipelines for selected MR",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.close_entity)),
+            action: "Close selected MR",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.reopen_entity)),
+            action: "Reopen selected MR",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: d(format!("{}", app.config.keybindings.mrs.delete_entity)),
+            action: "Delete selected MR",
+        },
+        Shortcut {
+            category: "Merge Requests",
+            key: s("o"),
+            action: "Open selected MR in browser",
+        },
+        // ── Pipelines ──
+        Shortcut {
+            category: "Pipelines",
+            key: s("Enter"),
+            action: "View pipeline jobs list",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: s("n"),
+            action: "Create pipeline with interactive form",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.pipelines.trigger_pipeline
+            )),
+            action: "Trigger new pipeline from MR",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: d(format!("{}", app.config.keybindings.pipelines.retry)),
+            action: "Retry selected pipeline(s)",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: d(format!("{}", app.config.keybindings.pipelines.cancel)),
+            action: "Cancel pipeline execution",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: s("Space"),
+            action: "Check / uncheck pipeline for bulk retry",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: s("o"),
+            action: "Open pipeline in browser",
+        },
+        // ── Jobs ──
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.view_trace)),
+            action: "View job trace (toggle zoom)",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: s("Esc / Backspc"),
+            action: "Go back to Pipelines list",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.enter_pipeline)),
+            action: "Switch to pipeline selector",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.retry)),
+            action: "Retry selected job(s)",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.start_job)),
+            action: "Start manual job (GitLab only)",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.cancel)),
+            action: "Cancel selected job(s)",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.select_job)),
+            action: "Check / uncheck job for bulk retry/cancel",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.select_stage)),
+            action: "Select all jobs in stage",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.download_artifact)),
+            action: "Download job artifact",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.view_trace_editor)),
+            action: "Open job trace in external $EDITOR",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.open_in_browser)),
+            action: "Open selected job in browser",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(format!("{}", app.config.keybindings.jobs.toggle_trace_wrap)),
+            action: "Toggle trace word wrap / clipped view",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: s("m"),
+            action: "Collapse / expand matrix jobs",
+        },
+        // ── Milestones ──
+        Shortcut {
+            category: "Milestones",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.milestones.create_milestone
+            )),
+            action: "Create new milestone",
+        },
+        Shortcut {
+            category: "Milestones",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.milestones.edit_milestone
+            )),
+            action: "Edit selected milestone",
+        },
+        Shortcut {
+            category: "Milestones",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.milestones.close_milestone
+            )),
+            action: "Close selected milestone",
+        },
+        Shortcut {
+            category: "Milestones",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.milestones.reopen_milestone
+            )),
+            action: "Reopen selected milestone",
+        },
+        Shortcut {
+            category: "Milestones",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.milestones.delete_milestone
+            )),
+            action: "Delete selected milestone",
+        },
+        Shortcut {
+            category: "Milestones",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.milestones.open_in_browser
+            )),
+            action: "Open milestone in browser",
+        },
+        // ── Runners ──
+        Shortcut {
+            category: "Runners",
+            key: d(format!(
+                "{} / {}",
+                app.config.keybindings.runners.pause, app.config.keybindings.runners.resume,
+            )),
+            action: "Pause / Resume runner",
+        },
+        Shortcut {
+            category: "Runners",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.runners.edit_description
+            )),
+            action: "Edit runner description text",
+        },
+        // ── Releases ──
+        Shortcut {
+            category: "Releases",
+            key: s("Enter"),
+            action: "View release notes (toggle zoom)",
+        },
+        Shortcut {
+            category: "Releases",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.releases.create_release
+            )),
+            action: "Create new release tag & changelog",
+        },
+        Shortcut {
+            category: "Releases",
+            key: d(format!("{}", app.config.keybindings.releases.edit_release)),
+            action: "Edit selected release",
+        },
+        Shortcut {
+            category: "Releases",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.releases.delete_release
+            )),
+            action: "Delete selected release",
+        },
+        Shortcut {
+            category: "Releases",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.releases.open_in_browser
+            )),
+            action: "Open release in browser",
+        },
+        // ── TODOs ──
+        Shortcut {
+            category: "TODOs",
+            key: d(format!("{}", app.config.keybindings.todos.mark_as_read)),
+            action: "Open todo target & mark read",
+        },
+        Shortcut {
+            category: "TODOs",
+            key: d(format!("{}", app.config.keybindings.todos.open_in_browser)),
+            action: "Open todo in browser",
+        },
+        // ── Terminal ──
+        Shortcut {
+            category: "Terminal",
+            key: s("j / k / ↑ / ↓"),
+            action: "Scroll terminal log",
+        },
+        Shortcut {
+            category: "Terminal",
+            key: d(format!("{}", app.config.keybindings.terminal.toggle_wrap)),
+            action: "Toggle terminal line wrapping",
+        },
+        // ── Branches ──
+        Shortcut {
+            category: "Branches",
+            key: d(format!("{}", app.config.keybindings.branches.create_branch)),
+            action: "Create new branch",
+        },
+        Shortcut {
+            category: "Branches",
+            key: d(format!("{}", app.config.keybindings.branches.delete_branch)),
+            action: "Delete selected branch",
+        },
+        // ── Environments ──
+        Shortcut {
+            category: "Environments",
+            key: d(format!(
+                "{}",
+                app.config.keybindings.environments.view_deployments
+            )),
+            action: "View deployments list for environment",
+        },
+        // ── Diff View ──
+        Shortcut {
+            category: "Diff View",
+            key: s("q / Esc"),
+            action: "Exit Diff View",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("Tab"),
+            action: "Toggle Focus (Files / Diff)",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("h / l / Left / Right"),
+            action: "Switch Panel Focus",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("j / k / ↓ / ↑"),
+            action: "Navigate files or diff lines",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("J / K"),
+            action: "Page down / Page up",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("[ / ]"),
+            action: "Previous / Next Hunk",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("c"),
+            action: "Add Comment on Line",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("r"),
+            action: "Submit Review (approve/changes/comment)",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("d"),
+            action: "Toggle unified / side-by-side layout",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("v / V"),
+            action: "Start / Stop line selection for comment",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("a"),
+            action: "Interact with comments on current line",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("C"),
+            action: "Add comment via external $EDITOR",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("e"),
+            action: "Add code suggestion via $EDITOR",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("/ f"),
+            action: "Search within diff",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("Ctrl+n / Ctrl+N"),
+            action: "Search next / previous match",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("z / Z"),
+            action: "Collapse / Expand all files",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("m"),
+            action: "Mark / unmark file (or directory) as reviewed",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("M"),
+            action: "Hide / show reviewed files in the tree",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("Enter / Space"),
+            action: "Expand file tree / Toggle zoom",
+        },
+        Shortcut {
+            category: "Diff View",
+            key: s("? / F1"),
+            action: "Show this help modal",
+        },
+        // ── Inspector / Editor ──
+        Shortcut {
+            category: "Inspector / Editor",
+            key: s("j / k / ↓ / ↑ / Tab / Shift+Tab"),
+            action: "Navigate fields & buttons",
+        },
+        Shortcut {
+            category: "Inspector / Editor",
+            key: s("Enter / Space"),
+            action: "Edit field / Select option / Submit",
+        },
+        Shortcut {
+            category: "Inspector / Editor",
+            key: s("Ctrl+E"),
+            action: "Edit description / notes in $EDITOR",
+        },
+        Shortcut {
+            category: "Inspector / Editor",
+            key: s("J / K"),
+            action: "Scroll description / notes pane",
+        },
+        Shortcut {
+            category: "Inspector / Editor",
+            key: s("Esc"),
+            action: "Exit inspector / Close editor form",
+        },
+        Shortcut {
+            category: "Inspector / Editor",
+            key: s("? / F1"),
+            action: "Show this help modal",
+        },
+        // ── Selector / Filter ──
+        Shortcut {
+            category: "Selector / Filter",
+            key: s("j / k / ↓ / ↑"),
+            action: "Navigate options",
+        },
+        Shortcut {
+            category: "Selector / Filter",
+            key: s("Enter"),
+            action: "Confirm selection",
+        },
+        Shortcut {
+            category: "Selector / Filter",
+            key: s("Space"),
+            action: "Toggle item (multi-select)",
+        },
+        Shortcut {
+            category: "Selector / Filter",
+            key: s("Esc"),
+            action: "Close selector overlay",
+        },
+        Shortcut {
+            category: "Selector / Filter",
+            key: s("Type to search"),
+            action: "Fuzzy filter available items",
+        },
+        Shortcut {
+            category: "Selector / Filter",
+            key: s("? / F1"),
+            action: "Show this help modal",
+        },
+        // ── Column Config ──
+        Shortcut {
+            category: "Column Config",
+            key: s("j / k / ↓ / ↑"),
+            action: "Navigate columns & group-by options",
+        },
+        Shortcut {
+            category: "Column Config",
+            key: s("Space"),
+            action: "Toggle column visibility checkbox",
+        },
+        Shortcut {
+            category: "Column Config",
+            key: s("Enter"),
+            action: "Open value filter selector for column",
+        },
+        Shortcut {
+            category: "Column Config",
+            key: s("s"),
+            action: "Save layout to config",
+        },
+        Shortcut {
+            category: "Column Config",
+            key: s("Esc"),
+            action: "Close columns config popup",
+        },
+        Shortcut {
+            category: "Column Config",
+            key: s("? / F1"),
+            action: "Show this help modal",
+        },
+        // ── Date Picker ──
+        Shortcut {
+            category: "Date Picker",
+            key: s("h / l / ← / →"),
+            action: "Previous / Next month",
+        },
+        Shortcut {
+            category: "Date Picker",
+            key: s("j / k / ↓ / ↑"),
+            action: "Previous / Next day",
+        },
+        Shortcut {
+            category: "Date Picker",
+            key: s("Enter"),
+            action: "Confirm date selection",
+        },
+        Shortcut {
+            category: "Date Picker",
+            key: s("Esc"),
+            action: "Cancel date selection",
+        },
+        Shortcut {
+            category: "Date Picker",
+            key: s("? / F1"),
+            action: "Show this help modal",
+        },
+    ];
+
+    let active_categories: &[&str] = if app.diff_view.is_some() {
+        &["Diff View"]
+    } else if app.edit_menu.is_some() {
+        &["Global & Nav", "Inspector / Editor"]
+    } else if app.focus_column_checklist {
+        &["Global & Nav", "Column Config"]
+    } else if app.date_picker.is_some() {
+        &["Global & Nav", "Date Picker"]
+    } else if app.selector.is_some() {
+        &["Global & Nav", "Selector / Filter"]
+    } else {
+        match app.active_tab {
+            Tab::Issues => &["Global & Nav", "Issues"],
+            Tab::MergeRequests => &["Global & Nav", "Merge Requests"],
+            Tab::Pipelines => &["Global & Nav", "Pipelines"],
+            Tab::Jobs => &["Global & Nav", "Jobs"],
+            Tab::Milestones => &["Global & Nav", "Milestones"],
+            Tab::Runners => &["Global & Nav", "Runners"],
+            Tab::Releases => &["Global & Nav", "Releases"],
+            Tab::Todos => &["Global & Nav", "TODOs"],
+            Tab::Branches => &["Global & Nav", "Branches"],
+            Tab::Environments => &["Global & Nav", "Environments"],
+            Tab::Terminal => &["Global & Nav", "Terminal"],
+        }
+    };
+
+    let filtered_shortcuts: Vec<&Shortcut> = shortcuts
+        .iter()
+        .filter(|s| active_categories.contains(&s.category))
+        .collect();
+
+    let block = Block::default()
+        .title(format!(" {} Keyboard Shortcuts ", icons.label_keyboard))
+        .title_style(
+            Style::default()
+                .fg(THEME.read().unwrap().header_fg)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(THEME.read().unwrap().border_focused))
+        .border_type(BorderType::Double)
+        .style(Style::default().bg(THEME.read().unwrap().bg));
+
+    let area = centered_rect_min(90, 85, 95, 38, size);
+    app.overlay_stack
+        .push((crate::app::OverlayKind::Help, area));
+
+    let help_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints(
+            [
+                Constraint::Length(3), // Search / Filter
+                Constraint::Min(0),    // Table
+            ]
+            .as_ref(),
+        )
+        .split(area);
+
+    // Action column width: inner table width minus the two fixed columns
+    // (20 + 24) and the inter-column spacing (2 gaps of 2).
+    let action_width = help_chunks[1].width.saturating_sub(20 + 24 + 4).max(8);
+
+    let border_color = if app.help_search_query.is_empty() {
+        THEME.read().unwrap().border
+    } else {
+        THEME.read().unwrap().border_focused
+    };
+    let search_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(" Filter Shortcuts ")
+        .title_style(
+            Style::default()
+                .fg(THEME.read().unwrap().text_muted)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let search_text = if app.help_search_query.is_empty() {
+        "Type to search commands...▋".to_string()
+    } else {
+        format!("{}▋", app.help_search_query)
+    };
+
+    let search_style = if app.help_search_query.is_empty() {
+        Style::default()
+            .fg(THEME.read().unwrap().text_muted)
+            .add_modifier(Modifier::ITALIC)
+    } else {
+        Style::default().fg(THEME.read().unwrap().text_normal)
+    };
+
+    let search_p = Paragraph::new(search_text)
+        .style(search_style)
+        .block(search_block)
+        .wrap(ratatui::widgets::Wrap { trim: true });
+
+    let rows: Vec<Row> =
+        if app.help_search_query.is_empty() {
+            let mut result_rows = Vec::new();
+            let mut last_category = "";
+            for s in &filtered_shortcuts {
+                if s.category != last_category {
+                    if !last_category.is_empty() {
+                        result_rows.push(Row::new(vec![
+                            Cell::from(""),
+                            Cell::from(""),
+                            Cell::from(""),
+                        ])); // spacer
+                    }
+                    let (action_text, action_lines) = wrap_cell_text(s.action, action_width);
+                    result_rows.push(
+                        Row::new(vec![
+                            Cell::from(Span::styled(
+                                s.category,
+                                Style::default()
+                                    .fg(THEME.read().unwrap().purple)
+                                    .add_modifier(Modifier::BOLD),
+                            )),
+                            Cell::from(Span::styled(
+                                s.key.clone(),
+                                Style::default()
+                                    .fg(THEME.read().unwrap().text_normal)
+                                    .add_modifier(Modifier::BOLD),
+                            )),
+                            Cell::from(action_text.patch_style(
+                                Style::default().fg(THEME.read().unwrap().text_normal),
+                            )),
+                        ])
+                        .height(action_lines),
+                    );
+                    last_category = s.category;
+                } else {
+                    let (action_text, action_lines) = wrap_cell_text(s.action, action_width);
+                    result_rows.push(
+                        Row::new(vec![
+                            Cell::from(""),
+                            Cell::from(Span::styled(
+                                s.key.clone(),
+                                Style::default()
+                                    .fg(THEME.read().unwrap().text_normal)
+                                    .add_modifier(Modifier::BOLD),
+                            )),
+                            Cell::from(action_text.patch_style(
+                                Style::default().fg(THEME.read().unwrap().text_normal),
+                            )),
+                        ])
+                        .height(action_lines),
+                    );
+                }
+            }
+            result_rows
+        } else {
+            let query = app.help_search_query.to_lowercase();
+            shortcuts
+                .iter()
+                .filter(|s| {
+                    s.category.to_lowercase().contains(&query)
+                        || s.key.to_lowercase().contains(&query)
+                        || s.action.to_lowercase().contains(&query)
+                })
+                .map(|s| {
+                    let (action_text, action_lines) = wrap_cell_text(s.action, action_width);
+                    Row::new(vec![
+                        Cell::from(Span::styled(
+                            s.category,
+                            Style::default()
+                                .fg(THEME.read().unwrap().purple)
+                                .add_modifier(Modifier::BOLD),
+                        )),
+                        Cell::from(Span::styled(
+                            s.key.clone(),
+                            Style::default()
+                                .fg(THEME.read().unwrap().text_normal)
+                                .add_modifier(Modifier::BOLD),
+                        )),
+                        Cell::from(
+                            action_text.patch_style(
+                                Style::default().fg(THEME.read().unwrap().text_normal),
+                            ),
+                        ),
+                    ])
+                    .height(action_lines)
+                })
+                .collect()
+        };
+
+    let widths = [
+        Constraint::Length(20),
+        Constraint::Length(24),
+        Constraint::Min(0),
+    ];
+
+    let header_style = Style::default()
+        .fg(THEME.read().unwrap().header_fg)
+        .add_modifier(Modifier::BOLD);
+    let table = Table::new(rows, widths)
+        .header(
+            Row::new(vec![
+                Cell::from(Span::styled("Category", header_style)),
+                Cell::from(Span::styled("Key", header_style)),
+                Cell::from(Span::styled("Action", header_style)),
+            ])
+            .height(1),
+        )
+        .block(block)
+        .row_highlight_style(Style::default())
+        .column_spacing(2);
+
+    clear_area(f, area);
+    f.render_widget(search_p, help_chunks[0]);
+    f.render_widget(table, help_chunks[1]);
 }
 
 /// Wrap a string into `width`-character lines at word boundaries,

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1243,129 +1243,123 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         // ── Issues ──
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.create_issue)),
+            key: d(app.config.keybindings.issues.create_issue.clone()),
             action: "Create new Issue",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.select_issue)),
+            key: d(app.config.keybindings.issues.select_issue.clone()),
             action: "Toggle issue selection (bulk edit with e)",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.issues.selection_toggle
-            )),
+            key: d(app.config.keybindings.issues.selection_toggle.clone()),
             action: "Toggle select mode (paint selection while navigating)",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.edit_entity)),
+            key: d(app.config.keybindings.issues.edit_entity.clone()),
             action: "Open parameter edit menu",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.close_entity)),
+            key: d(app.config.keybindings.issues.close_entity.clone()),
             action: "Close selected Issue",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.reopen_entity)),
+            key: d(app.config.keybindings.issues.reopen_entity.clone()),
             action: "Reopen selected Issue",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.delete_entity)),
+            key: d(app.config.keybindings.issues.delete_entity.clone()),
             action: "Delete selected Issue",
         },
         Shortcut {
             category: "Issues",
-            key: s("o"),
+            key: d(app.config.keybindings.issues.open_in_browser.clone()),
             action: "Open selected Issue in browser",
         },
         Shortcut {
             category: "Issues",
-            key: d(format!("{}", app.config.keybindings.issues.create_mr)),
+            key: d(app.config.keybindings.issues.create_mr.clone()),
             action: "Create Merge Request from selected Issue",
         },
         // ── Merge Requests ──
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.create_mr)),
+            key: d(app.config.keybindings.mrs.create_mr.clone()),
             action: "Create new Merge Request",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.select_mr)),
+            key: d(app.config.keybindings.mrs.select_mr.clone()),
             action: "Toggle MR/PR selection (bulk edit/merge with e/m)",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.selection_toggle)),
+            key: d(app.config.keybindings.mrs.selection_toggle.clone()),
             action: "Toggle select mode (paint selection while navigating)",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.edit_entity)),
+            key: d(app.config.keybindings.mrs.edit_entity.clone()),
             action: "Open parameter edit menu",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.approve_mr)),
+            key: d(app.config.keybindings.mrs.approve_mr.clone()),
             action: "Approve selected MR",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.revoke_mr)),
+            key: d(app.config.keybindings.mrs.revoke_mr.clone()),
             action: "Revoke your approval (GitLab only)",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.rebase_mr)),
+            key: d(app.config.keybindings.mrs.rebase_mr.clone()),
             action: "Rebase source branch onto target",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.merge_mr)),
+            key: d(app.config.keybindings.mrs.merge_mr.clone()),
             action: "Merge selected MR (configure squash/delete)",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.toggle_draft)),
+            key: d(app.config.keybindings.mrs.toggle_draft.clone()),
             action: "Toggle Draft / Ready status",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.view_diff)),
+            key: d(app.config.keybindings.mrs.view_diff.clone()),
             action: "View Merge Request diff changes",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.mrs.view_related_pipelines
-            )),
+            key: d(app.config.keybindings.mrs.view_related_pipelines.clone()),
             action: "View related pipelines for selected MR",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.close_entity)),
+            key: d(app.config.keybindings.mrs.close_entity.clone()),
             action: "Close selected MR",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.reopen_entity)),
+            key: d(app.config.keybindings.mrs.reopen_entity.clone()),
             action: "Reopen selected MR",
         },
         Shortcut {
             category: "Merge Requests",
-            key: d(format!("{}", app.config.keybindings.mrs.delete_entity)),
+            key: d(app.config.keybindings.mrs.delete_entity.clone()),
             action: "Delete selected MR",
         },
         Shortcut {
             category: "Merge Requests",
-            key: s("o"),
+            key: d(app.config.keybindings.mrs.open_in_browser.clone()),
             action: "Open selected MR in browser",
         },
         // ── Pipelines ──
@@ -1376,26 +1370,28 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Pipelines",
-            key: s("n"),
+            key: d(app.config.keybindings.pipelines.run_new.clone()),
             action: "Create pipeline with interactive form",
         },
         Shortcut {
             category: "Pipelines",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.pipelines.trigger_pipeline
-            )),
+            key: d(app.config.keybindings.pipelines.trigger_pipeline.clone()),
             action: "Trigger new pipeline from MR",
         },
         Shortcut {
             category: "Pipelines",
-            key: d(format!("{}", app.config.keybindings.pipelines.retry)),
+            key: d(app.config.keybindings.pipelines.retry.clone()),
             action: "Retry selected pipeline(s)",
         },
         Shortcut {
             category: "Pipelines",
-            key: d(format!("{}", app.config.keybindings.pipelines.cancel)),
+            key: d(app.config.keybindings.pipelines.cancel.clone()),
             action: "Cancel pipeline execution",
+        },
+        Shortcut {
+            category: "Pipelines",
+            key: d(app.config.keybindings.pipelines.open_workflow.clone()),
+            action: "Open pipeline workflow in browser",
         },
         Shortcut {
             category: "Pipelines",
@@ -1404,13 +1400,13 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Pipelines",
-            key: s("o"),
+            key: d(app.config.keybindings.pipelines.open_in_browser.clone()),
             action: "Open pipeline in browser",
         },
         // ── Jobs ──
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.view_trace)),
+            key: d(app.config.keybindings.jobs.view_trace.clone()),
             action: "View job trace (toggle zoom)",
         },
         Shortcut {
@@ -1420,53 +1416,63 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.enter_pipeline)),
+            key: d(app.config.keybindings.jobs.enter_pipeline.clone()),
             action: "Switch to pipeline selector",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.retry)),
+            key: d(app.config.keybindings.jobs.retry.clone()),
             action: "Retry selected job(s)",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.start_job)),
+            key: d(app.config.keybindings.jobs.start_job.clone()),
             action: "Start manual job (GitLab only)",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.cancel)),
+            key: d(app.config.keybindings.jobs.cancel.clone()),
             action: "Cancel selected job(s)",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.select_job)),
+            key: d(app.config.keybindings.jobs.select_job.clone()),
             action: "Check / uncheck job for bulk retry/cancel",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.select_stage)),
+            key: d(app.config.keybindings.jobs.select_stage.clone()),
             action: "Select all jobs in stage",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.download_artifact)),
+            key: d(app.config.keybindings.jobs.download_artifact.clone()),
             action: "Download job artifact",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.view_trace_editor)),
+            key: d(app.config.keybindings.jobs.view_trace_editor.clone()),
             action: "Open job trace in external $EDITOR",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.open_in_browser)),
+            key: d(app.config.keybindings.jobs.open_in_browser.clone()),
             action: "Open selected job in browser",
         },
         Shortcut {
             category: "Jobs",
-            key: d(format!("{}", app.config.keybindings.jobs.toggle_trace_wrap)),
+            key: d(app.config.keybindings.jobs.toggle_trace_wrap.clone()),
             action: "Toggle trace word wrap / clipped view",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(app.config.keybindings.jobs.trace_search.clone()),
+            action: "Search within job trace",
+        },
+        Shortcut {
+            category: "Jobs",
+            key: d(app.config.keybindings.jobs.toggle_trace_follow.clone()),
+            action: "Toggle trace auto-follow mode",
         },
         Shortcut {
             category: "Jobs",
@@ -1476,50 +1482,32 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         // ── Milestones ──
         Shortcut {
             category: "Milestones",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.milestones.create_milestone
-            )),
+            key: d(app.config.keybindings.milestones.create_milestone.clone()),
             action: "Create new milestone",
         },
         Shortcut {
             category: "Milestones",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.milestones.edit_milestone
-            )),
+            key: d(app.config.keybindings.milestones.edit_milestone.clone()),
             action: "Edit selected milestone",
         },
         Shortcut {
             category: "Milestones",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.milestones.close_milestone
-            )),
+            key: d(app.config.keybindings.milestones.close_milestone.clone()),
             action: "Close selected milestone",
         },
         Shortcut {
             category: "Milestones",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.milestones.reopen_milestone
-            )),
+            key: d(app.config.keybindings.milestones.reopen_milestone.clone()),
             action: "Reopen selected milestone",
         },
         Shortcut {
             category: "Milestones",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.milestones.delete_milestone
-            )),
+            key: d(app.config.keybindings.milestones.delete_milestone.clone()),
             action: "Delete selected milestone",
         },
         Shortcut {
             category: "Milestones",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.milestones.open_in_browser
-            )),
+            key: d(app.config.keybindings.milestones.open_in_browser.clone()),
             action: "Open milestone in browser",
         },
         // ── Runners ──
@@ -1533,10 +1521,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Runners",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.runners.edit_description
-            )),
+            key: d(app.config.keybindings.runners.edit_description.clone()),
             action: "Edit runner description text",
         },
         // ── Releases ──
@@ -1547,42 +1532,33 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Releases",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.releases.create_release
-            )),
+            key: d(app.config.keybindings.releases.create_release.clone()),
             action: "Create new release tag & changelog",
         },
         Shortcut {
             category: "Releases",
-            key: d(format!("{}", app.config.keybindings.releases.edit_release)),
+            key: d(app.config.keybindings.releases.edit_release.clone()),
             action: "Edit selected release",
         },
         Shortcut {
             category: "Releases",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.releases.delete_release
-            )),
+            key: d(app.config.keybindings.releases.delete_release.clone()),
             action: "Delete selected release",
         },
         Shortcut {
             category: "Releases",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.releases.open_in_browser
-            )),
+            key: d(app.config.keybindings.releases.open_in_browser.clone()),
             action: "Open release in browser",
         },
         // ── TODOs ──
         Shortcut {
             category: "TODOs",
-            key: d(format!("{}", app.config.keybindings.todos.mark_as_read)),
+            key: d(app.config.keybindings.todos.mark_as_read.clone()),
             action: "Open todo target & mark read",
         },
         Shortcut {
             category: "TODOs",
-            key: d(format!("{}", app.config.keybindings.todos.open_in_browser)),
+            key: d(app.config.keybindings.todos.open_in_browser.clone()),
             action: "Open todo in browser",
         },
         // ── Terminal ──
@@ -1593,27 +1569,24 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Terminal",
-            key: d(format!("{}", app.config.keybindings.terminal.toggle_wrap)),
+            key: d(app.config.keybindings.terminal.toggle_wrap.clone()),
             action: "Toggle terminal line wrapping",
         },
         // ── Branches ──
         Shortcut {
             category: "Branches",
-            key: d(format!("{}", app.config.keybindings.branches.create_branch)),
+            key: d(app.config.keybindings.branches.create_branch.clone()),
             action: "Create new branch",
         },
         Shortcut {
             category: "Branches",
-            key: d(format!("{}", app.config.keybindings.branches.delete_branch)),
+            key: d(app.config.keybindings.branches.delete_branch.clone()),
             action: "Delete selected branch",
         },
         // ── Environments ──
         Shortcut {
             category: "Environments",
-            key: d(format!(
-                "{}",
-                app.config.keybindings.environments.view_deployments
-            )),
+            key: d(app.config.keybindings.environments.view_deployments.clone()),
             action: "View deployments list for environment",
         },
         // ── Diff View ──
@@ -1714,7 +1687,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Diff View",
-            key: s("? / F1"),
+            key: d(format!("{} / F1", app.config.keybindings.global.help)),
             action: "Show this help modal",
         },
         // ── Inspector / Editor ──
@@ -1745,7 +1718,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Inspector / Editor",
-            key: s("? / F1"),
+            key: d(format!("{} / F1", app.config.keybindings.global.help)),
             action: "Show this help modal",
         },
         // ── Selector / Filter ──
@@ -1776,7 +1749,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Selector / Filter",
-            key: s("? / F1"),
+            key: d(format!("{} / F1", app.config.keybindings.global.help)),
             action: "Show this help modal",
         },
         // ── Column Config ──
@@ -1797,7 +1770,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Column Config",
-            key: s("s"),
+            key: d(app.config.keybindings.global.save_view.clone()),
             action: "Save layout to config",
         },
         Shortcut {
@@ -1807,7 +1780,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Column Config",
-            key: s("? / F1"),
+            key: d(format!("{} / F1", app.config.keybindings.global.help)),
             action: "Show this help modal",
         },
         // ── Date Picker ──
@@ -1833,7 +1806,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Date Picker",
-            key: s("? / F1"),
+            key: d(format!("{} / F1", app.config.keybindings.global.help)),
             action: "Show this help modal",
         },
     ];

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -1656,11 +1656,6 @@ pub(crate) fn render_tab_jobs(
                 String::new()
             };
 
-            let help_text = if app.job_trace_wrap {
-                " Esc: Back | Enter: Zoom | j/k: Scroll | /: Search | f: Follow | w: No-wrap "
-            } else {
-                " Esc: Back | Enter: Zoom | j/k: Scroll | /: Search | f: Follow | w: Wrap "
-            };
             let search_suffix = if app.job_trace_search_query.is_empty() {
                 String::new()
             } else {
@@ -1682,13 +1677,6 @@ pub(crate) fn render_tab_jobs(
                     Style::default()
                         .fg(theme.text_muted)
                         .add_modifier(Modifier::BOLD),
-                )
-                .title_bottom(
-                    ratatui::text::Line::from(vec![Span::styled(
-                        help_text,
-                        Style::default().fg(theme.text_muted),
-                    )])
-                    .alignment(Alignment::Right),
                 )
                 .border_style(Style::default().fg(theme.border));
 


### PR DESCRIPTION
## Description

- **Universal Accessibility:** Ensure the help modal (`?` / `F1`) can be accessed from every view, overlay, and mode across the entire application—including Diff View, Inspector/Editor forms, Selector overlays, Column Configuration popup, Date Picker, and Submit Dialogs.
- **Text Input Disambiguation:** When actively typing in text fields or search bars, function key `F1` opens help while preserving `?` for text entry.
- **Z-Order Rendering:** Extracted `render_help` to the end of `render_overlays` so the help modal and search bar render on top of all underlying overlays and receive priority event dispatching.
- **Increased Dimensions:** Expanded help modal footprint from a fixed `90x40` box to responsive `centered_rect_min(90, 85, 95, 38, size)` with widened columns for Category, Key, and Action.
- **Dynamic Keybinding Configuration:** Bound all displayed shortcut keys across every section to `app.config.keybindings` instead of hardcoded strings so custom keybindings reflect accurately.
- **Removed Cluttered Inline Hints:** Removed the bottom controls hint footer from the diff view and bottom border helper text from job trace preview, recovering vertical view area.
- **Contextual & Global Shortcuts:** Added shortcuts for Inspector/Editor, Selector/Filter, Column Config, and Date Picker, while allowing real-time search across all shortcuts in the entire app.
- **Tests:** Added comprehensive test coverage for help keybinding handling across all view states.