### PR TITLE
fix(branches): make Create Branch work on GitHub without crashing the TUI

### DIFF
--- a/src/backend/gh.rs
+++ b/src/backend/gh.rs
@@ -2231,10 +2231,34 @@ impl Backend for GhBackend {
         branch_name: &str,
         ref_branch: &str,
     ) -> Result<()> {
+        // GitHub API expects a commit SHA, not a branch name. Resolve if needed.
+        let sha = if ref_branch.len() == 40 && ref_branch.chars().all(|c| c.is_ascii_hexdigit()) {
+            // Already looks like a SHA
+            ref_branch.to_string()
+        } else {
+            // Try to resolve branch name to SHA via GitHub API
+            let endpoint = format!("/repos/{}/git/refs/heads/{}", project, ref_branch);
+            let resp = self
+                .raw_api(&endpoint, "GET", None, "Resolving Branch SHA")
+                .await?;
+            let parsed: serde_json::Value = serde_json::from_str(&resp)?;
+            // GitHub returns {"ref":"refs/heads/main","node_id":...,"object":{"sha":"abc123..."},...}
+            // or {"sha":"abc123...","url":"...","node_id":...} for newer API responses
+            parsed
+                .get("object")
+                .and_then(|o| o.get("sha"))
+                .and_then(|s| s.as_str())
+                .or_else(|| parsed.get("sha").and_then(|s| s.as_str()))
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Could not resolve branch '{}' to SHA", ref_branch)
+                })?
+        };
+
         let endpoint = format!("/repos/{}/git/refs", project);
         let payload = serde_json::json!({
             "ref": format!("refs/heads/{}", branch_name),
-            "sha": ref_branch,
+            "sha": sha,
         });
         let json_str = serde_json::to_string(&payload)?;
         self.raw_api(&endpoint, "POST", Some(&json_str), "Creating Branch")
@@ -2537,7 +2561,12 @@ async fn run_gh_raw_api(
         if !b.is_empty() {
             cmd.arg("--input");
             cmd.arg("-");
+            // Pipe all three streams: inherited stdout/stderr is a TTY under the
+            // ratatui alternate screen, which lets `gh` page JSON through $PAGER
+            // (e.g. less) and corrupt the TUI after POSTs like create_branch.
             cmd.stdin(std::process::Stdio::piped());
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
         }
     }
     cmd.arg(endpoint);

--- a/src/backend/glab.rs
+++ b/src/backend/glab.rs
@@ -2568,7 +2568,12 @@ async fn run_glab_raw_api(
         if !b.is_empty() {
             cmd.arg("--input");
             cmd.arg("-");
+            // Pipe all three streams: inherited stdout/stderr is a TTY under the
+            // ratatui alternate screen, which lets the CLI page JSON through
+            // $PAGER and corrupt the TUI after POSTs like create_branch.
             cmd.stdin(std::process::Stdio::piped());
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
         }
     }
     cmd.arg(endpoint);

--- a/src/entity_editor.rs
+++ b/src/entity_editor.rs
@@ -1285,6 +1285,20 @@ pub fn apply_selector_changes<B: Backend>(
                 });
             }
         }
+        "source_branch" | "target_branch" | "create_from" => {
+            // For branch selection fields, simply update the field value
+            if let Some(menu) = &mut app.edit_menu {
+                for f in menu.fields.iter_mut() {
+                    if f.label == "Source Branch" && field_type == "source_branch"
+                        || f.label == "Target Branch" && field_type == "target_branch"
+                        || f.label == "Create From" && field_type == "create_from"
+                    {
+                        f.value = values.first().cloned().unwrap_or_default();
+                        break;
+                    }
+                }
+            }
+        }
         _ => {}
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4298,6 +4298,7 @@ async fn main() -> Result<()> {
                                                 "pipeline_branch" => "Branch / Ref",
                                                 "workflow_file" => "Workflow File",
                                                 "tag" => "Tag",
+                                                "create_from" => "Create From",
                                                 other if other.starts_with("Input: ") => other,
                                                 _ => "",
                                             };
@@ -5298,6 +5299,47 @@ async fn main() -> Result<()> {
                                             });
                                         }
                                         continue;
+                                    } else if entity_type == "new_branch" {
+                                        let branch_name = menu
+                                            .fields
+                                            .iter()
+                                            .find(|f| f.label == "Branch Name")
+                                            .map(|f| f.value.trim().to_string())
+                                            .unwrap_or_default();
+                                        let create_from = menu
+                                            .fields
+                                            .iter()
+                                            .find(|f| f.label == "Create From")
+                                            .map(|f| f.value.trim().to_string())
+                                            .unwrap_or_default();
+
+                                        app.edit_menu = None;
+                                        let client = app.gitlab_client.clone().unwrap();
+                                        let project = app.scope.as_str().to_string();
+                                        let tx = events.sender();
+                                        let tab = app.active_tab;
+                                        tokio::spawn(async move {
+                                            match crate::domain::branches::create_branch(
+                                                &client,
+                                                &project,
+                                                &branch_name,
+                                                &create_from,
+                                            )
+                                            .await
+                                            {
+                                                Ok(_) => {
+                                                    let _ = tx
+                                                        .send(Event::CommandCompleted(tab, Ok(())));
+                                                }
+                                                Err(e) => {
+                                                    let _ = tx.send(Event::CommandCompleted(
+                                                        tab,
+                                                        Err(e.to_string()),
+                                                    ));
+                                                }
+                                            }
+                                        });
+                                        continue;
                                     } else if entity_type == "release" {
                                         let tag = menu
                                             .fields
@@ -6084,6 +6126,7 @@ async fn main() -> Result<()> {
                                     || field_name == "Source Branch"
                                     || field_name == "Target Branch"
                                     || field_name == "Branch / Ref"
+                                    || field_name == "Create From"
                                     || field_name == "Workflow File"
                                     || field_name == "Tag"
                                     || field_name == "Create from Issue"
@@ -6427,7 +6470,7 @@ async fn main() -> Result<()> {
                                                         client.fetch_milestones(&scope).await
                                                     }
                                                     "source_branch" | "target_branch"
-                                                    | "pipeline_branch" => {
+                                                    | "pipeline_branch" | "create_from" => {
                                                         client.fetch_branches(&scope).await
                                                     }
                                                     _ => Ok(Vec::new()),


### PR DESCRIPTION
Closes #442 
Fix:

  • Handle new_branch on edit-menu submit.
  • Wire Create From through the selector (create_from field type + apply_selector_changes).
  • Resolve Create From → SHA before creating the ref on GitHub.
  • Pipe stdin/stdout/stderr on raw API POSTs with a body so CLI output cannot enter the TUI.