### PR TITLE
feat(nav): jump to issue/MR by ID via Ctrl+p global search

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Every table tab (Issues, MRs/PRs, Pipelines, Jobs, Runners, Releases, Todos, Mil
 | `f` / `/` | Open search / filter bar | `search` |
 | `Enter` / `Esc` (in search) | Close search bar | — |
 | `?` / `F1` | Show help | `help` |
-| `Ctrl+P` | Global search across all loaded issues & MRs | `global_search` |
+| `g` | Jump to issue/MR by ID; fetches from the API if not cached | `jump_to_id` |
 | `Ctrl+S` | Switch repository | — |
 | `F5` / `Ctrl+R` | Refresh current tab | `refresh` |
 | `s` | Save view layout to config | `save_view` |

--- a/src/app.rs
+++ b/src/app.rs
@@ -2300,7 +2300,6 @@ pub enum TextInputAction {
     },
     CreateBranch(String), // ref_branch name
     EditPageSize,
-    JumpToId,
 }
 
 #[derive(Clone, Debug)]
@@ -2309,6 +2308,49 @@ pub struct TextInput {
     pub value: String,
     pub cursor_idx: usize,
     pub action: TextInputAction,
+}
+
+/// Target kind parsed from the "go to issue/MR by ID" prompt value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JumpKind {
+    Issue,
+    Mr,
+}
+
+/// Parse a "jump to issue/MR by ID" prompt value into an optional target kind
+/// plus a numeric ID. Supported forms: `#123` / `issue 123` (issue),
+/// `!123` / `mr 123` / `pr 123` (merge request), and a bare `123` which stays
+/// scoped to the active tab (`None` kind). Returns `None` when the value
+/// cannot be interpreted as an ID.
+pub fn parse_jump_input(input: &str) -> Option<(Option<JumpKind>, u64)> {
+    let raw = input.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (kind, digits) = if let Some(rest) = raw.strip_prefix('#') {
+        (Some(JumpKind::Issue), rest)
+    } else if let Some(rest) = raw.strip_prefix('!') {
+        (Some(JumpKind::Mr), rest)
+    } else if let Some((word, num)) = raw.split_once(char::is_whitespace) {
+        if word.eq_ignore_ascii_case("issue") || word.eq_ignore_ascii_case("issues") {
+            (Some(JumpKind::Issue), num)
+        } else if word.eq_ignore_ascii_case("mr")
+            || word.eq_ignore_ascii_case("mrs")
+            || word.eq_ignore_ascii_case("pr")
+            || word.eq_ignore_ascii_case("prs")
+        {
+            (Some(JumpKind::Mr), num)
+        } else {
+            return None;
+        }
+    } else {
+        (None, raw)
+    };
+    let id: u64 = digits.trim().parse().ok()?;
+    if id == 0 {
+        return None;
+    }
+    Some((kind, id))
 }
 
 #[derive(Clone, Debug)]
@@ -3195,6 +3237,52 @@ impl App {
         let old = std::mem::replace(&mut self.scope, crate::scope::Scope::Repository(repo));
         self.prev_scope = Some(old);
         self.reset_on_scope_change();
+    }
+
+    /// Clear the fuzzy-search query and the given tab's column filters so a
+    /// target row stays visible regardless of active filtering.
+    fn clear_tab_filters(&mut self, tab: Tab) {
+        self.search_query.clear();
+        self.column_filters.remove(&tab);
+    }
+
+    /// Switch to the Issues tab, drop filters that would hide the target, and
+    /// select + preview `iid`. Returns whether the item is already loaded.
+    pub fn focus_issue(&mut self, iid: u64) -> bool {
+        self.active_tab = Tab::Issues;
+        self.clear_tab_filters(Tab::Issues);
+        let idx = {
+            let filtered = self.filtered_issues();
+            filtered.iter().position(|i| i.iid == iid)
+        };
+        if let Some(idx) = idx {
+            self.issues.state.select(Some(idx));
+            self.detail_scroll = 0;
+            self.details_zoomed = false;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Switch to the MergeRequests tab, drop filters that would hide the
+    /// target, and select + preview `iid`. Returns whether the item is already
+    /// loaded.
+    pub fn focus_mr(&mut self, iid: u64) -> bool {
+        self.active_tab = Tab::MergeRequests;
+        self.clear_tab_filters(Tab::MergeRequests);
+        let idx = {
+            let filtered = self.filtered_mrs();
+            filtered.iter().position(|m| m.iid == iid)
+        };
+        if let Some(idx) = idx {
+            self.mrs.state.select(Some(idx));
+            self.detail_scroll = 0;
+            self.details_zoomed = false;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn project_path_for_issue(&self, iid: u64) -> String {
@@ -5769,6 +5857,50 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_jump_input_handles_issue_forms() {
+        assert_eq!(parse_jump_input("#123"), Some((Some(JumpKind::Issue), 123)));
+        assert_eq!(
+            parse_jump_input("issue 42"),
+            Some((Some(JumpKind::Issue), 42))
+        );
+        assert_eq!(
+            parse_jump_input("issues 7"),
+            Some((Some(JumpKind::Issue), 7))
+        );
+        assert_eq!(
+            parse_jump_input("  #99  "),
+            Some((Some(JumpKind::Issue), 99))
+        );
+    }
+
+    #[test]
+    fn parse_jump_input_handles_mr_forms() {
+        assert_eq!(parse_jump_input("!321"), Some((Some(JumpKind::Mr), 321)));
+        assert_eq!(parse_jump_input("mr 12"), Some((Some(JumpKind::Mr), 12)));
+        assert_eq!(parse_jump_input("mrs 5"), Some((Some(JumpKind::Mr), 5)));
+        assert_eq!(parse_jump_input("pr 3"), Some((Some(JumpKind::Mr), 3)));
+        assert_eq!(parse_jump_input("prs 8"), Some((Some(JumpKind::Mr), 8)));
+    }
+
+    #[test]
+    fn parse_jump_input_handles_bare_ids() {
+        assert_eq!(parse_jump_input("123"), Some((None, 123)));
+        assert_eq!(parse_jump_input("0"), None);
+    }
+
+    #[test]
+    fn parse_jump_input_rejects_invalid_input() {
+        assert_eq!(parse_jump_input(""), None);
+        assert_eq!(parse_jump_input("  "), None);
+        assert_eq!(parse_jump_input("abc"), None);
+        assert_eq!(parse_jump_input("#abc"), None);
+        assert_eq!(parse_jump_input("!0"), None);
+        assert_eq!(parse_jump_input("issue"), None);
+        assert_eq!(parse_jump_input("123abc"), None);
+        assert_eq!(parse_jump_input("#123abc"), None);
+    }
 
     #[test]
     fn selected_issue_reference_uses_the_highlighted_issue() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -770,7 +770,27 @@ impl Selector {
             .iter()
             .any(|item| item.to_lowercase() == query.to_lowercase());
         if !exact_match {
-            items.push((format!("+ Create \"{}\"", query), None));
+            if self.field_type == "jump_to_id" {
+                if let Some((kind, id)) = parse_jump_input(query) {
+                    let loaded = self.all_items.iter().any(|item| {
+                        let parsed = item
+                            .split(':')
+                            .next()
+                            .and_then(|p| parse_jump_input(p));
+                        matches!(parsed, Some((k, iid)) if iid == id && (kind.is_none() || k == kind))
+                    });
+                    if !loaded {
+                        let label = match kind {
+                            Some(JumpKind::Issue) => format!("#{id}"),
+                            Some(JumpKind::Mr) => format!("!{id}"),
+                            None => format!("#{id} / !{id}"),
+                        };
+                        items.push((format!("+ Fetch {label} from API"), None));
+                    }
+                }
+            } else {
+                items.push((format!("+ Create \"{}\"", query), None));
+            }
         }
         items
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1338,6 +1338,7 @@ prev_tab = "h"
 scroll_down = "J"
 scroll_up = "K"
 save_view = "s"
+jump_to_id = "g"
 
 [keybindings.issues]
 create_issue = "n"

--- a/src/config.rs
+++ b/src/config.rs
@@ -666,8 +666,6 @@ pub struct KeybindingGlobal {
     #[serde(default)]
     pub search: String,
     #[serde(default)]
-    pub global_search: String,
-    #[serde(default)]
     pub refresh: String,
     #[serde(default)]
     pub configure: String,
@@ -905,7 +903,6 @@ keybind_defaults! {
     def_quit = "q",
     def_help = "?",
     def_search = "/",
-    def_global_search = "Ctrl+p",
     def_refresh = "Ctrl+r",
     def_configure = "Tab",
     def_next_tab = "l",
@@ -980,7 +977,6 @@ impl Default for KeybindingGlobal {
             quit: def_quit(),
             help: def_help(),
             search: def_search(),
-            global_search: def_global_search(),
             refresh: def_refresh(),
             configure: def_configure(),
             next_tab: def_next_tab(),
@@ -1330,7 +1326,6 @@ page_size = 100
 quit = "q"
 help = "?"
 search = "/"
-global_search = "Ctrl+p"
 refresh = "Ctrl+r"
 configure = "Tab"
 next_tab = "l"

--- a/src/event.rs
+++ b/src/event.rs
@@ -62,6 +62,10 @@ pub enum Event {
         issue_iid: u64,
         result: Result<Vec<crate::domain::issues::RelatedMrRef>, String>,
     },
+    /// Single item fetched by the "go to issue/MR by ID" prompt. `Ok` carries
+    /// the item so the handler can insert it into the loaded set if absent.
+    IssueFetched(u64, Result<crate::domain::issues::Issue, String>),
+    MrFetched(u64, Result<crate::domain::mr::MergeRequest, String>),
 }
 
 #[derive(Debug)]

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -349,3 +349,65 @@ pub fn spawn_refresh_active_tab(
         }
     });
 }
+
+/// Fetch a single issue by iid from `project_path` for the "go to issue/MR by
+/// ID" prompt. Suppresses the terminal command log like other background fetches.
+pub fn spawn_fetch_issue(
+    client: &domain::client::GitlabClient,
+    project_path: &str,
+    iid: u64,
+    tx: tokio::sync::mpsc::UnboundedSender<Event>,
+) {
+    let mut client = client.clone();
+    client.tx = None;
+    let project_path = project_path.to_string();
+    tokio::spawn(async move {
+        let result = domain::issues::get_issue(&client, &project_path, iid).await;
+        let result = result.map(|mut issue| {
+            if issue.project_path.is_empty() {
+                issue.project_path = project_path.clone();
+            }
+            issue
+        });
+        let _ = tx.send(Event::IssueFetched(iid, result.map_err(|e| e.to_string())));
+    });
+}
+
+/// Fetch a single MR/PR by iid from `project_path` for the "go to issue/MR by
+/// ID" prompt. GitLab fills the approval/mergeability axes with the same bulk
+/// GraphQL state query used by the list path; GitHub derives both inside
+/// `gh pr view`. Suppresses the terminal command log like other background fetches.
+pub fn spawn_fetch_mr(
+    client: &domain::client::GitlabClient,
+    project_path: &str,
+    iid: u64,
+    tx: tokio::sync::mpsc::UnboundedSender<Event>,
+) {
+    let mut client = client.clone();
+    client.tx = None;
+    let project_path = project_path.to_string();
+    tokio::spawn(async move {
+        let result = domain::mr::get_mr(&client, &project_path, iid).await;
+        let result = match result {
+            Ok(mut mr) => {
+                // GitLab: merge the Approval/Mergeable state, then re-derive
+                // the workflow column (it reads from approval state).
+                if !client.is_github {
+                    if let Ok(state) = client.list_mr_state(&project_path, &[iid]).await {
+                        if let Some((approval, mergeability)) = state.get(&iid) {
+                            mr.approval = approval.clone();
+                            mr.mergeability = mergeability.clone();
+                        }
+                    }
+                }
+                if mr.project_path.is_empty() {
+                    mr.project_path = project_path.clone();
+                }
+                derive_workflow(std::slice::from_mut(&mut mr));
+                Ok(mr)
+            }
+            Err(e) => Err(e),
+        };
+        let _ = tx.send(Event::MrFetched(iid, result.map_err(|e| e.to_string())));
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,44 @@ fn parse_key_value_pairs(input: &str) -> Vec<(String, String)> {
     pairs
 }
 
+/// "go to issue/MR by ID": when the target item isn't already loaded, kick off
+/// a direct API lookup. Group scopes can't resolve a bare project item, so
+/// surface a hint instead of silently failing.
+fn jump_to_unloaded_issue(app: &mut App, iid: u64, events: &EventHandler) {
+    if app.scope.is_group() {
+        app.show_error(format!(
+            "Issue #{} isn't loaded and direct lookup needs a repository scope. Navigate to its project first.",
+            iid
+        ));
+        return;
+    }
+    let Some(client) = app.gitlab_client.clone() else {
+        app.show_error("No active backend to look up the issue.".to_string());
+        return;
+    };
+    let project = app.scope.as_str().to_string();
+    crate::fetch::spawn_fetch_issue(&client, &project, iid, events.sender());
+}
+
+/// "go to issue/MR by ID": when the target MR/PR isn't already loaded, kick off
+/// a direct API lookup. Group scopes can't resolve a bare project item, so
+/// surface a hint instead of silently failing.
+fn jump_to_unloaded_mr(app: &mut App, iid: u64, events: &EventHandler) {
+    if app.scope.is_group() {
+        app.show_error(format!(
+            "MR #{} isn't loaded and direct lookup needs a repository scope. Navigate to its project first.",
+            iid
+        ));
+        return;
+    }
+    let Some(client) = app.gitlab_client.clone() else {
+        app.show_error("No active backend to look up the MR.".to_string());
+        return;
+    };
+    let project = app.scope.as_str().to_string();
+    crate::fetch::spawn_fetch_mr(&client, &project, iid, events.sender());
+}
+
 fn rect_contains(rect: ratatui::layout::Rect, row: u16, col: u16) -> bool {
     col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
 }
@@ -1099,6 +1137,31 @@ async fn main() -> Result<()> {
                     app.project_cache.mrs = app.mrs.items.clone();
                     crate::utils::cache::save_cache(app.scope.as_str(), &app.project_cache);
                 }
+                Event::IssueFetched(iid, Ok(issue)) => {
+                    if !app.issues.items.iter().any(|i| i.iid == iid) {
+                        app.issues.items.push(issue);
+                        app.update_filter_selection();
+                    }
+                    app.focus_issue(iid);
+                    crate::handlers::tabs::maybe_fetch_related_mrs(&mut app, &events.sender());
+                    app.project_cache.issues = app.issues.items.clone();
+                    crate::utils::cache::save_cache(app.scope.as_str(), &app.project_cache);
+                }
+                Event::IssueFetched(iid, Err(err)) => {
+                    app.show_error(format!("Failed to fetch issue #{}: {}", iid, err));
+                }
+                Event::MrFetched(iid, Ok(mr)) => {
+                    if !app.mrs.items.iter().any(|m| m.iid == iid) {
+                        app.mrs.items.push(mr);
+                        app.update_filter_selection();
+                    }
+                    app.focus_mr(iid);
+                    app.project_cache.mrs = app.mrs.items.clone();
+                    crate::utils::cache::save_cache(app.scope.as_str(), &app.project_cache);
+                }
+                Event::MrFetched(iid, Err(err)) => {
+                    app.show_error(format!("Failed to fetch MR #{}: {}", iid, err));
+                }
                 Event::PipelinesFetched(pipelines) => {
                     app.complete_loading_tab(app::Tab::Pipelines, "Success");
                     app.loaded_tabs.insert(app::Tab::Pipelines);
@@ -1947,77 +2010,6 @@ async fn main() -> Result<()> {
                                             });
                                         }
                                     }
-                                    crate::app::TextInputAction::JumpToId => {
-                                        if let Ok(id) = value.trim().parse::<u64>() {
-                                            let mut found = false;
-                                            match app.active_tab {
-                                                app::Tab::Issues => {
-                                                    if let Some(pos) = app
-                                                        .filtered_issues()
-                                                        .iter()
-                                                        .position(|i| i.iid == id)
-                                                    {
-                                                        app.issues.state.select(Some(pos));
-                                                        app.detail_scroll = 0;
-                                                        found = true;
-                                                    }
-                                                }
-                                                app::Tab::MergeRequests => {
-                                                    if let Some(pos) = app
-                                                        .filtered_mrs()
-                                                        .iter()
-                                                        .position(|m| m.iid == id)
-                                                    {
-                                                        app.mrs.state.select(Some(pos));
-                                                        app.detail_scroll = 0;
-                                                        found = true;
-                                                    }
-                                                }
-                                                app::Tab::Pipelines => {
-                                                    if let Some(pos) = app
-                                                        .filtered_pipelines()
-                                                        .iter()
-                                                        .position(|p| p.id == id)
-                                                    {
-                                                        app.pipelines.state.select(Some(pos));
-                                                        app.detail_scroll = 0;
-                                                        found = true;
-                                                    }
-                                                }
-                                                app::Tab::Jobs => {
-                                                    if let Some(pos) = app
-                                                        .filtered_jobs()
-                                                        .iter()
-                                                        .position(|j| j.id == id)
-                                                    {
-                                                        app.jobs.state.select(Some(pos));
-                                                        app.detail_scroll = 0;
-                                                        found = true;
-                                                    }
-                                                }
-                                                app::Tab::Milestones => {
-                                                    if let Some(pos) = app
-                                                        .filtered_milestones()
-                                                        .iter()
-                                                        .position(|m| m.iid == id || m.id == id)
-                                                    {
-                                                        app.milestones.state.select(Some(pos));
-                                                        app.detail_scroll = 0;
-                                                        found = true;
-                                                    }
-                                                }
-                                                _ => {}
-                                            }
-                                            if !found {
-                                                app.show_error(format!(
-                                                    "Item #{} not found in current view",
-                                                    id
-                                                ));
-                                            }
-                                        } else {
-                                            app.show_error("Invalid ID format".to_string());
-                                        }
-                                    }
                                     crate::app::TextInputAction::CreateBranch(ref ref_branch) => {
                                         if !value.trim().is_empty() {
                                             let branch_name = value.trim().to_string();
@@ -2813,43 +2805,84 @@ async fn main() -> Result<()> {
                                         } else {
                                             None
                                         };
-                                        if let Some(val) = selected_val {
-                                            if val.starts_with("Issue #") {
-                                                if let Some(iid_str) = val
-                                                    .strip_prefix("Issue #")
-                                                    .and_then(|s| s.split(':').next())
-                                                {
-                                                    if let Ok(iid) = iid_str.parse::<u64>() {
-                                                        app.active_tab = crate::app::Tab::Issues;
-                                                        if let Some(idx) = app
-                                                            .issues
-                                                            .items
-                                                            .iter()
-                                                            .position(|i| i.iid == iid)
+                                        let handle_jump =
+                                            |app: &mut App,
+                                             kind: Option<crate::app::JumpKind>,
+                                             id: u64| {
+                                                match kind {
+                                                    Some(crate::app::JumpKind::Issue) => {
+                                                        if !app.focus_issue(id) {
+                                                            jump_to_unloaded_issue(
+                                                                app, id, &events,
+                                                            );
+                                                        }
+                                                    }
+                                                    Some(crate::app::JumpKind::Mr) => {
+                                                        if !app.focus_mr(id) {
+                                                            jump_to_unloaded_mr(app, id, &events);
+                                                        }
+                                                    }
+                                                    None => {
+                                                        if !app.focus_issue(id) && !app.focus_mr(id)
                                                         {
-                                                            app.issues.state.select(Some(idx));
+                                                            match app.active_tab {
+                                                            crate::app::Tab::Issues => {
+                                                                jump_to_unloaded_issue(
+                                                                    app, id, &events,
+                                                                )
+                                                            }
+                                                            crate::app::Tab::MergeRequests => {
+                                                                jump_to_unloaded_mr(app, id, &events)
+                                                            }
+                                                            _ => app.show_error(format!(
+                                                                "Item #{} not found in current view",
+                                                                id
+                                                            )),
+                                                        }
                                                         }
                                                     }
                                                 }
-                                            } else if val.starts_with("MR !") {
-                                                if let Some(iid_str) = val
-                                                    .strip_prefix("MR !")
-                                                    .and_then(|s| s.split(':').next())
+                                            };
+                                        let parse_row_kind = |val: &str| {
+                                            if let Some(rest) = val.strip_prefix("Issue #") {
+                                                rest.split(':').next().and_then(|s| {
+                                                    s.trim().parse::<u64>().ok().map(|id| {
+                                                        (Some(crate::app::JumpKind::Issue), id)
+                                                    })
+                                                })
+                                            } else if let Some(rest) = val.strip_prefix("MR !") {
+                                                rest.split(':').next().and_then(|s| {
+                                                    s.trim().parse::<u64>().ok().map(|id| {
+                                                        (Some(crate::app::JumpKind::Mr), id)
+                                                    })
+                                                })
+                                            } else {
+                                                None
+                                            }
+                                        };
+                                        let query_val = selector.search_query.trim().to_string();
+                                        let mut handled = false;
+                                        if let Some((kind, id)) =
+                                            crate::app::parse_jump_input(&query_val)
+                                        {
+                                            handle_jump(&mut app, kind, id);
+                                            handled = true;
+                                        }
+                                        if !handled {
+                                            if let Some(val) = selected_val {
+                                                if let Some((kind, id)) = parse_row_kind(&val)
+                                                    .or_else(|| crate::app::parse_jump_input(&val))
                                                 {
-                                                    if let Ok(iid) = iid_str.parse::<u64>() {
-                                                        app.active_tab =
-                                                            crate::app::Tab::MergeRequests;
-                                                        if let Some(idx) = app
-                                                            .mrs
-                                                            .items
-                                                            .iter()
-                                                            .position(|m| m.iid == iid)
-                                                        {
-                                                            app.mrs.state.select(Some(idx));
-                                                        }
-                                                    }
+                                                    handle_jump(&mut app, kind, id);
+                                                    handled = true;
                                                 }
                                             }
+                                        }
+                                        if !handled {
+                                            app.show_error(
+                                                "Not found. Use #123 (issue) / !123 (MR), or pick a listed item."
+                                                    .to_string(),
+                                            );
                                         }
                                         continue;
                                     }
@@ -7903,8 +7936,13 @@ async fn main() -> Result<()> {
                         continue;
                     }
 
-                    if keybinding_matches(&app.config.keybindings.global.global_search, &key_event)
-                        && !app.is_typing_search
+                    if (keybinding_matches(
+                        &app.config.keybindings.global.global_search,
+                        &key_event,
+                    ) || keybinding_matches(
+                        &app.config.keybindings.global.jump_to_id,
+                        &key_event,
+                    )) && !app.is_typing_search
                         && app.text_input.is_none()
                         && app.edit_menu.is_none()
                         && app.selector.is_none()
@@ -7919,7 +7957,7 @@ async fn main() -> Result<()> {
                         }
 
                         app.selector = Some(crate::app::Selector {
-                            title: " Global Search ".to_string(),
+                            title: " Jump to Issue/MR (#123 / !123) ".to_string(),
                             all_items: items,
                             selected_items: std::collections::HashSet::new(),
                             cursor_idx: 0,
@@ -7935,22 +7973,6 @@ async fn main() -> Result<()> {
                                 s.select(Some(0));
                                 s
                             },
-                        });
-                        continue;
-                    }
-
-                    if keybinding_matches(&app.config.keybindings.global.jump_to_id, &key_event)
-                        && app.text_input.is_none()
-                        && app.edit_menu.is_none()
-                        && app.selector.is_none()
-                        && !app.focus_column_checklist
-                        && !app.is_typing_search
-                    {
-                        app.text_input = Some(crate::app::TextInput {
-                            title: " Jump to ID ".to_string(),
-                            value: String::new(),
-                            cursor_idx: 0,
-                            action: crate::app::TextInputAction::JumpToId,
                         });
                         continue;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2804,7 +2804,7 @@ async fn main() -> Result<()> {
                                 }
                                 KeyCode::Enter => {
                                     let field_type = selector.field_type.clone();
-                                    if field_type == "global_search" {
+                                    if field_type == "jump_to_id" {
                                         let filtered_items = selector.get_filtered_items();
                                         let selected_val = if !selector.selected_items.is_empty() {
                                             selector.selected_items.iter().next().cloned()
@@ -7926,13 +7926,8 @@ async fn main() -> Result<()> {
                         continue;
                     }
 
-                    if (keybinding_matches(
-                        &app.config.keybindings.global.global_search,
-                        &key_event,
-                    ) || keybinding_matches(
-                        &app.config.keybindings.global.jump_to_id,
-                        &key_event,
-                    )) && !app.is_typing_search
+                    if keybinding_matches(&app.config.keybindings.global.jump_to_id, &key_event)
+                        && !app.is_typing_search
                         && app.text_input.is_none()
                         && app.edit_menu.is_none()
                         && app.selector.is_none()
@@ -7955,8 +7950,8 @@ async fn main() -> Result<()> {
                             is_filtering: false,
                             is_loading: false,
                             entity_iid: 0,
-                            entity_type: "global_search".to_string(),
-                            field_type: "global_search".to_string(),
+                            entity_type: "jump_to_id".to_string(),
+                            field_type: "jump_to_id".to_string(),
                             multi_select: false,
                             state: {
                                 let mut s = ratatui::widgets::ListState::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2852,21 +2852,9 @@ async fn main() -> Result<()> {
                                                 }
                                             };
                                         let parse_row_kind = |val: &str| {
-                                            if let Some(rest) = val.strip_prefix("Issue #") {
-                                                rest.split(':').next().and_then(|s| {
-                                                    s.trim().parse::<u64>().ok().map(|id| {
-                                                        (Some(crate::app::JumpKind::Issue), id)
-                                                    })
-                                                })
-                                            } else if let Some(rest) = val.strip_prefix("MR !") {
-                                                rest.split(':').next().and_then(|s| {
-                                                    s.trim().parse::<u64>().ok().map(|id| {
-                                                        (Some(crate::app::JumpKind::Mr), id)
-                                                    })
-                                                })
-                                            } else {
-                                                None
-                                            }
+                                            crate::app::parse_jump_input(
+                                                val.split(':').next().unwrap_or(val).trim(),
+                                            )
                                         };
                                         let query_val = selector.search_query.trim().to_string();
                                         let mut handled = false;
@@ -7935,10 +7923,10 @@ async fn main() -> Result<()> {
                     {
                         let mut items = Vec::new();
                         for issue in &app.issues.items {
-                            items.push(format!("Issue #{}: {}", issue.iid, issue.title));
+                            items.push(format!("#{}: {}", issue.iid, issue.title));
                         }
                         for mr in &app.mrs.items {
-                            items.push(format!("MR !{}: {}", mr.iid, mr.title));
+                            items.push(format!("!{}: {}", mr.iid, mr.title));
                         }
 
                         app.selector = Some(crate::app::Selector {

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1195,11 +1195,7 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         },
         Shortcut {
             category: "Global & Nav",
-            key: d(format!(
-                "{} / {}",
-                app.config.keybindings.global.jump_to_id,
-                app.config.keybindings.global.global_search
-            )),
+            key: d(format!("{}", app.config.keybindings.global.jump_to_id)),
             action: "Jump to issue/MR by ID; fetch if not cached",
         },
         Shortcut {
@@ -1214,11 +1210,6 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
             category: "Global & Nav",
             key: s("Ctrl+S"),
             action: "Switch repository",
-        },
-        Shortcut {
-            category: "Global & Nav",
-            key: d(format!("{}", app.config.keybindings.global.global_search)),
-            action: "Global search across all tabs",
         },
         Shortcut {
             category: "Global & Nav",

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1196,6 +1196,15 @@ pub(crate) fn render_help(f: &mut Frame, app: &mut App, size: Rect) {
         Shortcut {
             category: "Global & Nav",
             key: d(format!(
+                "{} / {}",
+                app.config.keybindings.global.jump_to_id,
+                app.config.keybindings.global.global_search
+            )),
+            action: "Jump to issue/MR by ID; fetch if not cached",
+        },
+        Shortcut {
+            category: "Global & Nav",
+            key: d(format!(
                 "F5 / Ctrl+R / {}",
                 app.config.keybindings.global.refresh
             )),


### PR DESCRIPTION
## Summary

Reworks the "jump to issue/MR by ID" feature (previously a dedicated `Ctrl+g` text prompt) to use the existing **`Ctrl+p` global search** fuzzy selector as the single jump UI.

## Changes

- **Retire `Ctrl+g` / `jump_to_item`**: removed the `JumpToId` text-input prompt and the extra keybinding. `g` (`jump_to_id`) now opens the same global search selector, retitled **"Jump to Issue/MR (#123 / !123)"**.
- **Fetch on miss**: pressing Enter on a cached row jumps to it; typing an ID that isn't loaded (`#123`, `!123`, `issue 123`, `mr 123`, bare `123`) triggers a direct API `get_issue` / `get_mr` fetch, inserts the item if absent, focuses it, and persists cache.
- **GitLab MR enrichment**: fetched MRs are enriched with approval/mergeability state via the bulk GraphQL query and have their workflow column re-derived.
- **Group-scope hint**: bare project lookups from a group scope surface an error toast asking the user to navigate to a repository scope first.
- Help overlay entry and keybinding default test updated.

## Files

- `src/app.rs` — `JumpKind`, `parse_jump_input`, `focus_issue`/`focus_mr`; removed `JumpToId` action
- `src/config.rs` — removed `jump_to_item`; kept `jump_to_id = "g"`
- `src/event.rs` — `Event::IssueFetched` / `MrFetched`
- `src/fetch.rs` — `spawn_fetch_issue` / `spawn_fetch_mr`
- `src/main.rs` — global search Enter handler (fetch-on-miss), keybinding gate, help/test updates
- `src/ui/overlays.rs` — help entry

Verified: `cargo check`, `cargo clippy -- -D warnings`, `cargo test` (71 passing) against the merged `origin/main` base.