### PR TITLE
fix(merge): stop passing --auto-merge=false to glab mr merge (#372)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2790,6 +2790,11 @@ pub struct App {
     pub job_trace: Option<String>,
     pub error_message: Option<String>,
     pub error_message_at: Option<std::time::Instant>,
+    /// True when the current error toast originated from a real glab/gh CLI
+    /// failure (stderr is captured in the terminal log).  False for guard
+    /// rejections that never ran a CLI command.  Controls the hint line shown
+    /// in the toast.
+    pub error_has_cli_detail: bool,
     pub runners: StatefulTable<crate::domain::runners::Runner>,
     pub releases: StatefulTable<crate::domain::releases::Release>,
     pub pipeline_jobs: std::collections::HashMap<u64, Vec<crate::domain::pipelines::Job>>,
@@ -2900,6 +2905,7 @@ impl Default for App {
             job_trace: None,
             error_message: None,
             error_message_at: None,
+            error_has_cli_detail: false,
             runners: StatefulTable::with_items(vec![]),
             releases: StatefulTable::with_items(vec![]),
             pipeline_jobs: std::collections::HashMap::new(),

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -480,9 +480,13 @@ impl GlabBackend {
         }
         if auto_merge {
             args.push("--auto-merge=true".into());
-        } else {
-            args.push("--auto-merge=false".into());
         }
+        // When auto_merge is false we intentionally omit the flag and let
+        // `glab` decide: it defaults to --auto-merge when a pipeline is
+        // running, and merges immediately when the pipeline is absent/done.
+        // Passing --auto-merge=false forces an immediate merge attempt which
+        // causes glab to exhaust its internal retry loop ("All attempts fail")
+        // whenever a pipeline is still in progress (#372).
         args.push("--yes".into());
         args
     }
@@ -2557,10 +2561,30 @@ mod tests {
                 "group/project",
                 "--squash",
                 "--remove-source-branch",
-                "--auto-merge=false",
+                // No --auto-merge flag when auto_merge=false; glab decides based on
+                // pipeline state, avoiding "All attempts fail" for in-progress pipelines.
                 "--yes",
             ]
         );
+        // Explicitly verify --auto-merge=false is never injected.
+        assert!(!args.contains(&"--auto-merge=false".to_string()));
+    }
+
+    #[test]
+    fn merge_args_auto_merge_true_adds_flag() {
+        let args = GlabBackend::merge_args("group/project", 42, false, false, None, true);
+        assert!(args.contains(&"--auto-merge=true".to_string()));
+        assert!(!args.contains(&"--auto-merge=false".to_string()));
+    }
+
+    #[test]
+    fn merge_args_auto_merge_false_omits_flag() {
+        // When the user does not check "Auto-merge", we must not pass
+        // --auto-merge=false because that forces glab to attempt an immediate
+        // merge even when a pipeline is still running, causing it to exhaust
+        // its internal retry loop with "All attempts fail" (#372).
+        let args = GlabBackend::merge_args("group/project", 42, false, false, None, false);
+        assert!(!args.iter().any(|a| a.starts_with("--auto-merge")));
     }
 
     #[test]

--- a/src/handlers/overlays.rs
+++ b/src/handlers/overlays.rs
@@ -389,7 +389,15 @@ fn run_submit_action(
                     .await;
                 let _ = tx2.send(Event::CommandCompleted(
                     crate::app::Tab::MergeRequests,
-                    result.map_err(|e| e.to_string()),
+                    result.map_err(|e| {
+                        // Strip the verbose glab prefix so the toast stays readable.
+                        e.to_string()
+                            .trim_start_matches("glab command failed: ")
+                            .lines()
+                            .next()
+                            .unwrap_or("merge failed")
+                            .to_string()
+                    }),
                 ));
             });
         }
@@ -407,8 +415,9 @@ fn run_submit_action(
             };
             let project_path = app.project_context.clone();
             let tx2 = tx.clone();
+            let total = iids.len();
             tokio::spawn(async move {
-                let mut failures = Vec::new();
+                let mut failures: Vec<(u64, String)> = Vec::new();
                 for (i, mr_iid) in iids.into_iter().enumerate() {
                     if i > 0 {
                         crate::backend::rate_limit::pace_bulk_operation().await;
@@ -425,7 +434,7 @@ fn run_submit_action(
                         .await
                     {
                         Ok(_) => {}
-                        Err(e) => failures.push(format!("#{mr_iid}: {e}")),
+                        Err(e) => failures.push((mr_iid, e.to_string())),
                     }
                 }
                 let _ = tx2.send(Event::CommandCompleted(
@@ -433,7 +442,26 @@ fn run_submit_action(
                     if failures.is_empty() {
                         Ok(())
                     } else {
-                        Err(failures.join(", "))
+                        let succeeded = total - failures.len();
+                        // Build a concise summary: "2/5 merged. Failed: #12: ..., #34: ..."
+                        // Truncate individual error messages so the toast stays readable.
+                        let detail: Vec<String> = failures
+                            .iter()
+                            .map(|(iid, err)| {
+                                // Trim the verbose glab prefix from error strings.
+                                let trimmed = err
+                                    .trim_start_matches("glab command failed: ")
+                                    .lines()
+                                    .next()
+                                    .unwrap_or(err.as_str());
+                                format!("#{iid}: {trimmed}")
+                            })
+                            .collect();
+                        Err(format!(
+                            "{succeeded}/{total} merged. {} failed: {}",
+                            failures.len(),
+                            detail.join(", ")
+                        ))
                     },
                 ));
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1499,6 +1499,8 @@ async fn main() -> Result<()> {
                         }
                         Err(err) => {
                             app.show_error(err);
+                            // CLI failure: full stderr is in the terminal log.
+                            app.error_has_cli_detail = true;
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1045,6 +1045,7 @@ async fn main() -> Result<()> {
                             }
                             Err(e) => {
                                 app.show_error(e);
+                                app.error_has_cli_detail = true;
                             }
                         }
                     }
@@ -1371,6 +1372,7 @@ async fn main() -> Result<()> {
                         app.status_message = Some("Offline / Connection failed".to_string());
                     } else {
                         app.show_error(err_msg);
+                        app.error_has_cli_detail = true;
                     }
                 }
                 Event::DiffFetched {
@@ -1400,6 +1402,7 @@ async fn main() -> Result<()> {
                 Event::DiffFetchFailed(err_msg) => {
                     app.diff_loading = false;
                     app.show_error(err_msg);
+                    app.error_has_cli_detail = true;
                 }
                 Event::TerminalCommandLogged {
                     timestamp,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1951,23 +1951,29 @@ pub fn render(f: &mut Frame, app: &mut App) {
             if at.elapsed() > std::time::Duration::from_secs(5) {
                 app.error_message = None;
                 app.error_message_at = None;
+                app.error_has_cli_detail = false;
             }
         }
     }
     if let Some(ref msg) = app.error_message {
         let theme = THEME.read().unwrap();
         let icons = ICONS.read().unwrap();
+        let show_hint = app.error_has_cli_detail;
 
         // First content line: "  <icon> <msg>  "
         let label = format!("  {} {}  ", icons.status_failed, msg);
         let hint = "  Full details in the terminal log below  ";
 
-        // Box width: widest of the two content lines, capped to terminal width
-        let content_w = label.chars().count().max(hint.chars().count()) as u16;
+        // Box width: content line width (plus hint width when shown), capped to terminal width
+        let content_w = if show_hint {
+            label.chars().count().max(hint.chars().count()) as u16
+        } else {
+            label.chars().count() as u16
+        };
         let inner_w = content_w.min(size.width.saturating_sub(4));
         let box_w = inner_w + 2;
-        // 4 rows: top border + error line + hint line + bottom border
-        let box_h = 4u16;
+        // 4 rows when hint is shown, 3 rows otherwise
+        let box_h = if show_hint { 4u16 } else { 3u16 };
         let box_x = size.x + (size.width.saturating_sub(box_w)) / 2;
         let box_y = size.height.saturating_sub(box_h + 1);
         let toast_area = Rect::new(box_x, box_y, box_w, box_h);
@@ -1988,29 +1994,39 @@ pub fn render(f: &mut Frame, app: &mut App) {
         let inner = block.inner(toast_area);
         f.render_widget(block, toast_area);
 
-        // Split inner into two rows: error message + hint
-        use ratatui::layout::Layout;
-        let rows = Layout::default()
-            .direction(ratatui::layout::Direction::Vertical)
-            .constraints([
-                ratatui::layout::Constraint::Length(1),
-                ratatui::layout::Constraint::Length(1),
-            ])
-            .split(inner);
+        if show_hint {
+            // Split inner into two rows: error message + hint
+            use ratatui::layout::Layout;
+            let rows = Layout::default()
+                .direction(ratatui::layout::Direction::Vertical)
+                .constraints([
+                    ratatui::layout::Constraint::Length(1),
+                    ratatui::layout::Constraint::Length(1),
+                ])
+                .split(inner);
 
-        // Row 0 — error message (truncated, bold red)
-        let display = truncate(&label, rows[0].width as usize);
-        let toast = Paragraph::new(display.as_str())
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(theme.red).add_modifier(Modifier::BOLD))
-            .wrap(Wrap { trim: false });
-        f.render_widget(toast, rows[0]);
+            // Row 0 — error message (truncated, bold red)
+            let display = truncate(&label, rows[0].width as usize);
+            let toast = Paragraph::new(display.as_str())
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(theme.red).add_modifier(Modifier::BOLD))
+                .wrap(Wrap { trim: false });
+            f.render_widget(toast, rows[0]);
 
-        // Row 1 — muted hint pointing to the terminal log
-        let hint_display = truncate(hint, rows[1].width as usize);
-        let hint_widget = Paragraph::new(hint_display.as_str())
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(theme.text_muted));
-        f.render_widget(hint_widget, rows[1]);
+            // Row 1 — muted hint pointing to the terminal log
+            let hint_display = truncate(hint, rows[1].width as usize);
+            let hint_widget = Paragraph::new(hint_display.as_str())
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(theme.text_muted));
+            f.render_widget(hint_widget, rows[1]);
+        } else {
+            // No hint — single content row, truncated to inner width
+            let display = truncate(&label, inner.width as usize);
+            let toast = Paragraph::new(display.as_str())
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(theme.red).add_modifier(Modifier::BOLD))
+                .wrap(Wrap { trim: false });
+            f.render_widget(toast, inner);
+        }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1958,13 +1958,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
         let theme = THEME.read().unwrap();
         let icons = ICONS.read().unwrap();
 
-        // Inner content: "  <icon> <msg>  "
+        // First content line: "  <icon> <msg>  "
         let label = format!("  {} {}  ", icons.status_failed, msg);
-        // Box width: content + 2 border chars, capped to terminal width
-        let inner_w = (label.chars().count() as u16).min(size.width.saturating_sub(4));
+        let hint = "  Full details in the terminal log below  ";
+
+        // Box width: widest of the two content lines, capped to terminal width
+        let content_w = label.chars().count().max(hint.chars().count()) as u16;
+        let inner_w = content_w.min(size.width.saturating_sub(4));
         let box_w = inner_w + 2;
-        // Anchor near the bottom but above the last row so the border is never clipped
-        let box_h = 3u16;
+        // 4 rows: top border + error line + hint line + bottom border
+        let box_h = 4u16;
         let box_x = size.x + (size.width.saturating_sub(box_w)) / 2;
         let box_y = size.height.saturating_sub(box_h + 1);
         let toast_area = Rect::new(box_x, box_y, box_w, box_h);
@@ -1985,12 +1988,29 @@ pub fn render(f: &mut Frame, app: &mut App) {
         let inner = block.inner(toast_area);
         f.render_widget(block, toast_area);
 
-        // Truncate label to inner width so it never overflows the border
-        let display = truncate(&label, inner.width as usize);
+        // Split inner into two rows: error message + hint
+        use ratatui::layout::Layout;
+        let rows = Layout::default()
+            .direction(ratatui::layout::Direction::Vertical)
+            .constraints([
+                ratatui::layout::Constraint::Length(1),
+                ratatui::layout::Constraint::Length(1),
+            ])
+            .split(inner);
+
+        // Row 0 — error message (truncated, bold red)
+        let display = truncate(&label, rows[0].width as usize);
         let toast = Paragraph::new(display.as_str())
             .alignment(Alignment::Center)
             .style(Style::default().fg(theme.red).add_modifier(Modifier::BOLD))
             .wrap(Wrap { trim: false });
-        f.render_widget(toast, inner);
+        f.render_widget(toast, rows[0]);
+
+        // Row 1 — muted hint pointing to the terminal log
+        let hint_display = truncate(hint, rows[1].width as usize);
+        let hint_widget = Paragraph::new(hint_display.as_str())
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(theme.text_muted));
+        f.render_widget(hint_widget, rows[1]);
     }
 }


### PR DESCRIPTION
## Problem

When merging MRs (single or bulk), `glab mr merge` was always called with `--auto-merge=false`. This forces an immediate merge attempt regardless of pipeline state. When a pipeline is still running, `glab` exhausts its internal retry loop and surfaces **"All attempts fail"** to the user with no actionable detail.

Renovate-heavy repos like the reporter's (720 MRs, 25 open) are particularly affected because their open MRs almost always have in-progress pipelines.

## Root cause

`GlabBackend::merge_args()` unconditionally appended `--auto-merge=false` even when the user did not check "Auto-merge" in the confirm dialog.

## Fix

- **Omit `--auto-merge` entirely** when the user hasn't checked "Auto-merge". `glab` then uses its own heuristic: auto-merge when a pipeline is running, immediate merge when it's done.
- **Only pass `--auto-merge=true`** when the user explicitly opts in via the dialog.
- **Better bulk-merge error reporting**: instead of joining every raw `glab` stderr blob into a comma-separated wall of text, emit a concise `"N/M merged. K failed: #iid: <error>"` summary.
- **Strip the verbose `glab command failed: ` prefix** from single and bulk merge errors so the toast is readable at a glance.

## Tests

- Updated existing `merge_args_skip_confirmation_prompt` test (removed expectation of `--auto-merge=false`)
- Added `merge_args_auto_merge_true_adds_flag` — asserts `--auto-merge=true` only appears when explicitly requested
- Added `merge_args_auto_merge_false_omits_flag` — asserts no `--auto-merge` flag when not requested

Closes #372