### PR TITLE
fix(ui): UI, table filtering & keybinding consistency (Batch 4)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3621,10 +3621,20 @@ impl App {
                     check_match(&item.iid.to_string());
                 }
                 if enabled_cols.contains("State") {
-                    if item.state == "opened" {
+                    if item.state.eq_ignore_ascii_case("opened")
+                        || item.state.eq_ignore_ascii_case("open")
+                        || item.state.eq_ignore_ascii_case("OPEN")
+                    {
                         check_match("OPEN");
-                    } else if item.state == "closed" {
+                        check_match("opened");
+                        check_match("open");
+                    } else if item.state.eq_ignore_ascii_case("closed")
+                        || item.state.eq_ignore_ascii_case("CLOSED")
+                    {
                         check_match("CLOSED");
+                        check_match("closed");
+                    } else {
+                        check_match(&item.state);
                     }
                 }
                 if enabled_cols.contains("Title") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7827,6 +7827,17 @@ async fn main() -> Result<()> {
                         continue;
                     }
 
+                    if keybinding_matches(&app.config.keybindings.global.save_view, &key_event)
+                        && !app.focus_column_checklist
+                        && app.text_input.is_none()
+                        && app.edit_menu.is_none()
+                        && app.selector.is_none()
+                    {
+                        app.save_layout(crate::app::SaveMenu::Global);
+                        app.show_error("Saved view configuration to config.toml".to_string());
+                        continue;
+                    }
+
                     if key_event.code == KeyCode::Char(',') && !app.focus_column_checklist {
                         app.focus_column_checklist = true;
                         app.column_checklist_idx = 0;

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -76,7 +76,10 @@ pub(crate) fn render_tab_issues(
             let is_checked = app
                 .selected_issues
                 .contains(&(i.project_path.clone(), i.iid));
-            let (state_text, state_style) = if i.state == "opened" {
+            let (state_text, state_style) = if i.state.eq_ignore_ascii_case("opened")
+                || i.state.eq_ignore_ascii_case("open")
+                || i.state.eq_ignore_ascii_case("OPEN")
+            {
                 (
                     format!("{} OPEN", icons.state_open),
                     Style::default()

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -190,16 +190,30 @@ pub fn parse_mr_title_prefix(title: &str) -> (String, String) {
 
 pub fn strip_ansi_escapes(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars();
+    let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\u{1b}' {
-            if let Some(next_c) = chars.next() {
+            if let Some(&next_c) = chars.peek() {
                 if next_c == '[' {
+                    chars.next();
                     for seq_c in chars.by_ref() {
                         if ('\u{40}'..='\u{7e}').contains(&seq_c) {
                             break;
                         }
                     }
+                } else if next_c == ']' {
+                    chars.next();
+                    while let Some(seq_c) = chars.next() {
+                        if seq_c == '\x07' {
+                            break;
+                        }
+                        if seq_c == '\u{1b}' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                } else if ('\u{40}'..='\u{5f}').contains(&next_c) {
+                    chars.next();
                 }
             }
         } else {
@@ -780,6 +794,12 @@ mod tests {
             strip_ansi_escapes(input),
             "[SUCCESS] Job finished successfully"
         );
+    }
+
+    #[test]
+    fn test_strip_ansi_escapes_osc_sequences() {
+        let input = "\u{1b}]0;title\u{07}clean text\u{1b}]8;;http://example.com\u{1b}\\link\u{1b}]8;;\u{1b}\\";
+        assert_eq!(strip_ansi_escapes(input), "clean textlink");
     }
 
     #[test]

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -82,6 +82,11 @@ impl<T> StatefulTable<T> {
         self.state.select(Some(i));
     }
 
+    pub fn next_item(&mut self) {
+        let len = self.items.len();
+        self.next(len);
+    }
+
     pub fn previous(&mut self, len: usize) {
         if len == 0 {
             return;
@@ -97,6 +102,11 @@ impl<T> StatefulTable<T> {
             None => 0,
         };
         self.state.select(Some(i));
+    }
+
+    pub fn previous_item(&mut self) {
+        let len = self.items.len();
+        self.previous(len);
     }
 
     pub fn unselect(&mut self) {


### PR DESCRIPTION
Fixes Batch 4 issues for Milestone v0.9.2:
- #392: Canonicalize case-insensitive State column filter matching ("OPEN" vs "opened")
- #400: Wire save_view keybinding in main event loop to save_layout
- #402: Add next_item and previous_item helpers to StatefulTable
- #403: Support OSC and non-CSI sequences in strip_ansi_escapes
- #406: Verify fallback theme tokens across theme loading

Closes #392, Closes #400, Closes #402, Closes #403, Closes #406