### PR TITLE
feat(issues): jump to related MRs/PRs from issue preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.9.1] - 2026-09-07
-
-### Features
-- **GitLab group-level backend foundation** — Added `Scope` enum (`Repository` / `Group`), `-g`/`--group` CLI flag, and `list_group_issues` / `list_group_mrs` / `list_group_pipelines` backend methods that hit `GET /groups/{id}/issues`, `/merge_requests`, `/pipelines` via `glab api` (aggregating across all projects in the group with `%2F`-encoded paths). Group context can be inferred from a remote URL (`git_helpers::parse_group`, web URLs via `parse_project_path_from_web_url`), the `--group` flag, or `config.group`. Recent groups are cached in `recent_groups.json`. GitHub has no org-level listing equivalent, so group-backed GitHub listings return `Err` (#330).
-- **Copy issue as Markdown reference** — New `copy_reference` keybinding (default `y`) on the Issues tab copies the selected issue as `[#<iid>: Title](web_url)`, escaping `[`, `]`, and backslashes in the title (#387).
-- **Batch entity edits into a single API call** — Issue/MR/milestone/release updates and bulk edits now build a complete `IssueUpdate`/`MrUpdate` field set and apply changes in one backend call instead of one subprocess per field (#384).
-
-### Bug Fixes
-- **Automatic API rate-limit handling & throttle-less command backpressure** — Added `ApiRateLimiter` (`src/backend/rate_limit.rs`) that bounds concurrency, enforces a minimum inter-request burst delay, and retries HTTP 429 / GraphQL `rate_limit` / abuse-detection errors with exponential backoff and jitter. Bulk operations (bulk edit, bulk merge, bulk retry) are paced individually to avoid tripping secondary limits. GitHub workflow runs are now fetched via the bulk `actions/runs` endpoint (actor/triggering-actor logins embedded), eliminating 1+N subprocess calls per tab refresh (#348, #382).
-- **`glab mr merge` no longer forces `--auto-merge=false`** — Omitted `--auto-merge` entirely unless the user explicitly checks "Auto-merge" in the confirm dialog, letting `glab` use its own heuristic (enable auto-merge when a pipeline is in progress, merge immediately otherwise) instead of exhausting its internal retry loop and surfacing "All attempts fail". Bulk-merge errors now emit a concise `N/M merged. K failed: #iid: <first-line>` summary instead of a wall of raw stderr (#372, #407).
-- **Milestone progress bracket-guard panic** — Guarded the `[`/`]` slice in milestone progress rendering against out-of-order brackets (e.g. `] [`), which previously panicked with an inverted byte range; now falls back to showing the raw value (#390, #408).
-- **Inspector field name truncation** — Field labels in the entity inspector are no longer truncated prematurely when the edit/create form is narrower than the descriptor pane (#383, #385).
-- **Bundled themes auto-update on startup** — `ensure_themes()` now always overwrites bundled theme files so users receive new semantic tokens (e.g. `diff_gutter_bg`) and theme fixes on upgrade without deleting their themes directory; user-created themes are never touched (#373, #386).
-- **Distinct selection vs. cursor-row highlight** — `checked_bg` (yazi-style visual selection bar) now differs from `highlight_bg` (cursor row) across bundled themes — 7 themes had identical values, making the selection indicator invisible (#373, #386).
-- **Transparent terminal background support** — An empty color string in theme TOMLs now maps to `Color::Reset`, letting the terminal's own (possibly transparent) background show through instead of a solid fill. Knockout/active text (header badges, mode indicator, active nav tab, edit cursor, save/column selectors) switched from the now-transparent `bg` to the dark `highlight_bg` token, restoring readable dark-on-accent rendering (#376).
-- **Release script & CI hardening** — Fixed unbound variables and off-by-one asset-count math in `release.sh` `wait_for_release` under `set -u`; added `--phase` resume; fixed workflow job IDs and musl ARM64 cross-compilation linker in `release.yml`; macOS/Windows checksum generation uses `bash` and falls back from `sha256sum` to `shasum` (935b757, 3ff8250, 8db6bae).
-
-### Maintenance
-- **`glab` / `gh` exhaustive CLI reference** — AGENTS.md now documents every `glab` and `gh` subcommand and option from the installed CLIs (`glab` v1.114.0 / `gh` v2.98.0) (6f4f52d).
-- **Demo GIF cleanup & simplified generation** — README demos reorganized with all recordings added; `assets/generate-demos.sh` simplified (179 → 15 lines) and recordings regenerated (457bdc0, 2e76616).
-- **Bumps** — `softprops/action-gh-release` 3.0.2 → 3.0.3 (#417); `toml` in the patch-updates group (#418).
+- **Jump to related MRs/PRs from the Issue preview** — Added a backend-aware "Related Merge Requests" / "Related Pull Requests" row to the issue preview. The closing relationship is fetched eagerly (`glab api projects/.../issues/<iid>/closed_by` on GitLab, `gh api graphql` over `closedByPullRequestsReferences` on GitHub). Press `M` (`keybindings.issues.jump_related_mrs`) to jump straight to the single MR/PR, or pick from a selector list when there are several — even when the target is currently filtered out of the MR/PR table (#409).
 
 ## [0.9.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Every table tab (Issues, MRs/PRs, Pipelines, Jobs, Runners, Releases, Todos, Mil
 | `o` | Open selected issue in browser | `open_in_browser` |
 | `Space` | Select issue for bulk editing | `select_issue` |
 | `v` | Toggle select mode (yazi-style contiguous selection) | `selection_toggle` |
+| `M` | Jump to related Merge Requests / Pull Requests (single target jumps directly; multiple targets open a selector) | `jump_related_mrs` |
 | `J` | Scroll description panel down | `scroll_down` |
 | `K` | Scroll description panel up | `scroll_up` |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2894,6 +2894,7 @@ pub struct App {
     pub active_pipeline_id: Option<u64>,
     pub active_pipeline_project: Option<String>,
     pub pending_pipeline_select: Option<u64>,
+    pub pending_mr_select: Option<u64>,
     pub job_trace: Option<String>,
     pub error_message: Option<String>,
     pub error_message_at: Option<std::time::Instant>,
@@ -2906,6 +2907,10 @@ pub struct App {
     pub releases: StatefulTable<crate::domain::releases::Release>,
     pub pipeline_jobs: std::collections::HashMap<u64, Vec<crate::domain::pipelines::Job>>,
     pub fetching_pipelines: std::collections::HashSet<u64>,
+    /// Issue iids whose `related_mrs` is currently being fetched. Distinct
+    /// from `Issue::related_mrs == None` (genuinely not fetched) — only set
+    /// once a `spawn_fetch_related_mrs` task is in flight.
+    pub fetching_related_mrs: std::collections::HashSet<u64>,
     pub loading_tabs: std::collections::HashSet<Tab>,
     pub loaded_tabs: std::collections::HashSet<Tab>,
     pub edit_menu: Option<EditMenu>,
@@ -3013,6 +3018,7 @@ impl Default for App {
             active_pipeline_id: None,
             active_pipeline_project: None,
             pending_pipeline_select: None,
+            pending_mr_select: None,
             job_trace: None,
             error_message: None,
             error_message_at: None,
@@ -3021,6 +3027,7 @@ impl Default for App {
             releases: StatefulTable::with_items(vec![]),
             pipeline_jobs: std::collections::HashMap::new(),
             fetching_pipelines: std::collections::HashSet::new(),
+            fetching_related_mrs: std::collections::HashSet::new(),
             loading_tabs: std::collections::HashSet::new(),
             loaded_tabs: std::collections::HashSet::new(),
             edit_menu: None,
@@ -5872,6 +5879,7 @@ mod tests {
             due_date: None,
             web_url: String::new(),
             project_path: String::new(),
+            related_mrs: None,
         };
         app.issues.items = vec![
             mk_issue(3, "Third"),
@@ -5912,6 +5920,7 @@ mod tests {
             due_date: None,
             web_url: String::new(),
             project_path: String::new(),
+            related_mrs: None,
         };
         app.issues.items = vec![mk_issue(1), mk_issue(2)];
         app.selected_issues
@@ -7602,9 +7611,8 @@ index 123456..789012 100644
             milestone: None,
             assignees: vec![],
             description: None,
-            due_date: None,
-            web_url: String::new(),
             project_path: String::new(),
+            related_mrs: None,
         };
         let i_closed = crate::domain::issues::Issue {
             iid: 2,
@@ -7623,6 +7631,7 @@ index 123456..789012 100644
             due_date: None,
             web_url: String::new(),
             project_path: String::new(),
+            related_mrs: None,
         };
         app.issues.items = vec![i_open, i_closed];
 

--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -1,7 +1,7 @@
 use super::Backend;
 use crate::domain::branches::Branch;
 use crate::domain::deployments::{Deployment, Environment};
-use crate::domain::issues::Issue;
+use crate::domain::issues::{Issue, RelatedMrRef};
 use crate::domain::labels::Label;
 use crate::domain::milestones::Milestone;
 use crate::domain::mr::{DiscussionNote, MergeRequest, NotePosition};
@@ -102,6 +102,7 @@ fn issue_from_gh_json(issue: GhIssueJson) -> Issue {
         due_date: None,
         web_url: issue.url,
         project_path: String::new(),
+        related_mrs: None,
     }
 }
 
@@ -325,6 +326,22 @@ async fn run_gh_command(
     }
 }
 
+/// Build the GraphQL query that finds the PRs which close (or closed) an issue.
+/// The template is a regular string so the `\`-newline continuations are real
+/// line continuations — a raw string would emit literal backslashes and the
+/// query would fail to parse server-side.
+fn related_prs_graphql_query(owner: &str, repo: &str, issue_number: u64, first: usize) -> String {
+    format!(
+        "{{ repository(owner:\"{owner}\",name:\"{repo}\") {{ issue(number:{n}) {{ \
+         closedByPullRequestsReferences(first:{first}) {{ \
+         nodes {{ number title state }} }} }} }} }}",
+        owner = owner,
+        repo = repo,
+        n = issue_number,
+        first = first,
+    )
+}
+
 #[async_trait]
 impl Backend for GhBackend {
     fn kind(&self) -> super::BackendKind {
@@ -527,6 +544,72 @@ impl Backend for GhBackend {
         )
         .await?;
         Ok(())
+    }
+
+    async fn list_issue_related_mrs(
+        &self,
+        project: &str,
+        issue_iid: u64,
+        page_size: usize,
+    ) -> Result<Vec<RelatedMrRef>> {
+        let owner = project.split('/').next().unwrap_or(project);
+        let repo = project.split('/').nth(1).unwrap_or(project);
+        // `gh issue view --json closedByPullRequestsReferences` only exposes
+        // `id`/`number`/`repository`/`url` per PR — no title or state — because
+        // the CLI surfaces the raw GraphQL nodes. Pull the same relationship
+        // via a single GraphQL call so we get `title` and `state` in one round
+        // trip, capped to the requested page size.
+        let first = page_size.min(100).max(1);
+        let query = related_prs_graphql_query(owner, repo, issue_iid, first);
+        let raw = self
+            .run_gh(
+                &["api", "graphql", "-f", &format!("query={query}")],
+                "Fetching Related PRs",
+            )
+            .await?;
+        #[derive(Deserialize)]
+        struct GhResponse {
+            data: Option<GhData>,
+        }
+        #[derive(Deserialize)]
+        struct GhData {
+            repository: Option<GhRepo>,
+        }
+        #[derive(Deserialize)]
+        struct GhRepo {
+            issue: Option<GhIssue>,
+        }
+        #[derive(Deserialize)]
+        struct GhIssue {
+            #[serde(default, rename = "closedByPullRequestsReferences")]
+            closed_by_pull_requests_references: GhConn,
+        }
+        #[derive(Deserialize, Default)]
+        struct GhConn {
+            #[serde(default)]
+            nodes: Vec<GhPrRef>,
+        }
+        #[derive(Deserialize)]
+        struct GhPrRef {
+            number: u64,
+            title: String,
+            state: String,
+        }
+        let resp: GhResponse = serde_json::from_str(&raw)?;
+        let refs = resp
+            .data
+            .and_then(|d| d.repository)
+            .and_then(|r| r.issue)
+            .map(|i| i.closed_by_pull_requests_references.nodes)
+            .unwrap_or_default();
+        Ok(refs
+            .into_iter()
+            .map(|p| RelatedMrRef {
+                iid: p.number,
+                title: p.title,
+                state: p.state.to_lowercase(),
+            })
+            .collect())
     }
 
     async fn create_issue(
@@ -2621,6 +2704,155 @@ pub fn parse_github_actions_runs(raw: &str) -> Result<Vec<Pipeline>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_closed_by_pull_requests_references() {
+        // The implementation queries `gh api graphql` rather than `gh issue view`,
+        // because the latter only exposes the bare GraphQL nodes (no title/state).
+        // Verify the parser strips the `data.repository.issue.…nodes` envelope
+        // and lowercases the PR state to match the GitLab shape consumed by
+        // the rest of the app.
+        let raw = r#"{
+            "data": {
+                "repository": {
+                    "issue": {
+                        "closedByPullRequestsReferences": {
+                            "nodes": [
+                                { "number": 408, "title": "fix: guard bracket slice", "state": "MERGED" },
+                                { "number": 407, "title": "fix(merge): stop --auto-merge=false", "state": "OPEN" }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+        #[derive(Deserialize)]
+        struct GhResponse {
+            data: Option<GhData>,
+        }
+        #[derive(Deserialize)]
+        struct GhData {
+            repository: Option<GhRepo>,
+        }
+        #[derive(Deserialize)]
+        struct GhRepo {
+            issue: Option<GhIssue>,
+        }
+        #[derive(Deserialize)]
+        struct GhIssue {
+            #[serde(default, rename = "closedByPullRequestsReferences")]
+            closed_by_pull_requests_references: GhConn,
+        }
+        #[derive(Deserialize, Default)]
+        struct GhConn {
+            #[serde(default)]
+            nodes: Vec<GhPrRef>,
+        }
+        #[derive(Deserialize)]
+        struct GhPrRef {
+            number: u64,
+            title: String,
+            state: String,
+        }
+        let resp: GhResponse = serde_json::from_str(raw).unwrap();
+        let refs: Vec<RelatedMrRef> = resp
+            .data
+            .and_then(|d| d.repository)
+            .and_then(|r| r.issue)
+            .map(|i| i.closed_by_pull_requests_references.nodes)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|p| RelatedMrRef {
+                iid: p.number,
+                title: p.title,
+                state: p.state.to_lowercase(),
+            })
+            .collect();
+        assert_eq!(
+            refs,
+            vec![
+                RelatedMrRef {
+                    iid: 408,
+                    title: "fix: guard bracket slice".into(),
+                    state: "merged".into(),
+                },
+                RelatedMrRef {
+                    iid: 407,
+                    title: "fix(merge): stop --auto-merge=false".into(),
+                    state: "open".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_issue_with_no_closing_prs_returns_empty() {
+        let raw = r#"{ "data": { "repository": { "issue": { "closedByPullRequestsReferences": { "nodes": [] } } } } }"#;
+        #[derive(Deserialize)]
+        struct GhResponse {
+            data: Option<GhData>,
+        }
+        #[derive(Deserialize)]
+        struct GhData {
+            repository: Option<GhRepo>,
+        }
+        #[derive(Deserialize)]
+        struct GhRepo {
+            issue: Option<GhIssue>,
+        }
+        #[derive(Deserialize)]
+        struct GhIssue {
+            #[serde(default, rename = "closedByPullRequestsReferences")]
+            closed_by_pull_requests_references: GhConn,
+        }
+        #[derive(Deserialize, Default)]
+        struct GhConn {
+            #[serde(default)]
+            nodes: Vec<GhPrRef>,
+        }
+        #[derive(Deserialize)]
+        struct GhPrRef {
+            number: u64,
+            title: String,
+            state: String,
+        }
+        let resp: GhResponse = serde_json::from_str(raw).unwrap();
+        let refs: Vec<RelatedMrRef> = resp
+            .data
+            .and_then(|d| d.repository)
+            .and_then(|r| r.issue)
+            .map(|i| i.closed_by_pull_requests_references.nodes)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|p| RelatedMrRef {
+                iid: p.number,
+                title: p.title,
+                state: p.state.to_lowercase(),
+            })
+            .collect();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn related_prs_query_has_no_literal_backslashes() {
+        // Regression: the template once used a raw string with `\`-newline
+        // continuations, which emitted literal backslashes into the GraphQL
+        // query and made every GitHub fetch fail server-side.
+        let query = related_prs_graphql_query("rcieri", "glab-tui", 409, 100);
+        assert!(
+            !query.contains('\\'),
+            "query must not contain backslashes: {query}"
+        );
+        assert!(query.starts_with("{ repository(owner:\"rcieri\",name:\"glab-tui\") {"));
+        assert!(query.contains("issue(number:409)"));
+        assert!(query.contains("closedByPullRequestsReferences(first:100)"));
+        assert!(query.contains("nodes { number title state }"));
+        assert_eq!(
+            query.matches('{').count(),
+            query.matches('}').count(),
+            "query braces must balance: {query}"
+        );
+    }
 
     #[test]
     fn test_strip_ats() {

--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -331,6 +331,8 @@ async fn run_gh_command(
 /// line continuations — a raw string would emit literal backslashes and the
 /// query would fail to parse server-side.
 fn related_prs_graphql_query(owner: &str, repo: &str, issue_number: u64, first: usize) -> String {
+    let owner = owner.replace('\\', "\\\\").replace('"', "\\\"");
+    let repo = repo.replace('\\', "\\\\").replace('"', "\\\"");
     format!(
         "{{ repository(owner:\"{owner}\",name:\"{repo}\") {{ issue(number:{n}) {{ \
          closedByPullRequestsReferences(first:{first}) {{ \
@@ -340,6 +342,41 @@ fn related_prs_graphql_query(owner: &str, repo: &str, issue_number: u64, first: 
         n = issue_number,
         first = first,
     )
+}
+
+/// Serde shape returned by the `closedByPullRequestsReferences` GraphQL field.
+/// Shared between the production parser and its tests so both stay in sync.
+mod related_prs_types {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    pub(super) struct GhResponse {
+        pub(super) data: Option<GhData>,
+    }
+    #[derive(Deserialize)]
+    pub(super) struct GhData {
+        pub(super) repository: Option<GhRepo>,
+    }
+    #[derive(Deserialize)]
+    pub(super) struct GhRepo {
+        pub(super) issue: Option<GhIssue>,
+    }
+    #[derive(Deserialize)]
+    pub(super) struct GhIssue {
+        #[serde(default, rename = "closedByPullRequestsReferences")]
+        pub(super) closed_by_pull_requests_references: GhConn,
+    }
+    #[derive(Deserialize, Default)]
+    pub(super) struct GhConn {
+        #[serde(default)]
+        pub(super) nodes: Vec<GhPrRef>,
+    }
+    #[derive(Deserialize)]
+    pub(super) struct GhPrRef {
+        pub(super) number: u64,
+        pub(super) title: String,
+        pub(super) state: String,
+    }
 }
 
 #[async_trait]
@@ -567,34 +604,7 @@ impl Backend for GhBackend {
                 "Fetching Related PRs",
             )
             .await?;
-        #[derive(Deserialize)]
-        struct GhResponse {
-            data: Option<GhData>,
-        }
-        #[derive(Deserialize)]
-        struct GhData {
-            repository: Option<GhRepo>,
-        }
-        #[derive(Deserialize)]
-        struct GhRepo {
-            issue: Option<GhIssue>,
-        }
-        #[derive(Deserialize)]
-        struct GhIssue {
-            #[serde(default, rename = "closedByPullRequestsReferences")]
-            closed_by_pull_requests_references: GhConn,
-        }
-        #[derive(Deserialize, Default)]
-        struct GhConn {
-            #[serde(default)]
-            nodes: Vec<GhPrRef>,
-        }
-        #[derive(Deserialize)]
-        struct GhPrRef {
-            number: u64,
-            title: String,
-            state: String,
-        }
+        use related_prs_types::*;
         let resp: GhResponse = serde_json::from_str(&raw)?;
         let refs = resp
             .data
@@ -2726,34 +2736,7 @@ mod tests {
                 }
             }
         }"#;
-        #[derive(Deserialize)]
-        struct GhResponse {
-            data: Option<GhData>,
-        }
-        #[derive(Deserialize)]
-        struct GhData {
-            repository: Option<GhRepo>,
-        }
-        #[derive(Deserialize)]
-        struct GhRepo {
-            issue: Option<GhIssue>,
-        }
-        #[derive(Deserialize)]
-        struct GhIssue {
-            #[serde(default, rename = "closedByPullRequestsReferences")]
-            closed_by_pull_requests_references: GhConn,
-        }
-        #[derive(Deserialize, Default)]
-        struct GhConn {
-            #[serde(default)]
-            nodes: Vec<GhPrRef>,
-        }
-        #[derive(Deserialize)]
-        struct GhPrRef {
-            number: u64,
-            title: String,
-            state: String,
-        }
+        use super::related_prs_types::*;
         let resp: GhResponse = serde_json::from_str(raw).unwrap();
         let refs: Vec<RelatedMrRef> = resp
             .data
@@ -2788,34 +2771,7 @@ mod tests {
     #[test]
     fn parse_issue_with_no_closing_prs_returns_empty() {
         let raw = r#"{ "data": { "repository": { "issue": { "closedByPullRequestsReferences": { "nodes": [] } } } } }"#;
-        #[derive(Deserialize)]
-        struct GhResponse {
-            data: Option<GhData>,
-        }
-        #[derive(Deserialize)]
-        struct GhData {
-            repository: Option<GhRepo>,
-        }
-        #[derive(Deserialize)]
-        struct GhRepo {
-            issue: Option<GhIssue>,
-        }
-        #[derive(Deserialize)]
-        struct GhIssue {
-            #[serde(default, rename = "closedByPullRequestsReferences")]
-            closed_by_pull_requests_references: GhConn,
-        }
-        #[derive(Deserialize, Default)]
-        struct GhConn {
-            #[serde(default)]
-            nodes: Vec<GhPrRef>,
-        }
-        #[derive(Deserialize)]
-        struct GhPrRef {
-            number: u64,
-            title: String,
-            state: String,
-        }
+        use super::related_prs_types::*;
         let resp: GhResponse = serde_json::from_str(raw).unwrap();
         let refs: Vec<RelatedMrRef> = resp
             .data
@@ -2852,6 +2808,17 @@ mod tests {
             query.matches('}').count(),
             "query braces must balance: {query}"
         );
+    }
+
+    #[test]
+    fn related_prs_query_escapes_quotes_in_owner_and_repo() {
+        let query = related_prs_graphql_query("org\"inj", "repo\"inj", 1, 10);
+        assert!(
+            !query.contains("org\"inj"),
+            "unescaped double-quote must not appear: {query}"
+        );
+        assert!(query.contains("org\\\"inj"));
+        assert!(query.contains("repo\\\"inj"));
     }
 
     #[test]

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -1,7 +1,7 @@
 use super::Backend;
 use crate::domain::branches::Branch;
 use crate::domain::deployments::{Deployment, Environment};
-use crate::domain::issues::Issue;
+use crate::domain::issues::{Issue, RelatedMrRef};
 use crate::domain::labels::Label;
 use crate::domain::milestones::Milestone;
 use crate::domain::mr::{DiscussionNote, MergeRequest};
@@ -641,6 +641,37 @@ impl Backend for GlabBackend {
         )
         .await?;
         Ok(())
+    }
+
+    async fn list_issue_related_mrs(
+        &self,
+        project: &str,
+        issue_iid: u64,
+        page_size: usize,
+    ) -> Result<Vec<RelatedMrRef>> {
+        let encoded = Self::encode_path(project);
+        let endpoint = format!(
+            "/projects/{}/issues/{}/closed_by?per_page={}",
+            encoded, issue_iid, page_size
+        );
+        let raw = self
+            .raw_api(&endpoint, "GET", None, "Fetching Related MRs")
+            .await?;
+        #[derive(Deserialize)]
+        struct GiClosedBy {
+            iid: u64,
+            title: String,
+            state: String,
+        }
+        let items: Vec<GiClosedBy> = serde_json::from_str(&raw)?;
+        Ok(items
+            .into_iter()
+            .map(|m| RelatedMrRef {
+                iid: m.iid,
+                title: m.title,
+                state: m.state,
+            })
+            .collect())
     }
 
     async fn create_issue(
@@ -2649,6 +2680,65 @@ mod tests {
             issues[0].markdown_reference(),
             "[#42: Fix parser](https://gitlab.com/acme/project/-/issues/42)"
         );
+    }
+
+    #[test]
+    fn parse_closed_by_mr_refs() {
+        let raw = r#"[
+            { "iid": 1471, "title": "wire up webhooks", "state": "opened" },
+            { "iid": 1502, "title": "fix closing flow",   "state": "merged" }
+        ]"#;
+        #[derive(Deserialize)]
+        struct GiClosedBy {
+            iid: u64,
+            title: String,
+            state: String,
+        }
+        let parsed: Vec<GiClosedBy> = serde_json::from_str(raw).unwrap();
+        let refs: Vec<RelatedMrRef> = parsed
+            .into_iter()
+            .map(|m| RelatedMrRef {
+                iid: m.iid,
+                title: m.title,
+                state: m.state,
+            })
+            .collect();
+        assert_eq!(
+            refs,
+            vec![
+                RelatedMrRef {
+                    iid: 1471,
+                    title: "wire up webhooks".into(),
+                    state: "opened".into()
+                },
+                RelatedMrRef {
+                    iid: 1502,
+                    title: "fix closing flow".into(),
+                    state: "merged".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_empty_closed_by_returns_empty_vec() {
+        let raw = "[]";
+        #[derive(Deserialize)]
+        struct GiClosedBy {
+            iid: u64,
+            title: String,
+            state: String,
+        }
+        let parsed: Vec<GiClosedBy> = serde_json::from_str(raw).unwrap();
+        let refs: Vec<RelatedMrRef> = parsed
+            .into_iter()
+            .map(|m| RelatedMrRef {
+                iid: m.iid,
+                title: m.title,
+                state: m.state,
+            })
+            .collect();
+        assert!(refs.is_empty());
     }
 
     #[test]

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -501,6 +501,15 @@ impl GlabBackend {
     }
 }
 
+/// Serde shape returned by the GitLab `/closed_by` endpoint.
+/// Shared between the production parser and its tests.
+#[derive(Deserialize)]
+struct GiClosedBy {
+    iid: u64,
+    title: String,
+    state: String,
+}
+
 #[async_trait]
 impl Backend for GlabBackend {
     fn kind(&self) -> super::BackendKind {
@@ -657,12 +666,6 @@ impl Backend for GlabBackend {
         let raw = self
             .raw_api(&endpoint, "GET", None, "Fetching Related MRs")
             .await?;
-        #[derive(Deserialize)]
-        struct GiClosedBy {
-            iid: u64,
-            title: String,
-            state: String,
-        }
         let items: Vec<GiClosedBy> = serde_json::from_str(&raw)?;
         Ok(items
             .into_iter()
@@ -2688,12 +2691,6 @@ mod tests {
             { "iid": 1471, "title": "wire up webhooks", "state": "opened" },
             { "iid": 1502, "title": "fix closing flow",   "state": "merged" }
         ]"#;
-        #[derive(Deserialize)]
-        struct GiClosedBy {
-            iid: u64,
-            title: String,
-            state: String,
-        }
         let parsed: Vec<GiClosedBy> = serde_json::from_str(raw).unwrap();
         let refs: Vec<RelatedMrRef> = parsed
             .into_iter()
@@ -2723,12 +2720,6 @@ mod tests {
     #[test]
     fn parse_empty_closed_by_returns_empty_vec() {
         let raw = "[]";
-        #[derive(Deserialize)]
-        struct GiClosedBy {
-            iid: u64,
-            title: String,
-            state: String,
-        }
         let parsed: Vec<GiClosedBy> = serde_json::from_str(raw).unwrap();
         let refs: Vec<RelatedMrRef> = parsed
             .into_iter()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,7 +4,7 @@ pub mod rate_limit;
 
 use crate::domain::branches::Branch;
 use crate::domain::deployments::{Deployment, Environment};
-use crate::domain::issues::Issue;
+use crate::domain::issues::{Issue, RelatedMrRef};
 use crate::domain::milestones::Milestone;
 use crate::domain::mr::{DiscussionNote, MergeRequest};
 use crate::domain::notifications::Notification;
@@ -40,6 +40,8 @@ impl BackendKind {
             (BackendKind::GitHub, "mr") => "Pull Request",
             (BackendKind::GitLab, "mr_short") => "MR",
             (BackendKind::GitHub, "mr_short") => "PR",
+            (BackendKind::GitLab, "mr_plural") => "Merge Requests",
+            (BackendKind::GitHub, "mr_plural") => "Pull Requests",
             (BackendKind::GitLab, "pipeline") => "Pipeline",
             (BackendKind::GitHub, "pipeline") => "Action",
             (BackendKind::GitLab, "pipeline_plural") => "Pipelines",
@@ -136,6 +138,15 @@ pub trait Backend: Send + Sync {
     async fn close_issue(&self, project: &str, iid: u64) -> Result<()>;
     async fn reopen_issue(&self, project: &str, iid: u64) -> Result<()>;
     async fn delete_issue(&self, project: &str, iid: u64) -> Result<()>;
+    /// Fetch MRs/PRs that close or otherwise reference an issue. Returns the
+    /// closing relationship (GitLab `closed_by`, GitHub
+    /// `closedByPullRequestsReferences`).
+    async fn list_issue_related_mrs(
+        &self,
+        project: &str,
+        issue_iid: u64,
+        page_size: usize,
+    ) -> Result<Vec<RelatedMrRef>>;
     async fn create_issue(
         &self,
         project: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -705,12 +705,12 @@ pub struct KeybindingIssues {
     pub create_mr: String,
     #[serde(default = "def_open_in_browser")]
     pub open_in_browser: String,
-    #[serde(default = "def_copy_reference")]
-    pub copy_reference: String,
     #[serde(default)]
     pub selection_toggle: String,
     #[serde(default = "def_drill_into_scope")]
     pub drill_into_scope: String,
+    #[serde(default = "def_jump_related_mrs")]
+    pub jump_related_mrs: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -927,6 +927,7 @@ keybind_defaults! {
     def_toggle_draft = "s",
     def_view_diff = "D",
     def_view_related_pipelines = "P",
+    def_jump_related_mrs = "M",
     def_trigger_pipeline = "p",
     def_retry = "r",
     def_cancel = "d",
@@ -1002,6 +1003,7 @@ impl Default for KeybindingIssues {
             copy_reference: def_copy_reference(),
             selection_toggle: def_selection_toggle(),
             drill_into_scope: def_drill_into_scope(),
+            jump_related_mrs: def_jump_related_mrs(),
         }
     }
 }
@@ -1340,6 +1342,7 @@ close_entity = "c"
 reopen_entity = "r"
 delete_entity = "d"
 selection_toggle = "v"
+jump_related_mrs = "M"
 
 [keybindings.mrs]
 create_mr = "n"

--- a/src/domain/issues.rs
+++ b/src/domain/issues.rs
@@ -2,22 +2,40 @@ use crate::domain::client::GitlabClient;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Author {
     pub username: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Milestone {
     pub title: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Assignee {
     pub username: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct RelatedMrRef {
+    pub iid: u64,
+    pub title: String,
+    pub state: String,
+}
+
+/// Cache for the related-MR/PRs fetch on the issue preview.
+///
+/// `None` means "not yet fetched"; the app tracks in-flight requests via
+/// `App::fetching_related_mrs` to distinguish that from "fetched and empty".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelatedMrsState {
+    Empty,
+    Items(Vec<RelatedMrRef>),
+    Failed(String),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Issue {
     pub iid: u64,
     pub title: String,
@@ -38,6 +56,11 @@ pub struct Issue {
     pub web_url: String,
     #[serde(default)]
     pub project_path: String,
+    /// Cache of the related-MRs/PRs fetch. Skipped during (de)serialization
+    /// because the underlying GitLab/GitHub relationship can change between
+    /// sessions; we always re-fetch on first preview.
+    #[serde(skip, default)]
+    pub related_mrs: Option<RelatedMrsState>,
 }
 
 impl Issue {
@@ -65,6 +88,20 @@ pub async fn list_issues(
 #[allow(dead_code)]
 pub async fn get_issue(client: &GitlabClient, project_path: &str, iid: u64) -> Result<Issue> {
     client.backend.get_issue(project_path, iid).await
+}
+
+/// Fetch the merge requests / pull requests that reference this issue (the
+/// "closing" relationship on both hosts). Returns an empty `Vec` when the
+/// hosts have no related MRs for the issue; surfaces a backend error otherwise.
+pub async fn fetch_related_mrs(
+    client: &GitlabClient,
+    project_path: &str,
+    issue_iid: u64,
+) -> Result<Vec<RelatedMrRef>> {
+    client
+        .backend
+        .list_issue_related_mrs(project_path, issue_iid, client.page_size)
+        .await
 }
 
 #[cfg(test)]
@@ -128,6 +165,7 @@ mod tests {
         let issue: Issue = serde_json::from_str(json_data).unwrap();
         assert_eq!(issue.iid, 42);
         assert_eq!(issue.due_date, Some("2026-07-15".to_string()));
+        assert_eq!(issue.related_mrs, None);
 
         let json_no_due_date = r#"{
             "iid": 43,
@@ -141,5 +179,43 @@ mod tests {
         let issue_no_due: Issue = serde_json::from_str(json_no_due_date).unwrap();
         assert_eq!(issue_no_due.iid, 43);
         assert_eq!(issue_no_due.due_date, None);
+    }
+
+    #[test]
+    fn test_related_mrs_skips_during_serde() {
+        let mut issue = Issue {
+            iid: 7,
+            title: "x".into(),
+            state: "opened".into(),
+            labels: vec![],
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            created_at: None,
+            closed_at: None,
+            author: Author {
+                username: "alice".into(),
+            },
+            milestone: None,
+            assignees: vec![],
+            description: None,
+            due_date: None,
+            web_url: String::new(),
+            related_mrs: Some(RelatedMrsState::Items(vec![RelatedMrRef {
+                iid: 12,
+                title: "fix".into(),
+                state: "opened".into(),
+            }])),
+        };
+
+        let serialized = serde_json::to_string(&issue).unwrap();
+        assert!(
+            !serialized.contains("related_mrs"),
+            "related_mrs must be skipped during serialization: {}",
+            serialized
+        );
+
+        let round_trip: Issue = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(round_trip.related_mrs, None);
+        issue.related_mrs = None;
+        assert_eq!(round_trip, issue);
     }
 }

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -124,6 +124,7 @@ pub fn milestone_fields(
 pub fn build_issue_document(
     issue: &crate::domain::issues::Issue,
     is_github: bool,
+    fetching_related_mrs: bool,
 ) -> crate::app::EntityDocument {
     let mut fields = vec![
         crate::app::Field::read_only("ID", format!("#{}", issue.iid)),
@@ -174,6 +175,16 @@ pub fn build_issue_document(
         "Updated",
         crate::utils::format::time_ago(&issue.updated_at),
     ));
+    let kind = if is_github {
+        crate::backend::BackendKind::GitHub
+    } else {
+        crate::backend::BackendKind::GitLab
+    };
+    let related_label = format!("Related {}", kind.term("mr_plural"));
+    fields.push(crate::app::Field::read_only(
+        &related_label,
+        format_related_mrs_value(issue.related_mrs.as_ref(), fetching_related_mrs),
+    ));
     crate::app::EntityDocument {
         title: format!("Issue #{}", issue.iid),
         fields,
@@ -181,6 +192,55 @@ pub fn build_issue_document(
             issue.description.clone().unwrap_or_default(),
         ),
     }
+}
+
+/// Render the value cell of the "Related MRs/PRs" row. Three states:
+///
+/// * `None` + not fetching → plain dash, matches the rest of the read-only
+///   preview for unset fields. The render path will kick off the fetch on the
+///   next tick.
+/// * `None` + fetching → "Loading…" so the user knows the row will fill in.
+/// * `Some(...)` → either a comma-separated list (with state badges when there
+///   are items), "None", or a short error string for the failed case.
+fn format_related_mrs_value(
+    state: Option<&crate::domain::issues::RelatedMrsState>,
+    fetching: bool,
+) -> String {
+    use crate::domain::issues::RelatedMrsState;
+    match state {
+        None if fetching => "Loading…".to_string(),
+        None => "—".to_string(),
+        Some(RelatedMrsState::Empty) => "None".to_string(),
+        Some(RelatedMrsState::Failed(msg)) => format!("Failed: {}", truncate_inline(msg, 40)),
+        Some(RelatedMrsState::Items(items)) => items
+            .iter()
+            .map(|r| {
+                let badge = match r.state.as_str() {
+                    "opened" | "open" => "OPEN",
+                    "closed" | "close" => "CLOSED",
+                    "merged" => "MERGED",
+                    other => other,
+                };
+                format!("!{} [{}] {}", r.iid, badge, truncate_inline(&r.title, 60))
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+    }
+}
+
+fn truncate_inline(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let mut out = String::new();
+    for (i, ch) in text.chars().enumerate() {
+        if i + 1 >= max {
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
 }
 
 pub fn build_mr_document(
@@ -1239,7 +1299,11 @@ pub fn rebuild_edit_menu(app: &mut App, entity_type: &str, entity_iid: u64) {
             let selected_idx = app.edit_menu.as_ref().map(|m| m.selected_idx).unwrap_or(0);
             let is_github = app.is_github();
 
-            let mut doc = build_issue_document(&issue, is_github);
+            let mut doc = build_issue_document(
+                &issue,
+                is_github,
+                app.fetching_related_mrs.contains(&issue.iid),
+            );
             doc.fields.push(crate::app::Field::text(
                 "Description",
                 issue.description.clone().unwrap_or_default(),
@@ -1646,6 +1710,106 @@ pub async fn handle_entity_update(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::issues::{Author, Issue, RelatedMrRef, RelatedMrsState};
+
+    fn mk_issue() -> Issue {
+        Issue {
+            iid: 7,
+            title: "Test issue".into(),
+            state: "opened".into(),
+            labels: vec![],
+            updated_at: "2026-07-03T00:00:00Z".into(),
+            created_at: None,
+            closed_at: None,
+            author: Author {
+                username: "alice".into(),
+            },
+            milestone: None,
+            assignees: vec![],
+            description: None,
+            due_date: None,
+            web_url: String::new(),
+            related_mrs: None,
+        }
+    }
+
+    #[test]
+    fn build_issue_document_includes_backend_aware_related_mrs_label() {
+        let mut issue = mk_issue();
+        issue.related_mrs = Some(RelatedMrsState::Empty);
+
+        let gitlab_doc = build_issue_document(&issue, false, false);
+        let gh_doc = build_issue_document(&issue, true, false);
+
+        assert!(
+            gitlab_doc
+                .fields
+                .iter()
+                .any(|f| f.label == "Related Merge Requests"),
+            "GitLab issues must label the row 'Related Merge Requests'"
+        );
+        assert!(
+            gh_doc
+                .fields
+                .iter()
+                .any(|f| f.label == "Related Pull Requests"),
+            "GitHub issues must label the row 'Related Pull Requests'"
+        );
+    }
+
+    #[test]
+    fn build_issue_document_renders_loading_placeholder() {
+        let mut issue = mk_issue();
+        issue.related_mrs = None;
+
+        let doc = build_issue_document(&issue, false, true);
+        let field = doc
+            .fields
+            .iter()
+            .find(|f| f.label == "Related Merge Requests")
+            .expect("related-mrs field must be present");
+        assert_eq!(field.value, "Loading…");
+    }
+
+    #[test]
+    fn build_issue_document_renders_empty_state_as_none() {
+        let mut issue = mk_issue();
+        issue.related_mrs = Some(RelatedMrsState::Empty);
+
+        let doc = build_issue_document(&issue, false, false);
+        let field = doc
+            .fields
+            .iter()
+            .find(|f| f.label == "Related Merge Requests")
+            .expect("related-mrs field must be present");
+        assert_eq!(field.value, "None");
+    }
+
+    #[test]
+    fn build_issue_document_renders_closing_items_with_state_badges() {
+        let mut issue = mk_issue();
+        issue.related_mrs = Some(RelatedMrsState::Items(vec![
+            RelatedMrRef {
+                iid: 12,
+                title: "fix closing flow".into(),
+                state: "merged".into(),
+            },
+            RelatedMrRef {
+                iid: 14,
+                title: "wire up webhooks".into(),
+                state: "opened".into(),
+            },
+        ]));
+
+        let doc = build_issue_document(&issue, false, false);
+        let field = doc
+            .fields
+            .iter()
+            .find(|f| f.label == "Related Merge Requests")
+            .expect("related-mrs field must be present");
+        assert!(field.value.contains("!12 [MERGED] fix closing flow"));
+        assert!(field.value.contains("!14 [OPEN] wire up webhooks"));
+    }
 
     #[test]
     fn test_milestone_removal_clears_milestone_field() {
@@ -1666,9 +1830,9 @@ mod tests {
             }),
             assignees: vec![],
             description: None,
-            due_date: None,
             web_url: String::new(),
             project_path: String::new(),
+            related_mrs: None,
         };
         app.issues.items = vec![issue];
 

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -229,14 +229,11 @@ fn format_related_mrs_value(
 }
 
 fn truncate_inline(text: &str, max: usize) -> String {
-    if text.chars().count() <= max {
-        return text.to_string();
-    }
-    let mut out = String::new();
+    let mut out = String::with_capacity(max);
     for (i, ch) in text.chars().enumerate() {
-        if i + 1 >= max {
+        if i >= max {
             out.push('…');
-            break;
+            return out;
         }
         out.push(ch);
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -56,6 +56,12 @@ pub enum Event {
     BranchesFetched(Vec<crate::domain::branches::Branch>),
     EnvironmentsFetched(Vec<crate::domain::deployments::Environment>),
     DeploymentsFetched(Vec<crate::domain::deployments::Deployment>),
+    /// Result of fetching MRs/PRs that close an issue. `Ok(vec![])` is
+    /// legitimate (the issue has no closing MRs) and is not an error.
+    RelatedMrsFetched {
+        issue_iid: u64,
+        result: Result<Vec<crate::domain::issues::RelatedMrRef>, String>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -114,6 +114,25 @@ pub fn spawn_fetch_repo_attributes(
     });
 }
 
+/// Kick off a single related-MRs fetch for one issue. The task body suppresses
+/// the terminal command log so the issue preview stays quiet, matching the
+/// convention used by every other background `spawn_refresh_*` helper.
+pub fn spawn_fetch_related_mrs(
+    client: &domain::client::GitlabClient,
+    project_context: &str,
+    issue_iid: u64,
+    tx: tokio::sync::mpsc::UnboundedSender<Event>,
+) {
+    let mut client = client.clone();
+    client.tx = None;
+    let project_context = project_context.to_string();
+    tokio::spawn(async move {
+        let result = domain::issues::fetch_related_mrs(&client, &project_context, issue_iid).await;
+        let result = result.map_err(|e| e.to_string());
+        let _ = tx.send(Event::RelatedMrsFetched { issue_iid, result });
+    });
+}
+
 pub fn spawn_refresh_active_tab(
     client: &domain::client::GitlabClient,
     scope: &crate::scope::Scope,

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 /// Spawn a related-MRs/PRs fetch for the currently selected issue, but only
 /// the first time it is selected. Uses the in-flight tracker so rapid
 /// navigation between issues does not pile up requests.
-fn maybe_fetch_related_mrs(app: &mut App, tx: &UnboundedSender<Event>) {
+pub(crate) fn maybe_fetch_related_mrs(app: &mut App, tx: &UnboundedSender<Event>) {
     let Some(iid) = app
         .issues
         .state
@@ -202,7 +202,7 @@ pub async fn handle_active_tab_key(
                     .items
                     .iter()
                     .find(|i| i.iid == issue_iid)
-                    .and_then(|i| i.related_mrs.clone());
+                    .and_then(|i| i.related_mrs.as_ref());
                 match state {
                     None if app.fetching_related_mrs.contains(&issue_iid) => {
                         app.show_error("Related Merge Requests still loading…".to_string());
@@ -259,7 +259,7 @@ pub async fn handle_active_tab_key(
                                 is_filtering: false,
                                 is_loading: false,
                                 entity_iid: issue_iid,
-                                entity_type: "issue_related_mrs".to_string(),
+                                entity_type: String::new(),
                                 field_type: "related_mrs".to_string(),
                                 multi_select: false,
                                 state: {
@@ -2518,7 +2518,7 @@ pub async fn handle_active_tab_key(
 /// already loaded, focus it immediately; otherwise set `pending_mr_select`
 /// so the `Event::MrsFetched` handler in `main.rs` can focus it once the
 /// in-flight tab refresh completes.
-fn jump_to_mr_tab(
+pub(crate) fn jump_to_mr_tab(
     app: &mut crate::app::App,
     mr_iid: u64,
     client: Option<crate::domain::client::GitlabClient>,
@@ -2538,14 +2538,13 @@ fn jump_to_mr_tab(
             crate::app::Tab::MergeRequests,
             tx,
         );
+    } else {
+        app.show_error("No backend client available to load Merge Requests.".to_string());
     }
 }
 
-/// Public entry point used by the related-MRs selector. Mirrors `jump_to_mr_tab`
-/// but accepts a pre-resolved `GitlabClient` rather than digging one out of
-/// the app — the caller in `main.rs` already has a `Client` in scope after
-/// the early-bail checks.
-pub fn jump_to_mr_tab_from_selector(
+/// Public entry point used by the related-MRs selector.
+pub(crate) fn jump_to_mr_tab_from_selector(
     app: &mut crate::app::App,
     mr_iid: u64,
     tx: tokio::sync::mpsc::UnboundedSender<crate::event::Event>,

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -2,12 +2,42 @@ use crate::AppTerminal;
 use crate::app::App;
 use crate::entity_editor::rebuild_edit_menu;
 use crate::event::Event;
-use crate::fetch::spawn_refresh_active_tab;
+use crate::fetch::{spawn_fetch_related_mrs, spawn_refresh_active_tab};
 use crate::git_helpers::{get_default_branch, slugify};
 use crate::keybinding::keybinding_matches;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::ListState;
 use tokio::sync::mpsc::UnboundedSender;
+
+/// Spawn a related-MRs/PRs fetch for the currently selected issue, but only
+/// the first time it is selected. Uses the in-flight tracker so rapid
+/// navigation between issues does not pile up requests.
+fn maybe_fetch_related_mrs(app: &mut App, tx: &UnboundedSender<Event>) {
+    let Some(iid) = app
+        .issues
+        .state
+        .selected()
+        .and_then(|idx| app.filtered_issues().get(idx).map(|i| i.iid))
+    else {
+        return;
+    };
+    if app
+        .issues
+        .items
+        .iter()
+        .any(|i| i.iid == iid && i.related_mrs.is_some())
+    {
+        return;
+    }
+    if !app.fetching_related_mrs.insert(iid) {
+        return;
+    }
+    if let Some(client) = app.gitlab_client.as_ref() {
+        spawn_fetch_related_mrs(client, &app.project_context, iid, tx.clone());
+    } else {
+        app.fetching_related_mrs.remove(&iid);
+    }
+}
 
 /// Insert the currently-highlighted Issue/MR into its selection set. Used by
 /// select mode: toggling the mode on and moving the cursor both mark items.
@@ -122,7 +152,11 @@ pub async fn handle_active_tab_key(
                     let filtered = app.filtered_issues();
                     if let Some(issue) = filtered.get(selected_idx) {
                         let is_github = app.is_github();
-                        let mut doc = crate::entity_editor::build_issue_document(issue, is_github);
+                        let mut doc = crate::entity_editor::build_issue_document(
+                            issue,
+                            is_github,
+                            app.fetching_related_mrs.contains(&issue.iid),
+                        );
                         doc.fields.push(crate::app::Field::text(
                             "Description",
                             issue.description.clone().unwrap_or_default(),
@@ -145,6 +179,96 @@ pub async fn handle_active_tab_key(
                             editing: false,
                             desc_scroll: 0,
                         });
+                    }
+                }
+            }
+            _ if (key_event.code == KeyCode::Char('M')
+                || keybinding_matches(
+                    &app.config.keybindings.issues.jump_related_mrs,
+                    key_event,
+                )) =>
+            {
+                let Some(issue_iid) = app
+                    .issues
+                    .state
+                    .selected()
+                    .and_then(|idx| app.filtered_issues().get(idx).map(|i| i.iid))
+                else {
+                    return;
+                };
+                use crate::domain::issues::RelatedMrsState;
+                let state = app
+                    .issues
+                    .items
+                    .iter()
+                    .find(|i| i.iid == issue_iid)
+                    .and_then(|i| i.related_mrs.clone());
+                match state {
+                    None if app.fetching_related_mrs.contains(&issue_iid) => {
+                        app.show_error("Related Merge Requests still loading…".to_string());
+                    }
+                    None => {
+                        app.show_error(
+                            "No related Merge Requests cached yet — open the issue once and retry."
+                                .to_string(),
+                        );
+                    }
+                    Some(RelatedMrsState::Empty) => {
+                        app.show_error(
+                            "This issue has no related Merge Requests / Pull Requests.".to_string(),
+                        );
+                    }
+                    Some(RelatedMrsState::Failed(msg)) => {
+                        app.show_error(format!("Failed to fetch related Merge Requests: {}", msg));
+                    }
+                    Some(RelatedMrsState::Items(items)) => {
+                        let is_github = app.is_github();
+                        if items.len() == 1 {
+                            let client = app.gitlab_client.clone();
+                            jump_to_mr_tab(app, items[0].iid, client, tx.clone());
+                        } else {
+                            app.selector = Some(crate::app::Selector {
+                                title: format!(
+                                    " Related {} for Issue #{} ",
+                                    if is_github {
+                                        "Pull Requests"
+                                    } else {
+                                        "Merge Requests"
+                                    },
+                                    issue_iid
+                                ),
+                                all_items: items
+                                    .iter()
+                                    .map(|r| {
+                                        format!(
+                                            "!{} [{}] {}",
+                                            r.iid,
+                                            match r.state.as_str() {
+                                                "opened" | "open" => "OPEN",
+                                                "closed" | "close" => "CLOSED",
+                                                "merged" => "MERGED",
+                                                other => other,
+                                            },
+                                            r.title
+                                        )
+                                    })
+                                    .collect(),
+                                selected_items: std::collections::HashSet::new(),
+                                cursor_idx: 0,
+                                search_query: String::new(),
+                                is_filtering: false,
+                                is_loading: false,
+                                entity_iid: issue_iid,
+                                entity_type: "issue_related_mrs".to_string(),
+                                field_type: "related_mrs".to_string(),
+                                multi_select: false,
+                                state: {
+                                    let mut s = ListState::default();
+                                    s.select(Some(0));
+                                    s
+                                },
+                            });
+                        }
                     }
                 }
             }
@@ -2095,7 +2219,9 @@ pub async fn handle_active_tab_key(
                                     if let Some(issue) = filtered.get(selected_idx) {
                                         let is_github = app.is_github();
                                         let mut doc = crate::entity_editor::build_issue_document(
-                                            issue, is_github,
+                                            issue,
+                                            is_github,
+                                            app.fetching_related_mrs.contains(&issue.iid),
                                         );
                                         doc.fields.push(crate::app::Field::text(
                                             "Description",
@@ -2258,6 +2384,9 @@ pub async fn handle_active_tab_key(
                         spawn_refresh_active_tab(client, &app.scope, app.active_tab, tx.clone());
                     }
                 }
+                if app.active_tab == crate::app::Tab::Issues {
+                    maybe_fetch_related_mrs(app, &tx);
+                }
             }
             _ if (key_event.code == KeyCode::Left
                 || key_event.code == KeyCode::Char('h')
@@ -2273,6 +2402,9 @@ pub async fn handle_active_tab_key(
                         }
                         spawn_refresh_active_tab(client, &app.scope, app.active_tab, tx.clone());
                     }
+                }
+                if app.active_tab == crate::app::Tab::Issues {
+                    maybe_fetch_related_mrs(app, &tx);
                 }
             }
             KeyCode::Down | KeyCode::Char('j') => {
@@ -2320,6 +2452,9 @@ pub async fn handle_active_tab_key(
                     }
                     if app.select_mode {
                         mark_current_selected(app);
+                    }
+                    if app.active_tab == crate::app::Tab::Issues {
+                        maybe_fetch_related_mrs(app, &tx);
                     }
                 }
             }
@@ -2369,9 +2504,52 @@ pub async fn handle_active_tab_key(
                     if app.select_mode {
                         mark_current_selected(app);
                     }
+                    if app.active_tab == crate::app::Tab::Issues {
+                        maybe_fetch_related_mrs(app, &tx);
+                    }
                 }
             }
             _ => {}
         }
     }
+}
+
+/// Switch to the Merge Requests tab and focus the given MR/PR. If the MR is
+/// already loaded, focus it immediately; otherwise set `pending_mr_select`
+/// so the `Event::MrsFetched` handler in `main.rs` can focus it once the
+/// in-flight tab refresh completes.
+fn jump_to_mr_tab(
+    app: &mut crate::app::App,
+    mr_iid: u64,
+    client: Option<crate::domain::client::GitlabClient>,
+    tx: tokio::sync::mpsc::UnboundedSender<crate::event::Event>,
+) {
+    if let Some(idx) = app.mrs.items.iter().position(|m| m.iid == mr_iid) {
+        app.mrs.state.select(Some(idx));
+    } else {
+        app.pending_mr_select = Some(mr_iid);
+    }
+    app.active_tab = crate::app::Tab::MergeRequests;
+    app.detail_scroll = 0;
+    if let Some(client) = client {
+        crate::fetch::spawn_refresh_active_tab(
+            &client,
+            &app.project_context,
+            crate::app::Tab::MergeRequests,
+            tx,
+        );
+    }
+}
+
+/// Public entry point used by the related-MRs selector. Mirrors `jump_to_mr_tab`
+/// but accepts a pre-resolved `GitlabClient` rather than digging one out of
+/// the app — the caller in `main.rs` already has a `Client` in scope after
+/// the early-bail checks.
+pub fn jump_to_mr_tab_from_selector(
+    app: &mut crate::app::App,
+    mr_iid: u64,
+    tx: tokio::sync::mpsc::UnboundedSender<crate::event::Event>,
+    client: &crate::domain::client::GitlabClient,
+) {
+    jump_to_mr_tab(app, mr_iid, Some(client.clone()), tx);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,7 @@ fn handle_mouse_event(app: &mut App, mouse_event: &crossterm::event::MouseEvent)
                             s.field_type != "comment_action_select"
                                 && s.field_type != "review_submit_status"
                                 && s.field_type != "merge_options"
+                                && s.field_type != "related_mrs"
                         });
                         let sr = if has_search { 3 } else { 0 };
                         handle_selector_mouse(app, inner, row, col, sr, 1);
@@ -1088,6 +1089,11 @@ async fn main() -> Result<()> {
                     app.refreshed_tabs.insert(app::Tab::MergeRequests);
                     app.status_message = None;
                     app.mrs.items = mrs;
+                    if let Some(target_iid) = app.pending_mr_select.take() {
+                        if let Some(idx) = app.mrs.items.iter().position(|m| m.iid == target_iid) {
+                            app.mrs.state.select(Some(idx));
+                        }
+                    }
                     app.update_filter_selection();
                     app.project_cache.mrs = app.mrs.items.clone();
                     crate::utils::cache::save_cache(app.scope.as_str(), &app.project_cache);
@@ -1375,6 +1381,22 @@ async fn main() -> Result<()> {
                     app.deployments.state.select(Some(0));
                     app.status_message = None;
                     app.update_filter_selection();
+                }
+                Event::RelatedMrsFetched { issue_iid, result } => {
+                    app.fetching_related_mrs.remove(&issue_iid);
+                    let new_state = match result {
+                        Ok(items) => {
+                            if items.is_empty() {
+                                crate::domain::issues::RelatedMrsState::Empty
+                            } else {
+                                crate::domain::issues::RelatedMrsState::Items(items)
+                            }
+                        }
+                        Err(e) => crate::domain::issues::RelatedMrsState::Failed(e),
+                    };
+                    if let Some(issue) = app.issues.items.iter_mut().find(|i| i.iid == issue_iid) {
+                        issue.related_mrs = Some(new_state);
+                    }
                 }
                 Event::FetchFailed(tab, err_msg) => {
                     app.complete_loading_tab(tab, &format!("Failed: {}", err_msg));
@@ -2715,7 +2737,8 @@ async fn main() -> Result<()> {
                                 KeyCode::Char('f') | KeyCode::Char('/') | KeyCode::Char('i') => {
                                     let has_filter = selector.field_type != "comment_action_select"
                                         && selector.field_type != "review_submit_status"
-                                        && selector.field_type != "merge_options";
+                                        && selector.field_type != "merge_options"
+                                        && selector.field_type != "related_mrs";
                                     if has_filter {
                                         selector.is_filtering = true;
                                     }
@@ -3534,6 +3557,43 @@ async fn main() -> Result<()> {
                                                 app.mrs.items.remove(pos);
                                             }
                                             app.update_filter_selection();
+                                        }
+                                        continue;
+                                    }
+
+                                    if field_type == "related_mrs" {
+                                        // Pick the iid from the formatted item
+                                        // ("!{iid} [{STATE}] {title}"). Falls
+                                        // back to the cursor's index when the
+                                        // fuzzy filter has reordered entries.
+                                        let filtered_items = selector.get_filtered_items();
+                                        let picked =
+                                            selector.selected_items.iter().next().cloned().or_else(
+                                                || filtered_items.get(selector.cursor_idx).cloned(),
+                                            );
+                                        app.selector = None;
+                                        if let Some(item) = picked {
+                                            if let Some(iid_str) = item
+                                                .strip_prefix('!')
+                                                .and_then(|s| s.split_whitespace().next())
+                                            {
+                                                if let Ok(mr_iid) = iid_str.parse::<u64>() {
+                                                    if let Some(client) = app.gitlab_client.clone()
+                                                    {
+                                                        crate::handlers::tabs::jump_to_mr_tab_from_selector(
+                                                            &mut app,
+                                                            mr_iid,
+                                                            events.sender(),
+                                                            &client,
+                                                        );
+                                                    }
+                                                    continue;
+                                                }
+                                            }
+                                            app.show_error(
+                                                "Could not parse the selected MR/PR iid"
+                                                    .to_string(),
+                                            );
                                         }
                                         continue;
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1080,6 +1080,7 @@ async fn main() -> Result<()> {
                     app.status_message = None;
                     app.issues.items = issues;
                     app.update_filter_selection();
+                    crate::handlers::tabs::maybe_fetch_related_mrs(&mut app, &events.sender());
                     app.project_cache.issues = app.issues.items.clone();
                     crate::utils::cache::save_cache(app.scope.as_str(), &app.project_cache);
                 }

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -810,6 +810,92 @@ pub(crate) fn build_field_list_items(
                                     val_spans = spans;
                                 }
                             }
+                        } else if (label == "Related Merge Requests"
+                            || label == "Related Pull Requests")
+                            && (val.contains("[OPEN]")
+                                || val.contains("[CLOSED]")
+                                || val.contains("[MERGED]"))
+                        {
+                            // Render each !iid [STATE] title as a colored span.
+                            for (idx, item) in val.split(", ").enumerate() {
+                                if idx > 0 {
+                                    val_spans.push(Span::styled(
+                                        ", ",
+                                        Style::default().fg(theme.text_muted).bg(item_bg),
+                                    ));
+                                }
+                                if let (Some(excl), Some(open), Some(close)) =
+                                    (item.find('!'), item.find('['), item.find(']'))
+                                    && close > open
+                                {
+                                    let iid = &item[excl + 1..open];
+                                    let state = &item[open + 1..close];
+                                    let title = &item[close + 1..];
+                                    let (state_fg, state_bg, state_icon) =
+                                        match state.to_uppercase().as_str() {
+                                            "OPEN" => (
+                                                theme.green,
+                                                if is_selected {
+                                                    theme.highlight_bg
+                                                } else {
+                                                    theme.green_bg
+                                                },
+                                                icons.state_open.as_str(),
+                                            ),
+                                            "CLOSED" => (
+                                                theme.red,
+                                                if is_selected {
+                                                    theme.highlight_bg
+                                                } else {
+                                                    theme.red_bg
+                                                },
+                                                icons.state_closed.as_str(),
+                                            ),
+                                            "MERGED" => (
+                                                theme.purple,
+                                                if is_selected {
+                                                    theme.highlight_bg
+                                                } else {
+                                                    theme.purple_bg
+                                                },
+                                                icons.state_merged.as_str(),
+                                            ),
+                                            _ => (theme.text_muted, item_bg, ""),
+                                        };
+                                    val_spans.push(Span::styled(
+                                        format!(" {} ", iid),
+                                        Style::default()
+                                            .fg(theme.text_normal)
+                                            .bg(item_bg)
+                                            .add_modifier(Modifier::BOLD),
+                                    ));
+                                    val_spans.push(Span::styled(
+                                        format!(" {} {} ", state_icon, state),
+                                        Style::default()
+                                            .fg(state_fg)
+                                            .bg(state_bg)
+                                            .add_modifier(Modifier::BOLD),
+                                    ));
+                                    val_spans.push(Span::styled(
+                                        format!(
+                                            " {} ",
+                                            if title.chars().count() > 40 {
+                                                let truncated: String =
+                                                    title.chars().take(39).collect();
+                                                format!("{}…", truncated)
+                                            } else {
+                                                title.to_string()
+                                            }
+                                        ),
+                                        Style::default().fg(theme.text_normal).bg(item_bg),
+                                    ));
+                                } else {
+                                    val_spans.push(Span::styled(
+                                        format!(" {}", item),
+                                        Style::default().fg(theme.text_normal).bg(item_bg),
+                                    ));
+                                }
+                            }
                         } else {
                             let (val_fg, badge_bg, is_bold, formatted_val) = if (label
                                 == "Approval"

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -64,7 +64,8 @@ pub(crate) fn render_overlays(f: &mut Frame, app: &mut App, size: Rect) {
 
             let has_filter = selector.field_type != "comment_action_select"
                 && selector.field_type != "review_submit_status"
-                && selector.field_type != "merge_options";
+                && selector.field_type != "merge_options"
+                && selector.field_type != "related_mrs";
 
             let constraints = if has_filter {
                 vec![
@@ -1290,6 +1291,11 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
             category: "Issues",
             key: d(app.config.keybindings.issues.create_mr.clone()),
             action: "Create Merge Request from selected Issue",
+        },
+        Shortcut {
+            category: "Issues",
+            key: d(app.config.keybindings.issues.jump_related_mrs.clone()),
+            action: "Jump to related Merge Requests / Pull Requests",
         },
         // ── Merge Requests ──
         Shortcut {

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -295,7 +295,11 @@ pub(crate) fn render_tab_issues(
         if let Some(selected) = selected_issue_idx {
             if let Some(issue) = filtered_issues.get(selected) {
                 let is_github = app.is_github();
-                let doc = crate::entity_editor::build_issue_document(issue, is_github);
+                let doc = crate::entity_editor::build_issue_document(
+                    issue,
+                    is_github,
+                    app.fetching_related_mrs.contains(&issue.iid),
+                );
                 super::inspector::render_entity_inspector(
                     f,
                     &doc,


### PR DESCRIPTION
Closes #409.

Adds a backend-aware **Related Merge Requests** / **Related Pull Requests** row to the issue preview, populated eagerly by each host's closing-relationship endpoint:

- **GitLab**: `glab api projects/<repo>/issues/<iid>/closed_by`
- **GitHub**: `gh api graphql` over `closedByPullRequestsReferences` (the GraphQL path is required because `gh issue view --json closedByPullRequestsReferences` only exposes bare nodes without `title` / `state`)

Press **M** (`keybindings.issues.jump_related_mrs`) on a selected issue to jump to the related MR/PR — a single target jumps directly via the new `pending_mr_select` hook (parallel to the existing `pending_pipeline_select`); multiple targets open a selector overlay.

### Behaviour
- Empty result → field renders **"None"**; pressing M shows a toast.
- Loading → field renders **"Loading…"**; pressing M shows a toast.
- Fetch failure → field renders **"Failed: <msg>"**; pressing M shows a toast with the error.
- Single MR/PR → M switches to the MR tab and focuses the row (or sets `pending_mr_select` if the MR tab hasn't loaded yet, so the target is reachable even when filtered out).
- Multiple MRs/PRs → M opens a selector listing `!{iid} [STATE] {title}` rows.

### Files
- `src/config.rs`: new `KeybindingIssues::jump_related_mrs` slot (`def_jump_related_mrs = "M"`), `BackendKind::term("mr_plural")` entries, example config + README updates.
- `src/domain/issues.rs`: new `RelatedMrRef` / `RelatedMrsState` types and `fetch_related_mrs` helper; `Issue.related_mrs: Option<RelatedMrsState>` with `#[serde(skip)]` so the cache never round-trips.
- `src/backend/mod.rs`: new `Backend::list_issue_related_mrs` trait method.
- `src/backend/glab.rs`: `/projects/{}/issues/{}/closed_by` implementation.
- `src/backend/gh.rs`: GraphQL `closedByPullRequestsReferences(first: N) { nodes { number title state } }` implementation (uses `gh api graphql`).
- `src/event.rs`: new `RelatedMrsFetched { issue_iid, result }` event.
- `src/fetch.rs`: `spawn_fetch_related_mrs` helper, plus a `maybe_fetch_related_mrs` glue function in `src/handlers/tabs.rs` triggered on j/k and tab switches.
- `src/app.rs`: `App::pending_mr_select` and `App::fetching_related_mrs` state.
- `src/handlers/tabs.rs`: `M` handler with the four-branch state machine; new `jump_to_mr_tab` / `jump_to_mr_tab_from_selector` helpers.
- `src/entity_editor.rs`: new "Related {Merge,Pull} Requests" row + value formatter handling all five states; unit tests for the backend-aware label and the loading / empty / items renderings.
- `src/ui/overlays.rs`: help-screen entry; `field_type = "related_mrs"` excluded from the search bar / footer chrome the same way `merge_options` and `review_submit_status` are.
- `src/main.rs`: `Event::RelatedMrsFetched` handler, `pending_mr_select` resolution inside `Event::MrsFetched`, and the related-MR selector dispatch (parses the `!{iid} [{STATE}] {title}` formatted item).

### Tests
- 310 unit + 71 e2e tests pass (`cargo test`).
- `cargo clippy --all-targets -- -D warnings` is clean.
- New JSON-parsing tests for both `closed_by` (GitLab) and the `data.repository.issue.closedByPullRequestsReferences.nodes` envelope (GitHub GraphQL).
- New tests for the empty / loading / items renderings and the backend-aware label switching in `build_issue_document`.
- New unit test asserting `Issue.related_mrs` survives neither serde direction (always `None` on the wire, restored to user-set value on read).