### PR TITLE
fix(backend): CLI backend & git helper fixes (Batch 3)

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -618,9 +618,17 @@ impl Backend for GhBackend {
                 args.extend(["--milestone".into(), milestone.clone()]);
             }
         }
-        // Note: GitHub issues do not support due dates at the REST API level
-        // (`gh issue edit` has no `--due-date` flag). The `due_date` field in
-        // `IssueUpdate` is GitLab-specific and is intentionally ignored here.
+        if update.due_date.is_some()
+            && update.title.is_none()
+            && update.description.is_none()
+            && update.add_labels.is_empty()
+            && update.remove_labels.is_empty()
+            && update.add_assignees.is_empty()
+            && update.remove_assignees.is_empty()
+            && update.milestone.is_none()
+        {
+            anyhow::bail!("GitHub issues do not support due dates");
+        }
         let args_refs: Vec<&str> = args.iter().map(AsRef::as_ref).collect();
         self.run_gh(&args_refs, "UPDATING ISSUE").await?;
         Ok(())
@@ -1356,16 +1364,33 @@ impl Backend for GhBackend {
     ) -> Result<Vec<Pipeline>> {
         match scope {
             Scope::Repository(project) => {
-                let per_page = (page_size * 10).clamp(1, 100);
-                let endpoint = format!("repos/{project}/actions/runs?per_page={per_page}");
-                let raw = self.run_gh(&["api", &endpoint], "Fetching Actions").await?;
-
-                let mut runs = parse_github_actions_runs(&raw)?;
-                for run in &mut runs {
-                    if run.project_path.is_empty() {
-                        run.project_path = project.to_string();
+                let mut runs = Vec::new();
+                let limit = page_size.max(1);
+                let per_page = limit.min(100);
+                let mut page = 1;
+                while runs.len() < limit {
+                    let endpoint =
+                        format!("repos/{project}/actions/runs?per_page={per_page}&page={page}");
+                    let Ok(raw) = self.run_gh(&["api", &endpoint], "Fetching Actions").await else {
+                        break;
+                    };
+                    let fetched = parse_github_actions_runs(&raw)?;
+                    if fetched.is_empty() {
+                        break;
                     }
+                    let count = fetched.len();
+                    for mut run in fetched {
+                        if run.project_path.is_empty() {
+                            run.project_path = project.to_string();
+                        }
+                        runs.push(run);
+                    }
+                    if count < per_page {
+                        break;
+                    }
+                    page += 1;
                 }
+                runs.truncate(limit);
                 Ok(runs)
             }
             Scope::Group(org) => {
@@ -1641,27 +1666,21 @@ impl Backend for GhBackend {
             .collect())
     }
 
-    async fn pause_runner(&self, _project: &str, runner_id: u64) -> Result<()> {
-        anyhow::bail!(
-            "GitHub runner management requires a repository path; trait method lacks project parameter"
-        )
+    async fn pause_runner(&self, _project: &str, _runner_id: u64) -> Result<()> {
+        anyhow::bail!("Runner management (pause/resume/edit) is not supported for GitHub runners")
     }
 
-    async fn resume_runner(&self, _project: &str, runner_id: u64) -> Result<()> {
-        anyhow::bail!(
-            "GitHub runner management requires a repository path; trait method lacks project parameter"
-        )
+    async fn resume_runner(&self, _project: &str, _runner_id: u64) -> Result<()> {
+        anyhow::bail!("Runner management (pause/resume/edit) is not supported for GitHub runners")
     }
 
     async fn update_runner_description(
         &self,
         _project: &str,
-        runner_id: u64,
-        description: &str,
+        _runner_id: u64,
+        _description: &str,
     ) -> Result<()> {
-        anyhow::bail!(
-            "GitHub runner management requires a repository path; trait method lacks project parameter"
-        )
+        anyhow::bail!("Runner management (pause/resume/edit) is not supported for GitHub runners")
     }
 
     // ── Releases ──
@@ -1962,7 +1981,7 @@ impl Backend for GhBackend {
                 let iso_due = if due.contains('T') {
                     due.to_string()
                 } else {
-                    format!("{}T23:59:59Z", due)
+                    format!("{}T00:00:00Z", due)
                 };
                 args.push("-f".into());
                 args.push(format!("due_on={}", iso_due));
@@ -2530,6 +2549,14 @@ pub fn parse_github_actions_runs(raw: &str) -> Result<Vec<Pipeline>> {
         triggering_actor: Option<GhActor>,
         #[serde(default)]
         html_url: Option<String>,
+        #[serde(default)]
+        repository: Option<GhRepo>,
+    }
+
+    #[derive(Deserialize)]
+    struct GhRepo {
+        #[serde(default)]
+        full_name: String,
     }
 
     #[derive(Deserialize)]
@@ -2568,6 +2595,7 @@ pub fn parse_github_actions_runs(raw: &str) -> Result<Vec<Pipeline>> {
                     .and_then(|a| a.login)
                     .or_else(|| r.actor.and_then(|a| a.login))
                     .unwrap_or_default();
+                let project_path = r.repository.map(|repo| repo.full_name).unwrap_or_default();
                 Pipeline {
                     id: r.id,
                     status,
@@ -2581,7 +2609,7 @@ pub fn parse_github_actions_runs(raw: &str) -> Result<Vec<Pipeline>> {
                     duration_seconds: duration,
                     created_at: r.created_at,
                     source: r.event,
-                    project_path: String::new(),
+                    project_path,
                     web_url: r.html_url,
                 }
             })

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -179,11 +179,16 @@ pub fn get_branches() -> Vec<String> {
                     if line.is_empty() {
                         return None;
                     }
-                    let name = line.strip_prefix('*').unwrap_or(line).trim().to_string();
-                    let name = name
-                        .strip_prefix("remotes/origin/")
-                        .unwrap_or(&name)
-                        .to_string();
+                    let name = line.strip_prefix('*').unwrap_or(line).trim();
+                    let name = if let Some(stripped) = name.strip_prefix("remotes/") {
+                        if let Some((_remote, branch_part)) = stripped.split_once('/') {
+                            branch_part.to_string()
+                        } else {
+                            stripped.to_string()
+                        }
+                    } else {
+                        name.to_string()
+                    };
                     if name.is_empty() || name.contains(" -> ") {
                         return None;
                     }


### PR DESCRIPTION
Fixes Batch 3 issues for Milestone v0.9.2:
- #391: Verify release subcommand in glab backend
- #393: Return explicit error when trying to update due date on GitHub issues
- #397: Standardize milestone due_date time suffix to T00:00:00Z across create and update
- #398: Paginate list_pipelines up to page_size in GitHub backend
- #399: Dynamically strip remotes/<remote_name>/ prefix for any upstream remote branch
- #401: Fix runner stub error message to accurately reflect unsupported runner management
- #415: Populate project_path in parse_github_actions_runs

Closes #391, Closes #393, Closes #397, Closes #398, Closes #399, Closes #401, Closes #415