### PR TITLE
fix(group-mode): group mode & organization scoping fixes (Batch 2)

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -2241,7 +2241,7 @@ impl Backend for GhBackend {
     async fn fetch_labels(&self, scope: &Scope, _per_request: usize) -> Result<Vec<Label>> {
         let repo_arg = match scope {
             Scope::Repository(project) => project.as_str(),
-            Scope::Group(org) => org.as_str(),
+            Scope::Group(_org) => return Ok(vec![]),
         };
         let raw = self
             .run_gh(

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -143,15 +143,42 @@ pub fn spawn_refresh_active_tab(
                         // GitHub already populated both axes during list_mrs.
                         // GitLab needs one bulk GraphQL call for the same iids.
                         if !client.is_github && !mrs.is_empty() {
-                            let iids: Vec<u64> = mrs.iter().map(|m| m.iid).collect();
-                            // A failure here leaves both axes None, which renders
-                            // as "—". Deliberately not surfaced as an error: on an
-                            // unsupported GitLab this would fire every refresh.
-                            if let Ok(state) = client.list_mr_state(&repo_path, &iids).await {
-                                for mr in mrs.iter_mut() {
-                                    if let Some((approval, mergeability)) = state.get(&mr.iid) {
-                                        mr.approval = approval.clone();
-                                        mr.mergeability = mergeability.clone();
+                            let mut by_project: std::collections::HashMap<String, Vec<u64>> =
+                                std::collections::HashMap::new();
+                            for mr in mrs.iter() {
+                                let proj =
+                                    if !mr.project_path.is_empty() {
+                                        mr.project_path.clone()
+                                    } else if let Some(p) = mr.web_url.as_deref().and_then(
+                                        crate::git_helpers::parse_project_path_from_web_url,
+                                    ) {
+                                        p
+                                    } else {
+                                        repo_path.clone()
+                                    };
+                                by_project.entry(proj).or_default().push(mr.iid);
+                            }
+                            for (proj, iids) in by_project {
+                                if let Ok(state) = client.list_mr_state(&proj, &iids).await {
+                                    for mr in mrs.iter_mut() {
+                                        let mr_proj = if !mr.project_path.is_empty() {
+                                            mr.project_path.clone()
+                                        } else {
+                                            mr.web_url
+                                                .as_deref()
+                                                .and_then(
+                                                    crate::git_helpers::parse_project_path_from_web_url,
+                                                )
+                                                .unwrap_or_default()
+                                        };
+                                        if mr_proj == proj || scope.is_repository() {
+                                            if let Some((approval, mergeability)) =
+                                                state.get(&mr.iid)
+                                            {
+                                                mr.approval = approval.clone();
+                                                mr.mergeability = mergeability.clone();
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -61,9 +61,10 @@ pub fn parse_project_path_from_web_url(web_url: &str) -> Option<String> {
             }
         }
     }
-    if let Some((_, path_part)) = web_url.split_once("github.com/") {
+    let without_scheme = web_url.split_once("://").map(|(_, p)| p).unwrap_or(web_url);
+    if let Some((_, path_part)) = without_scheme.split_once('/') {
         let parts: Vec<&str> = path_part.split('/').collect();
-        if parts.len() >= 2 {
+        if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
             return Some(format!("{}/{}", parts[0], parts[1]));
         }
     }
@@ -274,6 +275,24 @@ pub fn get_workflow_files(is_github: bool) -> Vec<String> {
 mod tests {
     use super::{detect_backend, parse_project_path, parse_remote_host};
     use crate::backend::BackendKind;
+
+    #[test]
+    fn parses_web_url_for_custom_hosts() {
+        assert_eq!(
+            super::parse_project_path_from_web_url(
+                "https://github.mycorp.com/myorg/myrepo/issues/1"
+            )
+            .as_deref(),
+            Some("myorg/myrepo")
+        );
+        assert_eq!(
+            super::parse_project_path_from_web_url(
+                "https://gitlab.mycorp.com/group/subgroup/project/-/issues/1"
+            )
+            .as_deref(),
+            Some("group/subgroup/project")
+        );
+    }
 
     #[test]
     fn parses_remote_hosts() {

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -53,9 +53,27 @@ pub async fn handle_active_tab_key(
                     String::new(),
                     is_github,
                 );
+                let project = if app.scope.is_group() {
+                    app.issues
+                        .state
+                        .selected()
+                        .and_then(|idx| app.issues.items.get(idx))
+                        .map(|i| {
+                            if !i.project_path.is_empty() {
+                                i.project_path.clone()
+                            } else {
+                                crate::git_helpers::parse_project_path_from_web_url(&i.web_url)
+                                    .unwrap_or_default()
+                            }
+                        })
+                        .filter(|p| !p.is_empty())
+                        .unwrap_or_else(|| app.scope.as_str().to_string())
+                } else {
+                    app.scope.as_str().to_string()
+                };
                 app.open_edit_menu(crate::app::EditMenu {
                     title: "Create Issue".to_string(),
-                    entity_project: app.scope.as_str().to_string(),
+                    entity_project: project,
                     fields,
                     initial_fields: std::collections::HashMap::new(),
                     selected_idx: 0,
@@ -326,9 +344,29 @@ pub async fn handle_active_tab_key(
                     String::new(),
                     is_github,
                 );
+                let project = if app.scope.is_group() {
+                    app.mrs
+                        .state
+                        .selected()
+                        .and_then(|idx| app.mrs.items.get(idx))
+                        .map(|m| {
+                            if !m.project_path.is_empty() {
+                                m.project_path.clone()
+                            } else {
+                                m.web_url
+                                    .as_deref()
+                                    .and_then(crate::git_helpers::parse_project_path_from_web_url)
+                                    .unwrap_or_default()
+                            }
+                        })
+                        .filter(|p| !p.is_empty())
+                        .unwrap_or_else(|| app.scope.as_str().to_string())
+                } else {
+                    app.scope.as_str().to_string()
+                };
                 app.open_edit_menu(crate::app::EditMenu {
                     title: format!("Create {}", pr_suffix),
-                    entity_project: app.scope.as_str().to_string(),
+                    entity_project: project,
                     fields,
                     initial_fields: std::collections::HashMap::new(),
                     selected_idx: 0,


### PR DESCRIPTION
Fixes Batch 2 issues for Milestone v0.9.2:
- #412: Support GitHub Enterprise & custom hosts in parse_project_path_from_web_url
- #413: Group MR GraphQL queries by project path in GitLab group scope
- #414: Set entity_project from highlighted item in group mode quick-create
- #416: Return empty label list for GitHub org scope in fetch_labels instead of failing -R flag

Closes #412, Closes #413, Closes #414, Closes #416