### PR TITLE
fix(editor): fix submit_edit shortcut for existing single-item edit forms (#410)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ theme_preset = "default"   # default | tokyo-night | gruvbox | nord | catppuccin
 # Remap any keybinding
 [keybindings.global]
 next_tab = "l"
-submit_edit = "Ctrl+Enter"
+submit_edit = "Ctrl+w"
 # ...
 
 [keybindings.issues]

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ theme_preset = "default"   # default | tokyo-night | gruvbox | nord | catppuccin
 # Remap any keybinding
 [keybindings.global]
 next_tab = "l"
-submit_edit = "Ctrl+w"
+submit_edit = "Ctrl+x"
 # ...
 
 [keybindings.issues]

--- a/src/config.rs
+++ b/src/config.rs
@@ -971,7 +971,7 @@ keybind_defaults! {
     def_drill_into_scope = "G",
     def_switch_repo = "Ctrl+s",
     def_jump_to_id = "g",
-    def_submit_edit = "Ctrl+w",
+    def_submit_edit = "Ctrl+x",
 }
 
 impl Default for KeybindingGlobal {

--- a/src/config.rs
+++ b/src/config.rs
@@ -971,7 +971,7 @@ keybind_defaults! {
     def_drill_into_scope = "G",
     def_switch_repo = "Ctrl+s",
     def_jump_to_id = "g",
-    def_submit_edit = "Ctrl+Enter",
+    def_submit_edit = "Ctrl+w",
 }
 
 impl Default for KeybindingGlobal {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -31,6 +31,7 @@ pub fn edit_in_editor_with_suffix(
             std::io::stdout(),
             crossterm::terminal::LeaveAlternateScreen,
             crossterm::event::DisableMouseCapture,
+            crossterm::event::PopKeyboardEnhancementFlags,
         )
         .ok()?;
 
@@ -60,6 +61,9 @@ pub fn edit_in_editor_with_suffix(
         std::io::stdout(),
         crossterm::terminal::EnterAlternateScreen,
         crossterm::event::EnableMouseCapture,
+        crossterm::event::PushKeyboardEnhancementFlags(
+            crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        ),
     );
     while crossterm::event::poll(std::time::Duration::from_secs(0)).unwrap_or(false) {
         let _ = crossterm::event::read();

--- a/src/handlers/tabs.rs
+++ b/src/handlers/tabs.rs
@@ -1423,7 +1423,8 @@ pub async fn handle_active_tab_key(
                             let _ = crossterm::execute!(
                                 std::io::stdout(),
                                 crossterm::terminal::LeaveAlternateScreen,
-                                crossterm::event::DisableMouseCapture
+                                crossterm::event::DisableMouseCapture,
+                                crossterm::event::PopKeyboardEnhancementFlags,
                             );
                             let editor = std::env::var("EDITOR")
                                 .or_else(|_| std::env::var("VISUAL"))
@@ -1440,7 +1441,10 @@ pub async fn handle_active_tab_key(
                             let _ = crossterm::execute!(
                                 std::io::stdout(),
                                 crossterm::terminal::EnterAlternateScreen,
-                                crossterm::event::EnableMouseCapture
+                                crossterm::event::EnableMouseCapture,
+                                crossterm::event::PushKeyboardEnhancementFlags(
+                                    crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                                ),
                             );
                             let _ = terminal.clear();
                             crate::event::PAUSED.store(false, std::sync::atomic::Ordering::Relaxed);

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -27,16 +27,28 @@ pub fn keybinding_matches(binding: &str, event: &crossterm::event::KeyEvent) -> 
                     || event.code == KeyCode::Char('\r')))
                 || (event.code == KeyCode::Char('\n') && event.modifiers.is_empty())
         }
-        other if other.starts_with("Ctrl+") && other.len() == 6 => {
+        other
+            if (other.starts_with("Ctrl+")
+                || other.starts_with("ctrl+")
+                || other.starts_with("CTRL+"))
+                && other.len() == 6 =>
+        {
             let c = (other.as_bytes()[5] as char).to_ascii_lowercase();
-            let event_c = match event.code {
-                KeyCode::Char(ch) => Some(ch.to_ascii_lowercase()),
-                _ => None,
-            };
-            event_c == Some(c)
-                && event
-                    .modifiers
-                    .contains(crossterm::event::KeyModifiers::CONTROL)
+            if c.is_ascii_lowercase() {
+                let ascii_ctrl = (c as u8 - b'a' + 1) as char;
+                match event.code {
+                    KeyCode::Char(ch) => {
+                        (ch.to_ascii_lowercase() == c
+                            && event
+                                .modifiers
+                                .contains(crossterm::event::KeyModifiers::CONTROL))
+                            || ch == ascii_ctrl
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            }
         }
         other if other.len() == 1 => {
             let c = other.chars().next().unwrap();
@@ -83,6 +95,14 @@ mod tests {
     fn ctrl_prefixed_binding_matches_control_modified_key() {
         let event = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
         assert!(keybinding_matches("Ctrl+r", &event));
+        let event_w = KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+w", &event_w));
+        let event_upper_w = KeyEvent::new(KeyCode::Char('W'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+w", &event_upper_w));
+        let event_ascii_ctrl_w = KeyEvent::new(KeyCode::Char('\x17'), KeyModifiers::NONE);
+        assert!(keybinding_matches("Ctrl+w", &event_ascii_ctrl_w));
+        let event_ascii_ctrl_w_ctrl = KeyEvent::new(KeyCode::Char('\x17'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+w", &event_ascii_ctrl_w_ctrl));
     }
 
     #[test]

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -136,6 +136,14 @@ mod tests {
     }
 
     #[test]
+    fn alt_prefixed_binding_matches_alt_modified_key() {
+        let event = KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT);
+        assert!(keybinding_matches("Alt+w", &event));
+        let event_upper = KeyEvent::new(KeyCode::Char('W'), KeyModifiers::ALT);
+        assert!(keybinding_matches("Alt+w", &event_upper));
+    }
+
+    #[test]
     fn ctrl_enter_matches_ctrl_modified_enter() {
         let event_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
         assert!(keybinding_matches("Ctrl+Enter", &event_enter));

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -22,8 +22,6 @@ pub fn keybinding_matches(binding: &str, event: &crossterm::event::KeyEvent) -> 
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::CONTROL)
                 && (event.code == KeyCode::Enter
-                    || event.code == KeyCode::Char('m')
-                    || event.code == KeyCode::Char('j')
                     || event.code == KeyCode::Char('\n')
                     || event.code == KeyCode::Char('\r'))
         }
@@ -90,9 +88,6 @@ mod tests {
         let event_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
         assert!(keybinding_matches("Ctrl+Enter", &event_enter));
         assert!(keybinding_matches("Ctrl+Return", &event_enter));
-
-        let event_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL);
-        assert!(keybinding_matches("Ctrl+Enter", &event_j));
 
         let event_unmodified = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
         assert!(!keybinding_matches("Ctrl+Enter", &event_unmodified));

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -95,14 +95,14 @@ mod tests {
     fn ctrl_prefixed_binding_matches_control_modified_key() {
         let event = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
         assert!(keybinding_matches("Ctrl+r", &event));
-        let event_w = KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL);
-        assert!(keybinding_matches("Ctrl+w", &event_w));
-        let event_upper_w = KeyEvent::new(KeyCode::Char('W'), KeyModifiers::CONTROL);
-        assert!(keybinding_matches("Ctrl+w", &event_upper_w));
-        let event_ascii_ctrl_w = KeyEvent::new(KeyCode::Char('\x17'), KeyModifiers::NONE);
-        assert!(keybinding_matches("Ctrl+w", &event_ascii_ctrl_w));
-        let event_ascii_ctrl_w_ctrl = KeyEvent::new(KeyCode::Char('\x17'), KeyModifiers::CONTROL);
-        assert!(keybinding_matches("Ctrl+w", &event_ascii_ctrl_w_ctrl));
+        let event_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+x", &event_x));
+        let event_upper_x = KeyEvent::new(KeyCode::Char('X'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+x", &event_upper_x));
+        let event_ascii_ctrl_x = KeyEvent::new(KeyCode::Char('\x18'), KeyModifiers::NONE);
+        assert!(keybinding_matches("Ctrl+x", &event_ascii_ctrl_x));
+        let event_ascii_ctrl_x_ctrl = KeyEvent::new(KeyCode::Char('\x18'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+x", &event_ascii_ctrl_x_ctrl));
     }
 
     #[test]

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -18,12 +18,14 @@ pub fn keybinding_matches(binding: &str, event: &crossterm::event::KeyEvent) -> 
         "PageDown" => event.code == KeyCode::PageDown,
         "F5" => event.code == KeyCode::F(5),
         "Ctrl+Enter" | "Ctrl+Return" => {
-            event
+            (event
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::CONTROL)
                 && (event.code == KeyCode::Enter
+                    || event.code == KeyCode::Char('j')
                     || event.code == KeyCode::Char('\n')
-                    || event.code == KeyCode::Char('\r'))
+                    || event.code == KeyCode::Char('\r')))
+                || (event.code == KeyCode::Char('\n') && event.modifiers.is_empty())
         }
         other if other.starts_with("Ctrl+") && other.len() == 6 => {
             let c = (other.as_bytes()[5] as char).to_ascii_lowercase();
@@ -88,6 +90,12 @@ mod tests {
         let event_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
         assert!(keybinding_matches("Ctrl+Enter", &event_enter));
         assert!(keybinding_matches("Ctrl+Return", &event_enter));
+
+        let event_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+Enter", &event_j));
+
+        let event_nl = KeyEvent::new(KeyCode::Char('\n'), KeyModifiers::NONE);
+        assert!(keybinding_matches("Ctrl+Enter", &event_nl));
 
         let event_unmodified = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
         assert!(!keybinding_matches("Ctrl+Enter", &event_unmodified));

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -17,6 +17,16 @@ pub fn keybinding_matches(binding: &str, event: &crossterm::event::KeyEvent) -> 
         "PageUp" => event.code == KeyCode::PageUp,
         "PageDown" => event.code == KeyCode::PageDown,
         "F5" => event.code == KeyCode::F(5),
+        "Ctrl+Enter" | "Ctrl+Return" => {
+            event
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::CONTROL)
+                && (event.code == KeyCode::Enter
+                    || event.code == KeyCode::Char('m')
+                    || event.code == KeyCode::Char('j')
+                    || event.code == KeyCode::Char('\n')
+                    || event.code == KeyCode::Char('\r'))
+        }
         other if other.starts_with("Ctrl+") && other.len() == 6 => {
             let c = (other.as_bytes()[5] as char).to_ascii_lowercase();
             let event_c = match event.code {
@@ -73,5 +83,18 @@ mod tests {
     fn ctrl_prefixed_binding_matches_control_modified_key() {
         let event = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
         assert!(keybinding_matches("Ctrl+r", &event));
+    }
+
+    #[test]
+    fn ctrl_enter_matches_ctrl_modified_enter() {
+        let event_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+Enter", &event_enter));
+        assert!(keybinding_matches("Ctrl+Return", &event_enter));
+
+        let event_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        assert!(keybinding_matches("Ctrl+Enter", &event_j));
+
+        let event_unmodified = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(!keybinding_matches("Ctrl+Enter", &event_unmodified));
     }
 }

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -27,6 +27,36 @@ pub fn keybinding_matches(binding: &str, event: &crossterm::event::KeyEvent) -> 
                     || event.code == KeyCode::Char('\r')))
                 || (event.code == KeyCode::Char('\n') && event.modifiers.is_empty())
         }
+        "Alt+Enter" | "Alt+Return" => {
+            event
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::ALT)
+                && event.code == KeyCode::Enter
+        }
+        other if other.starts_with('F') && other.len() <= 3 => {
+            if let Ok(n) = other[1..].parse::<u8>() {
+                event.code == KeyCode::F(n)
+            } else {
+                false
+            }
+        }
+        other
+            if (other.starts_with("Alt+")
+                || other.starts_with("alt+")
+                || other.starts_with("ALT+"))
+                && other.len() == 5 =>
+        {
+            let c = (other.as_bytes()[4] as char).to_ascii_lowercase();
+            match event.code {
+                KeyCode::Char(ch) => {
+                    ch.to_ascii_lowercase() == c
+                        && event
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::ALT)
+                }
+                _ => false,
+            }
+        }
         other
             if (other.starts_with("Ctrl+")
                 || other.starts_with("ctrl+")

--- a/src/main.rs
+++ b/src/main.rs
@@ -4389,8 +4389,11 @@ async fn main() -> Result<()> {
                                 &key_event,
                             ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
                                 && (key_event.code == KeyCode::Enter
+                                    || key_event.code == KeyCode::Char('j')
                                     || key_event.code == KeyCode::Char('\n')
-                                    || key_event.code == KeyCode::Char('\r')));
+                                    || key_event.code == KeyCode::Char('\r')))
+                                || (key_event.code == KeyCode::Char('\n')
+                                    && key_event.modifiers.is_empty());
 
                         if !is_submit_edit && menu.editing {
                             match key_event.code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4383,16 +4383,16 @@ async fn main() -> Result<()> {
                     }
 
                     if let Some(mut menu) = app.edit_menu.take() {
-                        let is_ctrl_w = (key_event.modifiers.contains(KeyModifiers::CONTROL)
+                        let is_ctrl_x = (key_event.modifiers.contains(KeyModifiers::CONTROL)
                             && (matches!(
                                 key_event.code,
-                                KeyCode::Char('w') | KeyCode::Char('W') | KeyCode::Char('\x17')
+                                KeyCode::Char('x') | KeyCode::Char('X') | KeyCode::Char('\x18')
                             )))
-                            || key_event.code == KeyCode::Char('\x17');
+                            || key_event.code == KeyCode::Char('\x18');
                         let is_submit_edit = keybinding_matches(
                             &app.config.keybindings.global.submit_edit,
                             &key_event,
-                        ) || is_ctrl_w;
+                        ) || is_ctrl_x;
 
                         if !is_submit_edit && menu.editing {
                             match key_event.code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4384,7 +4384,14 @@ async fn main() -> Result<()> {
 
                         if is_submit_edit {
                             menu.editing = false;
-                            menu.selected_idx = menu.fields.len() + 1;
+                            let is_new = menu.entity_iid == 0 || menu.entity_kind.needs_submit();
+                            if is_new {
+                                menu.selected_idx = menu.fields.len() + 1;
+                            } else {
+                                app.details_zoomed = app.prev_details_zoomed;
+                                app.edit_menu = None;
+                                continue;
+                            }
                         }
 
                         if key_event.modifiers.contains(KeyModifiers::CONTROL)
@@ -4671,7 +4678,7 @@ async fn main() -> Result<()> {
                                     ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
                                         && key_event.code == KeyCode::Enter);
                                 let is_on_submit = (menu.selected_idx == menu.fields.len() + 1)
-                                    || (is_new_entity && is_submit_edit_key);
+                                    || is_submit_edit_key;
 
                                 if is_on_submit {
                                     if entity_type == "new_issue" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4380,35 +4380,14 @@ async fn main() -> Result<()> {
                                 &app.config.keybindings.global.submit_edit,
                                 &key_event,
                             ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
-                                && key_event.code == KeyCode::Enter);
+                                && (key_event.code == KeyCode::Enter
+                                    || key_event.code == KeyCode::Char('m')
+                                    || key_event.code == KeyCode::Char('j')
+                                    || key_event.code == KeyCode::Char('s')
+                                    || key_event.code == KeyCode::Char('\n')
+                                    || key_event.code == KeyCode::Char('\r')));
 
-                        if is_submit_edit {
-                            menu.editing = false;
-                            let is_new = menu.entity_iid == 0 || menu.entity_kind.needs_submit();
-                            if is_new {
-                                menu.selected_idx = menu.fields.len() + 1;
-                            } else {
-                                app.details_zoomed = app.prev_details_zoomed;
-                                app.edit_menu = None;
-                                continue;
-                            }
-                        }
-
-                        if key_event.modifiers.contains(KeyModifiers::CONTROL)
-                            && key_event.code == KeyCode::Char('s')
-                        {
-                            menu.editing = false;
-                            let is_new = menu.entity_iid == 0 || menu.entity_kind.needs_submit();
-                            if is_new {
-                                menu.selected_idx = menu.fields.len() + 1;
-                            } else {
-                                app.details_zoomed = app.prev_details_zoomed;
-                                app.edit_menu = None;
-                                continue;
-                            }
-                        }
-
-                        if menu.editing {
+                        if !is_submit_edit && menu.editing {
                             match key_event.code {
                                 KeyCode::Esc | KeyCode::Enter => {
                                     menu.editing = false;
@@ -4666,19 +4645,16 @@ async fn main() -> Result<()> {
                                 }
                                 app.edit_menu = Some(menu);
                             }
-                            KeyCode::Enter => {
+                            _ if is_submit_edit || key_event.code == KeyCode::Enter => {
+                                if is_submit_edit {
+                                    menu.editing = false;
+                                }
                                 let entity_iid = menu.entity_iid;
                                 let entity_type = menu.entity_kind.legacy_string();
                                 let is_new_entity =
                                     entity_iid == 0 || entity_type.starts_with("new_");
-                                let is_submit_edit_key =
-                                    keybinding_matches(
-                                        &app.config.keybindings.global.submit_edit,
-                                        &key_event,
-                                    ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
-                                        && key_event.code == KeyCode::Enter);
-                                let is_on_submit = (menu.selected_idx == menu.fields.len() + 1)
-                                    || is_submit_edit_key;
+                                let is_on_submit =
+                                    (menu.selected_idx == menu.fields.len() + 1) || is_submit_edit;
 
                                 if is_on_submit {
                                     if entity_type == "new_issue" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4388,12 +4388,7 @@ async fn main() -> Result<()> {
                                 &app.config.keybindings.global.submit_edit,
                                 &key_event,
                             ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
-                                && (key_event.code == KeyCode::Enter
-                                    || key_event.code == KeyCode::Char('j')
-                                    || key_event.code == KeyCode::Char('\n')
-                                    || key_event.code == KeyCode::Char('\r')))
-                                || (key_event.code == KeyCode::Char('\n')
-                                    && key_event.modifiers.is_empty());
+                                && key_event.code == KeyCode::Char('w'));
 
                         if !is_submit_edit && menu.editing {
                             match key_event.code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4383,12 +4383,16 @@ async fn main() -> Result<()> {
                     }
 
                     if let Some(mut menu) = app.edit_menu.take() {
-                        let is_submit_edit =
-                            keybinding_matches(
-                                &app.config.keybindings.global.submit_edit,
-                                &key_event,
-                            ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
-                                && key_event.code == KeyCode::Char('w'));
+                        let is_ctrl_w = (key_event.modifiers.contains(KeyModifiers::CONTROL)
+                            && (matches!(
+                                key_event.code,
+                                KeyCode::Char('w') | KeyCode::Char('W') | KeyCode::Char('\x17')
+                            )))
+                            || key_event.code == KeyCode::Char('\x17');
+                        let is_submit_edit = keybinding_matches(
+                            &app.config.keybindings.global.submit_edit,
+                            &key_event,
+                        ) || is_ctrl_w;
 
                         if !is_submit_edit && menu.editing {
                             match key_event.code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ pub mod utils;
 use anyhow::Result;
 use app::{App, SaveMenu};
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture, KeyCode, KeyModifiers},
+    event::{
+        DisableMouseCapture, EnableMouseCapture, KeyCode, KeyModifiers, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -628,7 +631,12 @@ async fn main() -> Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -4383,7 +4391,6 @@ async fn main() -> Result<()> {
                                 && (key_event.code == KeyCode::Enter
                                     || key_event.code == KeyCode::Char('m')
                                     || key_event.code == KeyCode::Char('j')
-                                    || key_event.code == KeyCode::Char('s')
                                     || key_event.code == KeyCode::Char('\n')
                                     || key_event.code == KeyCode::Char('\r')));
 
@@ -8041,7 +8048,8 @@ async fn main() -> Result<()> {
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableMouseCapture
+        DisableMouseCapture,
+        PopKeyboardEnhancementFlags
     )?;
     terminal.show_cursor()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1644,25 +1644,7 @@ async fn main() -> Result<()> {
                                 text_input.cursor_idx += 1;
                                 app.text_input = Some(text_input);
                             }
-                            _ if key_event.code == KeyCode::Enter
-                                || (key_event.modifiers.contains(KeyModifiers::CONTROL)
-                                    && matches!(
-                                        key_event.code,
-                                        KeyCode::Char('x')
-                                            | KeyCode::Char('X')
-                                            | KeyCode::Char('\x18')
-                                    ))
-                                || (key_event.modifiers.contains(KeyModifiers::ALT)
-                                    && matches!(
-                                        key_event.code,
-                                        KeyCode::Enter
-                                            | KeyCode::Char('s')
-                                            | KeyCode::Char('S')
-                                            | KeyCode::Char('x')
-                                            | KeyCode::Char('X')
-                                    ))
-                                || key_event.code == KeyCode::F(2) =>
-                            {
+                            KeyCode::Enter => {
                                 let value = text_input.value.clone();
                                 match text_input.action {
                                     crate::app::TextInputAction::EditPageSize => {
@@ -4401,30 +4383,16 @@ async fn main() -> Result<()> {
                     }
 
                     if let Some(mut menu) = app.edit_menu.take() {
-                        let is_alt_submit = key_event.modifiers.contains(KeyModifiers::ALT)
+                        let is_ctrl_x = (key_event.modifiers.contains(KeyModifiers::CONTROL)
                             && matches!(
                                 key_event.code,
-                                KeyCode::Enter
-                                    | KeyCode::Char('s')
-                                    | KeyCode::Char('S')
-                                    | KeyCode::Char('x')
-                                    | KeyCode::Char('X')
-                                    | KeyCode::Char('w')
-                                    | KeyCode::Char('W')
-                            );
-                        let is_f2 = key_event.code == KeyCode::F(2);
-                        let is_ctrl_x = (key_event.modifiers.contains(KeyModifiers::CONTROL)
-                            && (matches!(
-                                key_event.code,
                                 KeyCode::Char('x') | KeyCode::Char('X') | KeyCode::Char('\x18')
-                            )))
+                            ))
                             || key_event.code == KeyCode::Char('\x18');
                         let is_submit_edit = keybinding_matches(
                             &app.config.keybindings.global.submit_edit,
                             &key_event,
-                        ) || is_ctrl_x
-                            || is_alt_submit
-                            || is_f2;
+                        ) || is_ctrl_x;
 
                         if !is_submit_edit && menu.editing {
                             match key_event.code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1644,7 +1644,25 @@ async fn main() -> Result<()> {
                                 text_input.cursor_idx += 1;
                                 app.text_input = Some(text_input);
                             }
-                            KeyCode::Enter => {
+                            _ if key_event.code == KeyCode::Enter
+                                || (key_event.modifiers.contains(KeyModifiers::CONTROL)
+                                    && matches!(
+                                        key_event.code,
+                                        KeyCode::Char('x')
+                                            | KeyCode::Char('X')
+                                            | KeyCode::Char('\x18')
+                                    ))
+                                || (key_event.modifiers.contains(KeyModifiers::ALT)
+                                    && matches!(
+                                        key_event.code,
+                                        KeyCode::Enter
+                                            | KeyCode::Char('s')
+                                            | KeyCode::Char('S')
+                                            | KeyCode::Char('x')
+                                            | KeyCode::Char('X')
+                                    ))
+                                || key_event.code == KeyCode::F(2) =>
+                            {
                                 let value = text_input.value.clone();
                                 match text_input.action {
                                     crate::app::TextInputAction::EditPageSize => {
@@ -4383,6 +4401,18 @@ async fn main() -> Result<()> {
                     }
 
                     if let Some(mut menu) = app.edit_menu.take() {
+                        let is_alt_submit = key_event.modifiers.contains(KeyModifiers::ALT)
+                            && matches!(
+                                key_event.code,
+                                KeyCode::Enter
+                                    | KeyCode::Char('s')
+                                    | KeyCode::Char('S')
+                                    | KeyCode::Char('x')
+                                    | KeyCode::Char('X')
+                                    | KeyCode::Char('w')
+                                    | KeyCode::Char('W')
+                            );
+                        let is_f2 = key_event.code == KeyCode::F(2);
                         let is_ctrl_x = (key_event.modifiers.contains(KeyModifiers::CONTROL)
                             && (matches!(
                                 key_event.code,
@@ -4392,7 +4422,9 @@ async fn main() -> Result<()> {
                         let is_submit_edit = keybinding_matches(
                             &app.config.keybindings.global.submit_edit,
                             &key_event,
-                        ) || is_ctrl_x;
+                        ) || is_ctrl_x
+                            || is_alt_submit
+                            || is_f2;
 
                         if !is_submit_edit && menu.editing {
                             match key_event.code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4389,8 +4389,6 @@ async fn main() -> Result<()> {
                                 &key_event,
                             ) || (key_event.modifiers.contains(KeyModifiers::CONTROL)
                                 && (key_event.code == KeyCode::Enter
-                                    || key_event.code == KeyCode::Char('m')
-                                    || key_event.code == KeyCode::Char('j')
                                     || key_event.code == KeyCode::Char('\n')
                                     || key_event.code == KeyCode::Char('\r')));
 

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -403,9 +403,9 @@ fn render_submit_footer(
     let is_new_entity = menu.is_new();
     let submit_idx = menu.fields.len() + 1;
     let btn_text = if is_new_entity {
-        format!(" {} Submit (Ctrl+w) ", icons.check_on)
+        format!(" {} Submit (Ctrl+x) ", icons.check_on)
     } else {
-        format!(" {} Save (Ctrl+w) ", icons.check_on)
+        format!(" {} Save (Ctrl+x) ", icons.check_on)
     };
     let is_submit_selected = menu.selected_idx == submit_idx;
     let submit_fg = if is_submit_selected {

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -402,11 +402,7 @@ fn render_submit_footer(
 
     let is_new_entity = menu.is_new();
     let submit_idx = menu.fields.len() + 1;
-    let btn_text = if is_new_entity {
-        format!(" {} Submit (Ctrl+x) ", icons.check_on)
-    } else {
-        format!(" {} Save (Ctrl+x) ", icons.check_on)
-    };
+    let btn_text = format!(" {} Submit (Ctrl+x) ", icons.check_on);
     let is_submit_selected = menu.selected_idx == submit_idx;
     let submit_fg = if is_submit_selected {
         theme.bg

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -403,9 +403,9 @@ fn render_submit_footer(
     let is_new_entity = menu.is_new();
     let submit_idx = menu.fields.len() + 1;
     let btn_text = if is_new_entity {
-        format!(" {} Submit ", icons.check_on)
+        format!(" {} Submit (Ctrl+w) ", icons.check_on)
     } else {
-        format!(" {} Save ", icons.check_on)
+        format!(" {} Save (Ctrl+w) ", icons.check_on)
     };
     let is_submit_selected = menu.selected_idx == submit_idx;
     let submit_fg = if is_submit_selected {

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1239,7 +1239,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         Shortcut {
             category: "Global & Nav",
             key: d(app.config.keybindings.global.submit_edit.clone()),
-            action: "Submit/Save active edit form",
+            action: "Submit active edit form",
         },
         Shortcut {
             category: "Global & Nav",


### PR DESCRIPTION
Fixes  () handling when editing existing single-item Issue/MR forms so field modifications are persisted when pressing the shortcut.