### PR TITLE
feat(editor): add global submit_edit shortcut for edit forms (#410)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ theme_preset = "default"   # default | tokyo-night | gruvbox | nord | catppuccin
 # Remap any keybinding
 [keybindings.global]
 next_tab = "l"
+submit_edit = "Ctrl+Enter"
 # ...
 
 [keybindings.issues]

--- a/src/config.rs
+++ b/src/config.rs
@@ -685,6 +685,8 @@ pub struct KeybindingGlobal {
     pub switch_repo: String,
     #[serde(default = "def_jump_to_id")]
     pub jump_to_id: String,
+    #[serde(default = "def_submit_edit")]
+    pub submit_edit: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -969,6 +971,7 @@ keybind_defaults! {
     def_drill_into_scope = "G",
     def_switch_repo = "Ctrl+s",
     def_jump_to_id = "g",
+    def_submit_edit = "Ctrl+Enter",
 }
 
 impl Default for KeybindingGlobal {
@@ -987,6 +990,7 @@ impl Default for KeybindingGlobal {
             save_view: def_save_view(),
             switch_repo: def_switch_repo(),
             jump_to_id: def_jump_to_id(),
+            submit_edit: def_submit_edit(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4375,6 +4375,18 @@ async fn main() -> Result<()> {
                     }
 
                     if let Some(mut menu) = app.edit_menu.take() {
+                        let is_submit_edit =
+                            keybinding_matches(
+                                &app.config.keybindings.global.submit_edit,
+                                &key_event,
+                            ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
+                                && key_event.code == KeyCode::Enter);
+
+                        if is_submit_edit {
+                            menu.editing = false;
+                            menu.selected_idx = menu.fields.len() + 1;
+                        }
+
                         if key_event.modifiers.contains(KeyModifiers::CONTROL)
                             && key_event.code == KeyCode::Char('s')
                         {
@@ -4652,7 +4664,14 @@ async fn main() -> Result<()> {
                                 let entity_type = menu.entity_kind.legacy_string();
                                 let is_new_entity =
                                     entity_iid == 0 || entity_type.starts_with("new_");
-                                let is_on_submit = menu.selected_idx == menu.fields.len() + 1;
+                                let is_submit_edit_key =
+                                    keybinding_matches(
+                                        &app.config.keybindings.global.submit_edit,
+                                        &key_event,
+                                    ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
+                                        && key_event.code == KeyCode::Enter);
+                                let is_on_submit = (menu.selected_idx == menu.fields.len() + 1)
+                                    || (is_new_entity && is_submit_edit_key);
 
                                 if is_on_submit {
                                     if entity_type == "new_issue" {

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1238,6 +1238,11 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Global & Nav",
+            key: d(app.config.keybindings.global.submit_edit.clone()),
+            action: "Submit/Save active edit form",
+        },
+        Shortcut {
+            category: "Global & Nav",
             key: s("Ctrl+C"),
             action: "Quit program",
         },


### PR DESCRIPTION
Adds configurable  keybinding (default ) to submit active Issue/MR edit forms directly from any field without needing footer navigation.