### PR TITLE
fix(ui): cap detail scroll to rendered content height

### DIFF
--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -929,6 +929,24 @@ pub(crate) fn diff_tree_row_layout(
     (name_display, padding)
 }
 
+/// Count the rows `Paragraph` renders for `lines`: `lines.len()` unwrapped,
+/// or per-`Line` word-wrapping at `width` (via `count_wrapped_lines`) when
+/// `wrap` is set — the same approximation the job-trace path already uses,
+/// since `Paragraph::line_count` needs ratatui's `unstable-rendered-line-info`
+/// feature, which this project doesn't enable.
+pub(crate) fn rendered_line_count(lines: &[Line], width: usize, wrap: bool) -> usize {
+    if !wrap {
+        return lines.len();
+    }
+    lines
+        .iter()
+        .map(|line| {
+            let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            super::diff::count_wrapped_lines(&text, width)
+        })
+        .sum()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1191,5 +1209,17 @@ mod tests {
         assert_eq!(spans[1].style, num);
         assert_eq!(spans[2].content, "│ ");
         assert_eq!(spans[2].style, sep);
+    }
+
+    #[test]
+    fn rendered_line_count_wraps_only_when_asked() {
+        let lines = vec![
+            Line::from("short line"),
+            Line::from("abcdefghijklmnopqrst"),
+            Line::from("other"),
+        ];
+
+        assert_eq!(rendered_line_count(&lines, 10, true), 4);
+        assert_eq!(rendered_line_count(&lines, 10, false), 3);
     }
 }

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -942,7 +942,7 @@ pub(crate) fn rendered_line_count(lines: &[Line], width: usize, wrap: bool) -> u
         .iter()
         .map(|line| {
             let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-            super::diff::count_wrapped_lines(&text, width)
+            super::diff::count_wrapped_lines(&text, width).max(1)
         })
         .sum()
 }
@@ -1221,5 +1221,12 @@ mod tests {
 
         assert_eq!(rendered_line_count(&lines, 10, true), 4);
         assert_eq!(rendered_line_count(&lines, 10, false), 3);
+    }
+
+    #[test]
+    fn rendered_line_count_counts_blank_lines_as_one_row() {
+        let lines = vec![Line::from("a"), Line::from(""), Line::from("b")];
+
+        assert_eq!(rendered_line_count(&lines, 10, true), 3);
     }
 }

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -1153,7 +1153,8 @@ pub(crate) fn render_inspector_content(
                 render_markdown(md, &theme, area.width)
             };
             let total_lines = rendered_line_count(&lines, area.width as usize, true);
-            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
+            let max_scroll =
+                u16::try_from(total_lines.saturating_sub(area.height as usize)).unwrap_or(u16::MAX);
             f.render_widget(
                 Paragraph::new(lines)
                     .scroll((scroll, 0))
@@ -1165,7 +1166,8 @@ pub(crate) fn render_inspector_content(
         InspectorContent::AnsiTrace { trace, wrap } => {
             let formatted_lines = parse_ansi_trace(trace, &theme);
             let total_lines = rendered_line_count(&formatted_lines, area.width as usize, *wrap);
-            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
+            let max_scroll =
+                u16::try_from(total_lines.saturating_sub(area.height as usize)).unwrap_or(u16::MAX);
             let mut paragraph = Paragraph::new(formatted_lines).scroll((scroll, 0));
             if *wrap {
                 paragraph = paragraph.wrap(ratatui::widgets::Wrap { trim: false });
@@ -1226,7 +1228,8 @@ pub(crate) fn render_inspector_content(
                 ]));
             }
             let total_lines = rendered_line_count(&lines, area.width as usize, true);
-            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
+            let max_scroll =
+                u16::try_from(total_lines.saturating_sub(area.height as usize)).unwrap_or(u16::MAX);
             f.render_widget(
                 Paragraph::new(lines)
                     .scroll((scroll, 0))
@@ -1237,7 +1240,8 @@ pub(crate) fn render_inspector_content(
         }
         InspectorContent::Custom(lines) => {
             let total_lines = rendered_line_count(lines, area.width as usize, true);
-            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
+            let max_scroll =
+                u16::try_from(total_lines.saturating_sub(area.height as usize)).unwrap_or(u16::MAX);
             f.render_widget(
                 Paragraph::new(lines.clone())
                     .scroll((scroll, 0))

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 use crate::app::{EditMenu, EntityDocument, Field, FieldTone, FieldType, InspectorContent};
 use crate::config::{ICONS, THEME};
-use crate::ui::helpers::get_label_color;
+use crate::ui::helpers::{get_label_color, rendered_line_count};
 use crate::utils::format::parse_ansi_trace;
 use crate::utils::markdown::render_markdown;
 
@@ -49,7 +49,7 @@ pub(crate) fn render_entity_inspector(
     area: Rect,
     mut mode: InspectorMode<'_>,
     label_colors: &HashMap<String, Color>,
-) {
+) -> u16 {
     let icons = ICONS.read().unwrap();
     let theme = THEME.read().unwrap();
 
@@ -95,7 +95,7 @@ pub(crate) fn render_entity_inspector(
     f.render_widget(block, area);
 
     if inner.width == 0 || inner.height == 0 {
-        return;
+        return 0;
     }
 
     // Reserve a footer for the submit/save button in edit mode.
@@ -140,7 +140,7 @@ pub(crate) fn render_entity_inspector(
 
     let has_fields = !doc.fields.is_empty();
 
-    if has_content && has_fields {
+    let max_scroll = if has_content && has_fields {
         // Single column: metadata fields on top, full-width markdown below.
         // Replaces the old side-by-side duplex (and the narrow stacked)
         // layouts — the description now owns the full width beneath the
@@ -176,10 +176,10 @@ pub(crate) fn render_entity_inspector(
             is_interactive,
             &theme,
         );
-        render_content_pane(f, &mut mode, doc, chunks[1], Borders::TOP);
+        render_content_pane(f, &mut mode, doc, chunks[1], Borders::TOP)
     } else if has_content {
         // Only content.
-        render_content_pane(f, &mut mode, doc, main_area, Borders::NONE);
+        render_content_pane(f, &mut mode, doc, main_area, Borders::NONE)
     } else {
         // Only fields.
         render_fields_list(
@@ -195,12 +195,15 @@ pub(crate) fn render_entity_inspector(
             is_interactive,
             &theme,
         );
-    }
+        0
+    };
 
     // Submit/save footer (edit mode only).
     if is_interactive {
         render_submit_footer(f, &mut mode, submit_area, &theme, &icons);
     }
+
+    max_scroll
 }
 
 /// Render the shared field list. In edit mode the list is driven by the menu's
@@ -252,7 +255,7 @@ fn render_content_pane(
     doc: &EntityDocument,
     area: Rect,
     borders: ratatui::widgets::Borders,
-) {
+) -> u16 {
     let icons = ICONS.read().unwrap();
     let theme = THEME.read().unwrap();
 
@@ -291,7 +294,7 @@ fn render_content_pane(
             f.render_widget(desc_block, area);
 
             if desc_inner.width == 0 || desc_inner.height == 0 {
-                return;
+                return 0;
             }
 
             let desc_lines = if is_desc_selected && menu.editing {
@@ -368,6 +371,7 @@ fn render_content_pane(
                     .wrap(ratatui::widgets::Wrap { trim: false }),
                 desc_inner,
             );
+            0
         }
         InspectorMode::ReadOnly { scroll, .. } => {
             let content_block = Block::default()
@@ -375,7 +379,7 @@ fn render_content_pane(
                 .border_style(Style::default().fg(theme.border));
             let content_inner = content_block.inner(area);
             f.render_widget(content_block, area);
-            render_inspector_content(f, &doc.content, content_inner, *scroll);
+            render_inspector_content(f, &doc.content, content_inner, *scroll)
         }
     }
 }
@@ -1132,7 +1136,7 @@ pub(crate) fn render_inspector_content(
     content: &InspectorContent,
     area: Rect,
     scroll: u16,
-) {
+) -> u16 {
     let icons = ICONS.read().unwrap();
     let theme = THEME.read().unwrap();
 
@@ -1148,20 +1152,26 @@ pub(crate) fn render_inspector_content(
             } else {
                 render_markdown(md, &theme, area.width)
             };
+            let total_lines = rendered_line_count(&lines, area.width as usize, true);
+            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
             f.render_widget(
                 Paragraph::new(lines)
                     .scroll((scroll, 0))
                     .wrap(ratatui::widgets::Wrap { trim: false }),
                 area,
             );
+            max_scroll
         }
         InspectorContent::AnsiTrace { trace, wrap } => {
             let formatted_lines = parse_ansi_trace(trace, &theme);
+            let total_lines = rendered_line_count(&formatted_lines, area.width as usize, *wrap);
+            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
             let mut paragraph = Paragraph::new(formatted_lines).scroll((scroll, 0));
             if *wrap {
                 paragraph = paragraph.wrap(ratatui::widgets::Wrap { trim: false });
             }
             f.render_widget(paragraph, area);
+            max_scroll
         }
         InspectorContent::PipelineStages(jobs) => {
             let mut lines = Vec::new();
@@ -1215,20 +1225,26 @@ pub(crate) fn render_inspector_content(
                     Span::styled(status_text, status_style),
                 ]));
             }
+            let total_lines = rendered_line_count(&lines, area.width as usize, true);
+            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
             f.render_widget(
                 Paragraph::new(lines)
                     .scroll((scroll, 0))
                     .wrap(ratatui::widgets::Wrap { trim: true }),
                 area,
             );
+            max_scroll
         }
         InspectorContent::Custom(lines) => {
+            let total_lines = rendered_line_count(lines, area.width as usize, true);
+            let max_scroll = total_lines.saturating_sub(area.height as usize) as u16;
             f.render_widget(
                 Paragraph::new(lines.clone())
                     .scroll((scroll, 0))
                     .wrap(ratatui::widgets::Wrap { trim: true }),
                 area,
             );
+            max_scroll
         }
         InspectorContent::Empty(msg) => {
             f.render_widget(
@@ -1241,6 +1257,7 @@ pub(crate) fn render_inspector_content(
                 .alignment(Alignment::Center),
                 area,
             );
+            0
         }
     }
 }
@@ -1399,7 +1416,9 @@ mod tests {
         let content = InspectorContent::Markdown("- Parent\n    - Nested\n\n> Quoted".to_string());
 
         terminal
-            .draw(|f| render_inspector_content(f, &content, f.area(), 0))
+            .draw(|f| {
+                render_inspector_content(f, &content, f.area(), 0);
+            })
             .unwrap();
 
         let buffer = terminal.backend().buffer();
@@ -1414,6 +1433,31 @@ mod tests {
         assert!(rendered.contains("• Parent"));
         assert!(rendered.contains("  • Nested"));
         assert!(rendered.contains("  ▌ Quoted"));
+    }
+
+    #[test]
+    fn test_render_inspector_content_returns_max_scroll_for_custom_lines() {
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let content = InspectorContent::Custom(vec![
+            Line::from("one"),
+            Line::from("two"),
+            Line::from("three"),
+            Line::from("four"),
+            Line::from("five"),
+            Line::from("six"),
+            Line::from("seven"),
+        ]);
+
+        let mut max_scroll = 0;
+        terminal
+            .draw(|f| {
+                max_scroll = render_inspector_content(f, &content, f.area(), 0);
+            })
+            .unwrap();
+
+        // 7 lines in a 5-row area: 2 rows can't be scrolled into view.
+        assert_eq!(max_scroll, 2);
     }
 
     #[test]

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -9,6 +9,12 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
 };
 
+/// Cap `app.detail_scroll` to `max` so a held-down scroll key can't push the
+/// preview content past its last line.
+fn clamp_detail_scroll(app: &mut App, max: u16) {
+    app.detail_scroll = app.detail_scroll.min(max);
+}
+
 /// Return a responsive column width: uses `base` normally but shrinks on narrow terminals.
 fn col_w(content_width: u16, base: u16) -> Constraint {
     if content_width >= 120 {
@@ -300,7 +306,7 @@ pub(crate) fn render_tab_issues(
                     is_github,
                     app.fetching_related_mrs.contains(&issue.iid),
                 );
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -310,6 +316,7 @@ pub(crate) fn render_tab_issues(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -962,7 +969,7 @@ pub(crate) fn render_tab_merge_requests(
 
                 let doc =
                     crate::entity_editor::build_mr_document(mr, is_github, unresolved_threads);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -972,6 +979,7 @@ pub(crate) fn render_tab_merge_requests(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -1314,7 +1322,7 @@ pub(crate) fn render_tab_pipelines(
             if let Some(p) = filtered_pipelines.get(selected) {
                 let jobs = app.pipeline_jobs.get(&p.id()).cloned().unwrap_or_default();
                 let doc = crate::entity_editor::build_pipeline_document(p, &jobs);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -1324,6 +1332,7 @@ pub(crate) fn render_tab_pipelines(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -1794,6 +1803,11 @@ pub(crate) fn render_tab_jobs(
             } else {
                 super::helpers::append_stage_summaries(&mut text, &app.jobs.items);
             }
+            let summary_height = detail_rect.height.saturating_sub(2) as usize;
+            let summary_width = detail_rect.width.saturating_sub(2) as usize;
+            let total_lines = super::helpers::rendered_line_count(&text, summary_width, false);
+            let max_detail_scroll = total_lines.saturating_sub(summary_height) as u16;
+            clamp_detail_scroll(app, max_detail_scroll);
             f.render_widget(
                 Paragraph::new(text)
                     .block(preview_block)
@@ -2016,7 +2030,7 @@ pub(crate) fn render_tab_runners(
         if let Some(selected) = app.runners.state.selected() {
             if let Some(r) = filtered_runners.get(selected) {
                 let doc = crate::entity_editor::build_runner_document(r);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -2026,6 +2040,7 @@ pub(crate) fn render_tab_runners(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -2243,7 +2258,7 @@ pub(crate) fn render_tab_releases(
         if let Some(selected) = app.releases.state.selected() {
             if let Some(r) = filtered_releases.get(selected) {
                 let doc = crate::entity_editor::build_release_document(r);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -2253,6 +2268,7 @@ pub(crate) fn render_tab_releases(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -2480,7 +2496,7 @@ pub(crate) fn render_tab_todos(
         if let Some(selected) = app.todos.state.selected() {
             if let Some(n) = filtered_todos.get(selected) {
                 let doc = crate::entity_editor::build_todo_document(n);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -2490,6 +2506,7 @@ pub(crate) fn render_tab_todos(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -2738,7 +2755,7 @@ pub(crate) fn render_tab_milestones(
                     .as_deref()
                     .or_else(|| app.milestone_issues_cache.get(&m.iid).map(|v| v.as_slice()));
                 let doc = crate::entity_editor::build_milestone_document(m, issues, is_github);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -2748,6 +2765,7 @@ pub(crate) fn render_tab_milestones(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -2935,7 +2953,7 @@ pub(crate) fn render_tab_branches(
         if let Some(idx) = app.branches.state.selected() {
             if let Some(branch) = filtered.get(idx) {
                 let doc = crate::entity_editor::build_branch_document(branch);
-                super::inspector::render_entity_inspector(
+                let max_detail_scroll = super::inspector::render_entity_inspector(
                     f,
                     &doc,
                     detail_rect,
@@ -2945,6 +2963,7 @@ pub(crate) fn render_tab_branches(
                     },
                     &app.label_colors,
                 );
+                clamp_detail_scroll(app, max_detail_scroll);
             } else {
                 f.render_widget(Paragraph::new("").block(preview_block), detail_rect);
             }
@@ -3114,7 +3133,7 @@ pub(crate) fn render_tab_environments(
             if let Some(idx) = app.environments.state.selected() {
                 if let Some(env) = filtered.get(idx) {
                     let doc = crate::entity_editor::build_environment_document(env);
-                    super::inspector::render_entity_inspector(
+                    let max_detail_scroll = super::inspector::render_entity_inspector(
                         f,
                         &doc,
                         detail_rect,
@@ -3124,6 +3143,7 @@ pub(crate) fn render_tab_environments(
                         },
                         &app.label_colors,
                     );
+                    clamp_detail_scroll(app, max_detail_scroll);
                 }
             } else {
                 f.render_widget(
@@ -3284,5 +3304,30 @@ pub(crate) fn render_tab_terminal(
         }
 
         f.render_widget(Paragraph::new(log_lines).block(custom_main_block), area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_detail_scroll_caps_scroll_to_max() {
+        let mut app = App::default();
+        app.detail_scroll = 50;
+
+        clamp_detail_scroll(&mut app, 10);
+
+        assert_eq!(app.detail_scroll, 10);
+    }
+
+    #[test]
+    fn clamp_detail_scroll_leaves_scroll_below_max_unchanged() {
+        let mut app = App::default();
+        app.detail_scroll = 3;
+
+        clamp_detail_scroll(&mut app, 10);
+
+        assert_eq!(app.detail_scroll, 3);
     }
 }

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -1804,9 +1804,10 @@ pub(crate) fn render_tab_jobs(
                 super::helpers::append_stage_summaries(&mut text, &app.jobs.items);
             }
             let summary_height = detail_rect.height.saturating_sub(2) as usize;
-            let summary_width = detail_rect.width.saturating_sub(2) as usize;
-            let total_lines = super::helpers::rendered_line_count(&text, summary_width, false);
-            let max_detail_scroll = total_lines.saturating_sub(summary_height) as u16;
+            // Not wrapped, so rendered_line_count doesn't read the width.
+            let total_lines = super::helpers::rendered_line_count(&text, 0, false);
+            let max_detail_scroll =
+                u16::try_from(total_lines.saturating_sub(summary_height)).unwrap_or(u16::MAX);
             clamp_detail_scroll(app, max_detail_scroll);
             f.render_widget(
                 Paragraph::new(text)
@@ -3310,6 +3311,60 @@ pub(crate) fn render_tab_terminal(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::issues::{Author, Issue};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn render_tab_issues_clamps_detail_scroll_to_content_max() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::default();
+        app.issues.items = vec![Issue {
+            iid: 1,
+            title: "Issue 1".to_string(),
+            state: "opened".to_string(),
+            labels: vec![],
+            updated_at: String::new(),
+            created_at: None,
+            closed_at: None,
+            author: Author {
+                username: "u1".to_string(),
+            },
+            milestone: None,
+            assignees: vec![],
+            description: Some("line\n\n".repeat(100)),
+            due_date: None,
+            web_url: String::new(),
+            project_path: String::new(),
+            related_mrs: None,
+        }];
+        app.issues.state.select(Some(0));
+        app.detail_scroll = 999;
+
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                let content_area = Rect::new(0, 0, area.width, 10);
+                let detail_rect = Rect::new(0, 10, area.width, 10);
+                render_tab_issues(
+                    f,
+                    &mut app,
+                    content_area,
+                    detail_rect,
+                    Block::default(),
+                    Style::default(),
+                    Style::default(),
+                );
+            })
+            .unwrap();
+
+        assert!(
+            app.detail_scroll < 999,
+            "detail_scroll should have been clamped to the content's max, was {}",
+            app.detail_scroll
+        );
+    }
 
     #[test]
     fn clamp_detail_scroll_caps_scroll_to_max() {


### PR DESCRIPTION
## Bug

Holding a scroll key in a ReadOnly preview pane pushes the content out of
view. `app.detail_scroll` keeps growing while the rendered text does not, so
the pane goes blank and there is no way back except scrolling up by the same
amount. This affects the nine ReadOnly preview call sites and the
pipeline-jobs summary pane. The job-trace path already computes and clamps its
own `max_scroll` and is untouched here.

A second symptom runs in the other direction: in multi-paragraph previews the
last lines cannot be reached at all.

## Root Cause

`render_inspector_content` and `render_entity_inspector` applied
`app.detail_scroll` unclamped. Nothing derived an upper bound from the
rendered line count and the area height.

The unreachable last lines are a separate miscount. Line counting goes through
`count_wrapped_lines()`, which returns 0 for an empty string. Every blank
`Line`, meaning paragraph breaks in rendered markdown and `PipelineStages`
separators, contributed 0 rows instead of the 1 row `Paragraph` actually
renders. Any bound computed from that count came out too small.

Both functions now return the `max_scroll` they compute, and
`clamp_detail_scroll()` in `src/ui/tabs.rs` applies it at the call sites.
Counting goes through a new `rendered_line_count()` in `src/ui/helpers.rs`
that reuses `count_wrapped_lines()` the same way the trace path does;
`Paragraph::line_count` would need ratatui's `unstable-rendered-line-info`
feature, which this project does not enable.

Mouse-wheel scrolling in `src/main.rs` writes the same field and is bounded by
the same clamp on the next render, so it needed no separate change.

Two smaller things ride along, both in the changed lines: the truncating
`as u16` casts for `max_scroll` and `max_detail_scroll` become saturating
conversions, and an unused width argument in the jobs summary path is dropped.
Happy to split those out if you would rather see them separately.

## Verification

- [x] Added/updated tests

The existing suite covered the helper pieces in isolation only. Added a
render-level test that asserts a `render_entity_inspector` call site actually
clamps `app.detail_scroll`.
