### PR TITLE
feat(issues): add keybinding to copy issue as Markdown link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,6 +95,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
 ]
 
 [[package]]
@@ -298,6 +316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +510,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +527,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -510,8 +553,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "euclid"
@@ -585,6 +634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +654,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -650,6 +711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +748,7 @@ name = "glab-tui-crate"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "async-trait",
  "chrono",
  "clap",
@@ -696,13 +768,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -713,7 +794,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -964,7 +1045,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -988,6 +1069,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1026,6 +1116,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1094,6 +1267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1312,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap",
 ]
 
 [[package]]
@@ -1192,6 +1382,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -1441,7 +1637,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1621,7 +1817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1721,7 +1917,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1734,7 +1930,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1744,7 +1940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -1770,7 +1966,7 @@ dependencies = [
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -1895,7 +2091,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1947,6 +2143,17 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
 
 [[package]]
 name = "typenum"
@@ -2105,6 +2312,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,7 +2475,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2268,12 +2545,86 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2286,6 +2637,41 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.19",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1.89"
 clap = { version = "4", features = ["derive"] }
 serde_yaml = "0.9"
 pulldown-cmark = { version = "0.13.0", default-features = false }
+arboard = { version = "3.6.1", default-features = false, features = ["wayland-data-control"] }
 [dev-dependencies]
 libc = "0.2.186"
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Every table tab (Issues, MRs/PRs, Pipelines, Jobs, Runners, Releases, Todos, Mil
 | `r` | Reopen selected issue | `reopen_entity` |
 | `d` | Delete selected issue (with confirmation) | `delete_entity` |
 | `y` | Copy selected issue as `[#42: Title](URL)` | `copy_reference` |
-| `o` | Open selected issue in browser | — |
+| `o` | Open selected issue in browser | `open_in_browser` |
 | `Space` | Select issue for bulk editing | `select_issue` |
 | `v` | Toggle select mode (yazi-style contiguous selection) | `selection_toggle` |
 | `J` | Scroll description panel down | `scroll_down` |

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ next_tab = "l"
 [keybindings.issues]
 create_issue = "n"
 edit_entity = "e"
+copy_reference = "y"
 # ...
 
 # Persist default column visibility / grouping / filters per pane
@@ -434,6 +435,7 @@ Every table tab (Issues, MRs/PRs, Pipelines, Jobs, Runners, Releases, Todos, Mil
 | `c` | Close selected issue | `close_entity` |
 | `r` | Reopen selected issue | `reopen_entity` |
 | `d` | Delete selected issue (with confirmation) | `delete_entity` |
+| `y` | Copy selected issue as `[#42: Title](URL)` | `copy_reference` |
 | `o` | Open selected issue in browser | — |
 | `Space` | Select issue for bulk editing | `select_issue` |
 | `v` | Toggle select mode (yazi-style contiguous selection) | `selection_toggle` |

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,28 @@ static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 /// key press).
 static FUZZY_MATCHER: LazyLock<SkimMatcherV2> = LazyLock::new(SkimMatcherV2::default);
 
+trait ClipboardWriter {
+    fn set_text(&mut self, text: String) -> anyhow::Result<()>;
+}
+
+#[derive(Default)]
+struct SystemClipboard {
+    inner: Option<arboard::Clipboard>,
+}
+
+impl ClipboardWriter for SystemClipboard {
+    fn set_text(&mut self, text: String) -> anyhow::Result<()> {
+        if self.inner.is_none() {
+            self.inner = Some(arboard::Clipboard::new()?);
+        }
+        self.inner
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Clipboard is unavailable"))?
+            .set_text(text)?;
+        Ok(())
+    }
+}
+
 fn file_extension(file_path: &str) -> Option<&str> {
     let file_name = file_path.rsplit(|c| c == '/' || c == '\\').next()?;
     let ext = file_name.rsplit('.').next()?;
@@ -2836,6 +2858,7 @@ pub struct App {
     pub diff_loading: bool,
     pub todos: StatefulTable<crate::domain::notifications::Notification>,
     pub status_message: Option<String>,
+    clipboard: Box<dyn ClipboardWriter>,
     pub refreshed_tabs: std::collections::HashSet<Tab>,
     pub tx: Option<tokio::sync::mpsc::UnboundedSender<crate::event::Event>>,
     pub enabled_columns: std::collections::HashMap<Tab, std::collections::HashSet<String>>,
@@ -2939,6 +2962,7 @@ impl Default for App {
             diff_loading: false,
             todos: StatefulTable::with_items(vec![]),
             status_message: None,
+            clipboard: Box::new(SystemClipboard::default()),
             refreshed_tabs: std::collections::HashSet::new(),
             tx: None,
             enabled_columns: {
@@ -3004,6 +3028,23 @@ impl App {
         }
         self.prev_details_zoomed = self.details_zoomed;
         self.edit_menu = Some(menu);
+    }
+
+    pub fn selected_issue_reference(&self) -> Option<String> {
+        self.issues
+            .state
+            .selected()
+            .and_then(|index| self.filtered_issues().get(index).copied())
+            .filter(|issue| !issue.web_url.is_empty())
+            .map(crate::domain::issues::Issue::markdown_reference)
+    }
+
+    pub fn copy_selected_issue_reference(&mut self) -> anyhow::Result<()> {
+        let reference = self
+            .selected_issue_reference()
+            .ok_or_else(|| anyhow::anyhow!("Issue URL unavailable; refresh the Issues tab"))?;
+        self.clipboard.set_text(reference)?;
+        Ok(())
     }
 
     /// Ids and titles of the current bulk selection, sorted by iid. Built from
@@ -5524,6 +5565,95 @@ mod tests {
     use super::*;
 
     #[test]
+    fn selected_issue_reference_uses_the_highlighted_issue() {
+        let mut app = App::default();
+        app.issues.items = vec![
+            serde_json::from_str(
+                r#"{
+                    "iid": 42,
+                    "title": "Fix parser",
+                    "state": "opened",
+                    "labels": [],
+                    "updated_at": "2026-08-29T11:00:00Z",
+                    "author": {"username": "octocat"},
+                    "web_url": "https://github.com/acme/project/issues/42"
+                }"#,
+            )
+            .unwrap(),
+        ];
+        app.issues.state.select(Some(0));
+
+        assert_eq!(
+            app.selected_issue_reference().as_deref(),
+            Some("[#42: Fix parser](https://github.com/acme/project/issues/42)")
+        );
+    }
+
+    #[test]
+    fn copy_selected_issue_reference_preserves_existing_status() {
+        struct RecordingClipboard(std::rc::Rc<std::cell::RefCell<Option<String>>>);
+
+        impl ClipboardWriter for RecordingClipboard {
+            fn set_text(&mut self, text: String) -> anyhow::Result<()> {
+                *self.0.borrow_mut() = Some(text);
+                Ok(())
+            }
+        }
+
+        let copied = std::rc::Rc::new(std::cell::RefCell::new(None));
+        let mut app = App::default();
+        app.clipboard = Box::new(RecordingClipboard(copied.clone()));
+        app.issues.items = vec![
+            serde_json::from_str(
+                r#"{
+                    "iid": 42,
+                    "title": "Fix parser",
+                    "state": "opened",
+                    "labels": [],
+                    "updated_at": "2026-08-29T11:00:00Z",
+                    "author": {"username": "octocat"},
+                    "web_url": "https://github.com/acme/project/issues/42"
+                }"#,
+            )
+            .unwrap(),
+        ];
+        app.issues.state.select(Some(0));
+        app.status_message = Some("Loaded from offline cache".to_string());
+
+        app.copy_selected_issue_reference().unwrap();
+
+        assert_eq!(
+            copied.borrow().as_deref(),
+            Some("[#42: Fix parser](https://github.com/acme/project/issues/42)")
+        );
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some("Loaded from offline cache")
+        );
+    }
+
+    #[test]
+    fn selected_issue_reference_is_unavailable_without_a_url() {
+        let mut app = App::default();
+        app.issues.items = vec![
+            serde_json::from_str(
+                r#"{
+                    "iid": 42,
+                    "title": "Cached issue",
+                    "state": "opened",
+                    "labels": [],
+                    "updated_at": "2026-08-29T11:00:00Z",
+                    "author": {"username": "octocat"}
+                }"#,
+            )
+            .unwrap(),
+        ];
+        app.issues.state.select(Some(0));
+
+        assert_eq!(app.selected_issue_reference(), None);
+    }
+
+    #[test]
     fn bulk_selection_summary_lists_full_selection_sorted_by_iid() {
         let mut app = App::default();
         let mk_issue = |iid: u64, title: &str| crate::domain::issues::Issue {
@@ -5541,6 +5671,7 @@ mod tests {
             assignees: vec![],
             description: None,
             due_date: None,
+            web_url: String::new(),
         };
         app.issues.items = vec![
             mk_issue(3, "Third"),
@@ -5578,6 +5709,7 @@ mod tests {
             assignees: vec![],
             description: None,
             due_date: None,
+            web_url: String::new(),
         };
         app.issues.items = vec![mk_issue(1), mk_issue(2)];
         app.selected_issues.extend([1, 2]);
@@ -7254,6 +7386,7 @@ index 123456..789012 100644
             assignees: vec![],
             description: None,
             due_date: None,
+            web_url: String::new(),
         };
         let i_closed = crate::domain::issues::Issue {
             iid: 2,
@@ -7270,6 +7403,7 @@ index 123456..789012 100644
             assignees: vec![],
             description: None,
             due_date: None,
+            web_url: String::new(),
         };
         app.issues.items = vec![i_open, i_closed];
 

--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -30,6 +30,90 @@ fn normalize_labels(s: &str) -> String {
     s.replace(", ", ",")
 }
 
+#[derive(Deserialize)]
+struct GhIssueJson {
+    number: u64,
+    title: String,
+    state: String,
+    url: String,
+    #[serde(default)]
+    labels: Vec<serde_json::Value>,
+    author: Option<GhIssueLogin>,
+    body: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    #[serde(rename = "closedAt")]
+    closed_at: Option<String>,
+    milestone: Option<GhIssueMilestone>,
+    #[serde(default)]
+    assignees: Vec<GhIssueLogin>,
+}
+
+#[derive(Deserialize)]
+struct GhIssueLogin {
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct GhIssueMilestone {
+    title: String,
+}
+
+fn issue_from_gh_json(issue: GhIssueJson) -> Issue {
+    let state = if issue.state == "OPEN" {
+        "opened"
+    } else {
+        "closed"
+    }
+    .to_string();
+    let labels = issue
+        .labels
+        .iter()
+        .filter_map(|value| value.get("name")?.as_str().map(String::from))
+        .collect();
+
+    Issue {
+        iid: issue.number,
+        title: issue.title,
+        state,
+        labels,
+        updated_at: issue.updated_at,
+        created_at: Some(issue.created_at),
+        closed_at: issue.closed_at,
+        author: crate::domain::issues::Author {
+            username: issue.author.map(|author| author.login).unwrap_or_default(),
+        },
+        milestone: issue
+            .milestone
+            .map(|milestone| crate::domain::issues::Milestone {
+                title: milestone.title,
+            }),
+        assignees: issue
+            .assignees
+            .into_iter()
+            .map(|assignee| crate::domain::issues::Assignee {
+                username: assignee.login,
+            })
+            .collect(),
+        description: issue.body,
+        due_date: None,
+        web_url: issue.url,
+    }
+}
+
+fn parse_gh_issue(raw: &str) -> Result<Issue> {
+    Ok(issue_from_gh_json(serde_json::from_str(raw)?))
+}
+
+fn parse_gh_issues(raw: &str) -> Result<Vec<Issue>> {
+    Ok(serde_json::from_str::<Vec<GhIssueJson>>(raw)?
+        .into_iter()
+        .map(issue_from_gh_json)
+        .collect())
+}
+
 /// `None` for anything that is not a usable login, so an unknown user can
 /// never be mistaken for a known one. Never returns `Some("")`.
 fn parse_gh_login(raw: &str) -> Option<String> {
@@ -273,7 +357,7 @@ impl Backend for GhBackend {
                     "issue",
                     "list",
                     "--json",
-                    "number,title,state,labels,author,body,createdAt,updatedAt,closedAt,milestone,assignees",
+                    "number,title,state,labels,author,body,createdAt,updatedAt,closedAt,milestone,assignees,url",
                     "-R",
                     project,
                     "--state",
@@ -285,77 +369,7 @@ impl Backend for GhBackend {
             )
             .await?;
 
-        #[derive(Deserialize)]
-        struct GhIssue {
-            number: u64,
-            title: String,
-            state: String,
-            #[serde(default)]
-            labels: Vec<serde_json::Value>,
-            author: Option<GhLogin>,
-            body: Option<String>,
-            #[serde(rename = "createdAt")]
-            #[allow(dead_code)]
-            created_at: String,
-            #[serde(rename = "updatedAt")]
-            updated_at: String,
-            #[serde(rename = "closedAt")]
-            closed_at: Option<String>,
-            milestone: Option<GhMs>,
-            #[serde(default)]
-            assignees: Vec<GhLogin>,
-        }
-        #[derive(Deserialize)]
-        struct GhLogin {
-            login: String,
-        }
-        #[derive(Deserialize)]
-        struct GhMs {
-            title: String,
-        }
-
-        let gh_issues: Vec<GhIssue> = serde_json::from_str(&raw)?;
-        Ok(gh_issues
-            .into_iter()
-            .map(|gi| {
-                let state = if gi.state == "OPEN" {
-                    "opened"
-                } else {
-                    "closed"
-                }
-                .to_string();
-                let labels: Vec<String> = gi
-                    .labels
-                    .iter()
-                    .filter_map(|v| v.get("name")?.as_str().map(String::from))
-                    .collect();
-                let author = crate::domain::issues::Author {
-                    username: gi.author.map(|a| a.login).unwrap_or_default(),
-                };
-                let milestone = gi
-                    .milestone
-                    .map(|m| crate::domain::issues::Milestone { title: m.title });
-                let assignees: Vec<crate::domain::issues::Assignee> = gi
-                    .assignees
-                    .into_iter()
-                    .map(|a| crate::domain::issues::Assignee { username: a.login })
-                    .collect();
-                Issue {
-                    iid: gi.number,
-                    title: gi.title,
-                    state,
-                    labels,
-                    updated_at: gi.updated_at,
-                    created_at: Some(gi.created_at),
-                    closed_at: gi.closed_at,
-                    author,
-                    milestone,
-                    assignees,
-                    description: gi.body,
-                    due_date: None,
-                }
-            })
-            .collect())
+        parse_gh_issues(&raw)
     }
 
     async fn get_issue(&self, project: &str, iid: u64) -> Result<Issue> {
@@ -366,78 +380,14 @@ impl Backend for GhBackend {
                     "view",
                     &iid.to_string(),
                     "--json",
-                    "number,title,state,labels,author,body,createdAt,updatedAt,closedAt,milestone,assignees",
+                    "number,title,state,labels,author,body,createdAt,updatedAt,closedAt,milestone,assignees,url",
                     "-R",
                     project,
                 ],
                 "Fetching Issue",
             )
             .await?;
-        #[derive(Deserialize)]
-        struct GhIssue {
-            number: u64,
-            title: String,
-            state: String,
-            #[serde(default)]
-            labels: Vec<serde_json::Value>,
-            author: Option<GhLogin>,
-            body: Option<String>,
-            #[serde(rename = "createdAt")]
-            #[allow(dead_code)]
-            created_at: String,
-            #[serde(rename = "updatedAt")]
-            updated_at: String,
-            #[serde(rename = "closedAt")]
-            closed_at: Option<String>,
-            milestone: Option<GhMs>,
-            #[serde(default)]
-            assignees: Vec<GhLogin>,
-        }
-        #[derive(Deserialize)]
-        struct GhLogin {
-            login: String,
-        }
-        #[derive(Deserialize)]
-        struct GhMs {
-            title: String,
-        }
-        let gi: GhIssue = serde_json::from_str(&raw)?;
-        let state = if gi.state == "OPEN" {
-            "opened"
-        } else {
-            "closed"
-        }
-        .to_string();
-        let labels: Vec<String> = gi
-            .labels
-            .iter()
-            .filter_map(|v| v.get("name")?.as_str().map(String::from))
-            .collect();
-        let author = crate::domain::issues::Author {
-            username: gi.author.map(|a| a.login).unwrap_or_default(),
-        };
-        let milestone = gi
-            .milestone
-            .map(|m| crate::domain::issues::Milestone { title: m.title });
-        let assignees: Vec<crate::domain::issues::Assignee> = gi
-            .assignees
-            .into_iter()
-            .map(|a| crate::domain::issues::Assignee { username: a.login })
-            .collect();
-        Ok(Issue {
-            iid: gi.number,
-            title: gi.title,
-            state,
-            labels,
-            updated_at: gi.updated_at,
-            created_at: Some(gi.created_at),
-            closed_at: gi.closed_at,
-            author,
-            milestone,
-            assignees,
-            description: gi.body,
-            due_date: None,
-        })
+        parse_gh_issue(&raw)
     }
 
     async fn close_issue(&self, project: &str, iid: u64) -> Result<()> {
@@ -1603,7 +1553,7 @@ impl Backend for GhBackend {
                     "issue",
                     "list",
                     "--json",
-                    "number,title,state,labels,author,body,createdAt,updatedAt,closedAt,milestone,assignees",
+                    "number,title,state,labels,author,body,createdAt,updatedAt,closedAt,milestone,assignees,url",
                     "-R",
                     project,
                     "--milestone",
@@ -1616,76 +1566,7 @@ impl Backend for GhBackend {
                 "Fetching Milestone Issues",
             )
             .await?;
-        #[derive(Deserialize)]
-        struct GhIssue {
-            number: u64,
-            title: String,
-            state: String,
-            #[serde(default)]
-            labels: Vec<serde_json::Value>,
-            author: Option<GhLogin>,
-            body: Option<String>,
-            #[serde(rename = "createdAt")]
-            #[allow(dead_code)]
-            created_at: String,
-            #[serde(rename = "updatedAt")]
-            updated_at: String,
-            #[serde(rename = "closedAt")]
-            closed_at: Option<String>,
-            milestone: Option<GhMs>,
-            #[serde(default)]
-            assignees: Vec<GhLogin>,
-        }
-        #[derive(Deserialize)]
-        struct GhLogin {
-            login: String,
-        }
-        #[derive(Deserialize)]
-        struct GhMs {
-            title: String,
-        }
-        let gh_issues: Vec<GhIssue> = serde_json::from_str(&raw)?;
-        Ok(gh_issues
-            .into_iter()
-            .map(|gi| {
-                let state = if gi.state == "OPEN" {
-                    "opened"
-                } else {
-                    "closed"
-                }
-                .to_string();
-                let labels: Vec<String> = gi
-                    .labels
-                    .iter()
-                    .filter_map(|v| v.get("name")?.as_str().map(String::from))
-                    .collect();
-                let author = crate::domain::issues::Author {
-                    username: gi.author.map(|a| a.login).unwrap_or_default(),
-                };
-                let milestone = gi
-                    .milestone
-                    .map(|m| crate::domain::issues::Milestone { title: m.title });
-                let assignees: Vec<crate::domain::issues::Assignee> = gi
-                    .assignees
-                    .into_iter()
-                    .map(|a| crate::domain::issues::Assignee { username: a.login })
-                    .collect();
-                Issue {
-                    iid: gi.number,
-                    title: gi.title,
-                    state,
-                    labels,
-                    updated_at: gi.updated_at,
-                    created_at: Some(gi.created_at),
-                    closed_at: gi.closed_at,
-                    author,
-                    milestone,
-                    assignees,
-                    description: gi.body,
-                    due_date: None,
-                }
-            })
-            .collect())
+        parse_gh_issues(&raw)
     }
 
     async fn create_milestone(
@@ -2363,6 +2244,57 @@ mod tests {
         assert_eq!(normalize_labels("bug, feature"), "bug,feature");
         assert_eq!(normalize_labels("bug,feature"), "bug,feature");
         assert_eq!(normalize_labels("bug"), "bug");
+    }
+
+    #[test]
+    fn github_issue_json_produces_a_copyable_reference() {
+        let raw = r#"{
+            "number": 42,
+            "title": "Fix parser",
+            "state": "OPEN",
+            "labels": [{"name": "bug"}],
+            "author": {"login": "octocat"},
+            "body": "Details",
+            "createdAt": "2026-08-29T10:00:00Z",
+            "updatedAt": "2026-08-29T11:00:00Z",
+            "closedAt": null,
+            "milestone": null,
+            "assignees": [],
+            "url": "https://github.com/acme/project/issues/42"
+        }"#;
+
+        let issue = parse_gh_issue(raw).unwrap();
+
+        assert_eq!(
+            issue.markdown_reference(),
+            "[#42: Fix parser](https://github.com/acme/project/issues/42)"
+        );
+    }
+
+    #[test]
+    fn github_issue_list_json_keeps_each_copyable_url() {
+        let raw = r#"[{
+            "number": 42,
+            "title": "Fix parser",
+            "state": "OPEN",
+            "labels": [],
+            "author": {"login": "octocat"},
+            "body": null,
+            "createdAt": "2026-08-29T10:00:00Z",
+            "updatedAt": "2026-08-29T11:00:00Z",
+            "closedAt": null,
+            "milestone": null,
+            "assignees": [],
+            "url": "https://github.com/acme/project/issues/42"
+        }]"#;
+
+        let issues = parse_gh_issues(raw).unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(
+            issues[0].markdown_reference(),
+            "[#42: Fix parser](https://github.com/acme/project/issues/42)"
+        );
     }
 
     #[test]

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -31,6 +31,14 @@ fn normalize_labels(s: &str) -> String {
     s.replace(", ", ",")
 }
 
+fn parse_glab_issue(raw: &str) -> Result<Issue> {
+    Ok(serde_json::from_str(raw)?)
+}
+
+fn parse_glab_issues(raw: &str) -> Result<Vec<Issue>> {
+    Ok(serde_json::from_str(raw)?)
+}
+
 /// Number of `--per-page per_request` calls needed to cover a `page_size` item budget.
 fn page_count(page_size: usize, per_request: usize) -> usize {
     page_size.div_ceil(per_request.max(1)).max(1)
@@ -543,66 +551,7 @@ impl Backend for GlabBackend {
 
         let mut all: Vec<Issue> = Vec::new();
         for raw in responses {
-            #[derive(Deserialize)]
-            struct GiIssue {
-                iid: u64,
-                title: String,
-                state: String,
-                #[serde(default)]
-                labels: Vec<String>,
-                updated_at: String,
-                #[serde(default)]
-                created_at: Option<String>,
-                #[serde(default)]
-                closed_at: Option<String>,
-                author: GiAuthor,
-                milestone: Option<GiMilestone>,
-                #[serde(default)]
-                assignees: Vec<GiAssignee>,
-                #[serde(default)]
-                description: Option<String>,
-                #[serde(default)]
-                due_date: Option<String>,
-            }
-            #[derive(Deserialize)]
-            struct GiAuthor {
-                username: String,
-            }
-            #[derive(Deserialize)]
-            struct GiMilestone {
-                title: String,
-            }
-            #[derive(Deserialize)]
-            struct GiAssignee {
-                username: String,
-            }
-            let issues: Vec<GiIssue> = serde_json::from_str(&raw).unwrap_or_default();
-            all.extend(issues.into_iter().map(|i| {
-                Issue {
-                    iid: i.iid,
-                    title: i.title,
-                    state: i.state,
-                    labels: i.labels,
-                    updated_at: i.updated_at,
-                    created_at: i.created_at,
-                    closed_at: i.closed_at,
-                    author: crate::domain::issues::Author {
-                        username: i.author.username,
-                    },
-                    milestone: i
-                        .milestone
-                        .map(|m| crate::domain::issues::Milestone { title: m.title }),
-                    assignees: i
-                        .assignees
-                        .into_iter()
-                        .map(|a| crate::domain::issues::Assignee {
-                            username: a.username,
-                        })
-                        .collect(),
-                    description: i.description,
-                    due_date: i.due_date,
-                }
-            }));
+            all.extend(parse_glab_issues(&raw).unwrap_or_default());
         }
         Ok(all)
     }
@@ -622,64 +571,7 @@ impl Backend for GlabBackend {
                 "Fetching Issue",
             )
             .await?;
-        #[derive(Deserialize)]
-        struct GiIssue {
-            iid: u64,
-            title: String,
-            state: String,
-            #[serde(default)]
-            labels: Vec<String>,
-            updated_at: String,
-            #[serde(default)]
-            created_at: Option<String>,
-            #[serde(default)]
-            closed_at: Option<String>,
-            author: GiAuthor,
-            milestone: Option<GiMilestone>,
-            #[serde(default)]
-            assignees: Vec<GiAssignee>,
-            #[serde(default)]
-            description: Option<String>,
-            #[serde(default)]
-            due_date: Option<String>,
-        }
-        #[derive(Deserialize)]
-        struct GiAuthor {
-            username: String,
-        }
-        #[derive(Deserialize)]
-        struct GiMilestone {
-            title: String,
-        }
-        #[derive(Deserialize)]
-        struct GiAssignee {
-            username: String,
-        }
-        let i: GiIssue = serde_json::from_str(&raw)?;
-        Ok(Issue {
-            iid: i.iid,
-            title: i.title,
-            state: i.state,
-            labels: i.labels,
-            updated_at: i.updated_at,
-            created_at: i.created_at,
-            closed_at: i.closed_at,
-            author: crate::domain::issues::Author {
-                username: i.author.username,
-            },
-            milestone: i
-                .milestone
-                .map(|m| crate::domain::issues::Milestone { title: m.title }),
-            assignees: i
-                .assignees
-                .into_iter()
-                .map(|a| crate::domain::issues::Assignee {
-                    username: a.username,
-                })
-                .collect(),
-            description: i.description,
-            due_date: i.due_date,
-        })
+        parse_glab_issue(&raw)
     }
 
     async fn close_issue(&self, project: &str, iid: u64) -> Result<()> {
@@ -1905,67 +1797,7 @@ impl Backend for GlabBackend {
                 "Fetching Milestone Issues",
             )
             .await?;
-        #[derive(Deserialize)]
-        struct GiIssue {
-            iid: u64,
-            title: String,
-            state: String,
-            #[serde(default)]
-            labels: Vec<String>,
-            updated_at: String,
-            #[serde(default)]
-            created_at: Option<String>,
-            #[serde(default)]
-            closed_at: Option<String>,
-            author: GiAuthor,
-            milestone: Option<GiMilestone>,
-            #[serde(default)]
-            assignees: Vec<GiAssignee>,
-            #[serde(default)]
-            description: Option<String>,
-            #[serde(default)]
-            due_date: Option<String>,
-        }
-        #[derive(Deserialize)]
-        struct GiAuthor {
-            username: String,
-        }
-        #[derive(Deserialize)]
-        struct GiMilestone {
-            title: String,
-        }
-        #[derive(Deserialize)]
-        struct GiAssignee {
-            username: String,
-        }
-        let issues: Vec<GiIssue> = serde_json::from_str(&raw)?;
-        Ok(issues
-            .into_iter()
-            .map(|i| Issue {
-                iid: i.iid,
-                title: i.title,
-                state: i.state,
-                labels: i.labels,
-                updated_at: i.updated_at,
-                created_at: i.created_at,
-                closed_at: i.closed_at,
-                author: crate::domain::issues::Author {
-                    username: i.author.username,
-                },
-                milestone: i
-                    .milestone
-                    .map(|m| crate::domain::issues::Milestone { title: m.title }),
-                assignees: i
-                    .assignees
-                    .into_iter()
-                    .map(|a| crate::domain::issues::Assignee {
-                        username: a.username,
-                    })
-                    .collect(),
-                description: i.description,
-                due_date: i.due_date,
-            })
-            .collect())
+        parse_glab_issues(&raw)
     }
 
     async fn create_milestone(
@@ -2542,6 +2374,59 @@ async fn run_glab_raw_api(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gitlab_issue_json_produces_a_copyable_reference() {
+        let raw = r#"{
+            "iid": 42,
+            "title": "Fix parser",
+            "state": "opened",
+            "labels": ["bug"],
+            "updated_at": "2026-08-29T11:00:00Z",
+            "created_at": "2026-08-29T10:00:00Z",
+            "closed_at": null,
+            "author": {"username": "octocat"},
+            "milestone": null,
+            "assignees": [],
+            "description": "Details",
+            "due_date": null,
+            "web_url": "https://gitlab.com/acme/project/-/issues/42"
+        }"#;
+
+        let issue = parse_glab_issue(raw).unwrap();
+
+        assert_eq!(
+            issue.markdown_reference(),
+            "[#42: Fix parser](https://gitlab.com/acme/project/-/issues/42)"
+        );
+    }
+
+    #[test]
+    fn gitlab_issue_list_json_keeps_each_copyable_url() {
+        let raw = r#"[{
+            "iid": 42,
+            "title": "Fix parser",
+            "state": "opened",
+            "labels": [],
+            "updated_at": "2026-08-29T11:00:00Z",
+            "created_at": "2026-08-29T10:00:00Z",
+            "closed_at": null,
+            "author": {"username": "octocat"},
+            "milestone": null,
+            "assignees": [],
+            "description": null,
+            "due_date": null,
+            "web_url": "https://gitlab.com/acme/project/-/issues/42"
+        }]"#;
+
+        let issues = parse_glab_issues(raw).unwrap();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(
+            issues[0].markdown_reference(),
+            "[#42: Fix parser](https://gitlab.com/acme/project/-/issues/42)"
+        );
+    }
 
     #[test]
     fn merge_args_skip_confirmation_prompt() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -691,6 +691,8 @@ pub struct KeybindingIssues {
     pub create_mr: String,
     #[serde(default = "def_open_in_browser")]
     pub open_in_browser: String,
+    #[serde(default = "def_copy_reference")]
+    pub copy_reference: String,
     #[serde(default)]
     pub selection_toggle: String,
 }
@@ -892,6 +894,7 @@ keybind_defaults! {
     def_create_issue = "n",
     def_select_issue = "Space",
     def_create_mr_issue = "m",
+    def_copy_reference = "y",
     def_edit_entity = "e",
     def_close_entity = "c",
     def_reopen_entity = "r",
@@ -973,6 +976,7 @@ impl Default for KeybindingIssues {
             select_issue: def_select_issue(),
             create_mr: def_create_mr_issue(),
             open_in_browser: def_open_in_browser(),
+            copy_reference: def_copy_reference(),
             selection_toggle: def_selection_toggle(),
         }
     }
@@ -1876,6 +1880,11 @@ page_size = 250
         assert_eq!(github.backend, Some(crate::backend::BackendKind::GitHub));
         let gitlab: Config = toml::from_str("backend = \"gitlab\"").expect("parse config");
         assert_eq!(gitlab.backend, Some(crate::backend::BackendKind::GitLab));
+    }
+
+    #[test]
+    fn copy_issue_reference_defaults_to_y() {
+        assert_eq!(Config::default().keybindings.issues.copy_reference, "y");
     }
 
     #[test]

--- a/src/domain/issues.rs
+++ b/src/domain/issues.rs
@@ -34,6 +34,19 @@ pub struct Issue {
     pub description: Option<String>,
     #[serde(default)]
     pub due_date: Option<String>,
+    #[serde(default)]
+    pub web_url: String,
+}
+
+impl Issue {
+    pub fn markdown_reference(&self) -> String {
+        let title = self
+            .title
+            .replace('\\', "\\\\")
+            .replace('[', "\\[")
+            .replace(']', "\\]");
+        format!("[#{}: {}]({})", self.iid, title, self.web_url)
+    }
 }
 
 pub async fn list_issues(
@@ -60,6 +73,48 @@ pub async fn get_issue(client: &GitlabClient, project_path: &str, iid: u64) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn issue_reference_is_a_markdown_link_with_id_and_title() {
+        let issue: Issue = serde_json::from_str(
+            r#"{
+                "iid": 42,
+                "title": "Fix parser",
+                "state": "opened",
+                "labels": [],
+                "updated_at": "2026-07-03T00:00:00Z",
+                "author": { "username": "testuser" },
+                "web_url": "https://github.com/acme/project/issues/42"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            issue.markdown_reference(),
+            "[#42: Fix parser](https://github.com/acme/project/issues/42)"
+        );
+    }
+
+    #[test]
+    fn issue_reference_escapes_markdown_link_text() {
+        let issue: Issue = serde_json::from_str(
+            r#"{
+                "iid": 42,
+                "title": "Fix [parser] \\ paths",
+                "state": "opened",
+                "labels": [],
+                "updated_at": "2026-07-03T00:00:00Z",
+                "author": { "username": "testuser" },
+                "web_url": "https://github.com/acme/project/issues/42"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            issue.markdown_reference(),
+            r"[#42: Fix \[parser\] \\ paths](https://github.com/acme/project/issues/42)"
+        );
+    }
 
     #[test]
     fn test_deserialize_issue_due_date() {

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -1625,6 +1625,7 @@ mod tests {
             assignees: vec![],
             description: None,
             due_date: None,
+            web_url: String::new(),
         };
         app.issues.items = vec![issue];
 

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -151,6 +151,11 @@ pub async fn handle_active_tab_key(
                     }
                 }
             }
+            _ if keybinding_matches(&app.config.keybindings.issues.copy_reference, key_event) => {
+                if let Err(error) = app.copy_selected_issue_reference() {
+                    app.show_error(format!("Failed to copy issue reference: {error}"));
+                }
+            }
             _ if keybinding_matches(&app.config.keybindings.issues.open_in_browser, key_event) => {
                 if let Some(selected_idx) = app.issues.state.selected() {
                     if let Some(issue) = app.filtered_issues().get(selected_idx) {

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1278,6 +1278,11 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Issues",
+            key: d(app.config.keybindings.issues.copy_reference.clone()),
+            action: "Copy selected Issue as Markdown link",
+        },
+        Shortcut {
+            category: "Issues",
             key: d(app.config.keybindings.issues.open_in_browser.clone()),
             action: "Open selected Issue in browser",
         },


### PR DESCRIPTION
## What

- add a remappable `issues.copy_reference` keybinding, defaulting to `y`
- copy the selected issue as `[#42: Title](URL)` with escaped Markdown link text
- retain canonical GitHub and GitLab issue URLs while keeping old caches compatible
- support macOS, Windows, X11, and native Wayland clipboards

## Verification

- `cargo test` — 311 unit tests and 71 end-to-end tests
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check`
- manually verified through the Herdr development build on macOS